### PR TITLE
feat: Add Memory Browser, connector settings UI, and media analysis toggle

### DIFF
--- a/app/Domain/Signal/Actions/AnalyzeMediaAction.php
+++ b/app/Domain/Signal/Actions/AnalyzeMediaAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Signal\Actions;
 
+use App\Models\GlobalSetting;
 use Illuminate\Support\Facades\Log;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\ValueObjects\Media\Image;
@@ -16,6 +17,10 @@ class AnalyzeMediaAction
      */
     public function execute(Media $media): ?string
     {
+        if (! GlobalSetting::get('media_analysis_enabled', false)) {
+            return null;
+        }
+
         $mimeType = $media->mime_type;
 
         try {

--- a/app/Livewire/Memory/MemoryBrowserPage.php
+++ b/app/Livewire/Memory/MemoryBrowserPage.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Livewire\Memory;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Memory\Models\Memory;
+use App\Domain\Project\Models\Project;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class MemoryBrowserPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $search = '';
+
+    #[Url]
+    public string $agentFilter = '';
+
+    #[Url]
+    public string $projectFilter = '';
+
+    #[Url]
+    public string $sourceTypeFilter = '';
+
+    public string $sortField = 'created_at';
+
+    public string $sortDirection = 'desc';
+
+    public ?string $expandedId = null;
+
+    public function sortBy(string $field): void
+    {
+        if ($this->sortField === $field) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortField = $field;
+            $this->sortDirection = 'asc';
+        }
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedAgentFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedProjectFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedSourceTypeFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function toggleExpand(string $id): void
+    {
+        $this->expandedId = $this->expandedId === $id ? null : $id;
+    }
+
+    public function deleteMemory(string $id): void
+    {
+        Memory::where('id', $id)->delete();
+
+        if ($this->expandedId === $id) {
+            $this->expandedId = null;
+        }
+
+        session()->flash('message', 'Memory deleted.');
+    }
+
+    public function render()
+    {
+        $query = Memory::query()->with(['agent', 'project']);
+
+        if ($this->search) {
+            $query->where('content', 'ilike', "%{$this->search}%");
+        }
+
+        if ($this->agentFilter) {
+            $query->where('agent_id', $this->agentFilter);
+        }
+
+        if ($this->projectFilter) {
+            $query->where('project_id', $this->projectFilter);
+        }
+
+        if ($this->sourceTypeFilter) {
+            $query->where('source_type', $this->sourceTypeFilter);
+        }
+
+        $query->orderBy($this->sortField, $this->sortDirection);
+
+        return view('livewire.memory.memory-browser-page', [
+            'memories' => $query->paginate(30),
+            'agents' => Agent::orderBy('name')->pluck('name', 'id'),
+            'projects' => Project::orderBy('name')->pluck('name', 'id'),
+            'sourceTypes' => Memory::distinct()->pluck('source_type')->sort()->values(),
+        ])->layout('layouts.app', ['header' => 'Memory Browser']);
+    }
+}

--- a/app/Livewire/Settings/GlobalSettingsPage.php
+++ b/app/Livewire/Settings/GlobalSettingsPage.php
@@ -28,7 +28,18 @@ class GlobalSettingsPage extends Component
 
     public int $webhookRateLimit = 50;
 
+    public int $discordRateLimit = 20;
+
+    public int $teamsRateLimit = 20;
+
+    public int $googleChatRateLimit = 20;
+
+    public int $whatsappRateLimit = 10;
+
     public int $targetCooldownDays = 7;
+
+    // Media analysis
+    public bool $mediaAnalysisEnabled = false;
 
     // Default pipeline LLM
     public string $defaultLlmProvider = 'anthropic';
@@ -58,8 +69,14 @@ class GlobalSettingsPage extends Component
         $this->telegramRateLimit = $rateLimits['telegram'] ?? 20;
         $this->slackRateLimit = $rateLimits['slack'] ?? 20;
         $this->webhookRateLimit = $rateLimits['webhook'] ?? 50;
+        $this->discordRateLimit = $rateLimits['discord'] ?? 20;
+        $this->teamsRateLimit = $rateLimits['teams'] ?? 20;
+        $this->googleChatRateLimit = $rateLimits['google_chat'] ?? 20;
+        $this->whatsappRateLimit = $rateLimits['whatsapp'] ?? 10;
 
         $this->targetCooldownDays = GlobalSetting::get('target_cooldown_days', 7);
+
+        $this->mediaAnalysisEnabled = (bool) GlobalSetting::get('media_analysis_enabled', false);
         $this->approvalTimeoutHours = GlobalSetting::get('approval_timeout_hours', 48);
 
         $this->defaultLlmProvider = GlobalSetting::get('default_llm_provider', 'anthropic') ?? 'anthropic';
@@ -88,6 +105,10 @@ class GlobalSettingsPage extends Component
             'telegramRateLimit' => 'required|integer|min:1',
             'slackRateLimit' => 'required|integer|min:1',
             'webhookRateLimit' => 'required|integer|min:1',
+            'discordRateLimit' => 'required|integer|min:1',
+            'teamsRateLimit' => 'required|integer|min:1',
+            'googleChatRateLimit' => 'required|integer|min:1',
+            'whatsappRateLimit' => 'required|integer|min:1',
             'targetCooldownDays' => 'required|integer|min:0',
         ]);
 
@@ -96,6 +117,10 @@ class GlobalSettingsPage extends Component
             'telegram' => $this->telegramRateLimit,
             'slack' => $this->slackRateLimit,
             'webhook' => $this->webhookRateLimit,
+            'discord' => $this->discordRateLimit,
+            'teams' => $this->teamsRateLimit,
+            'google_chat' => $this->googleChatRateLimit,
+            'whatsapp' => $this->whatsappRateLimit,
         ]);
         GlobalSetting::set('target_cooldown_days', $this->targetCooldownDays);
 
@@ -111,6 +136,13 @@ class GlobalSettingsPage extends Component
         GlobalSetting::set('approval_timeout_hours', $this->approvalTimeoutHours);
 
         session()->flash('message', 'Approval settings saved.');
+    }
+
+    public function saveMediaAnalysisSettings(): void
+    {
+        GlobalSetting::set('media_analysis_enabled', $this->mediaAnalysisEnabled);
+
+        session()->flash('message', 'Media analysis settings saved.');
     }
 
     public function addBlacklistEntry(): void

--- a/resources/views/components/sidebar-link.blade.php
+++ b/resources/views/components/sidebar-link.blade.php
@@ -37,6 +37,8 @@
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" /></svg>
     @elseif($icon === 'folder')
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" /></svg>
+    @elseif($icon === 'circle-stack')
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125v-3.75" /></svg>
     @endif
     {{ $slot }}
 </a>

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -42,6 +42,10 @@
             Credentials
         </x-sidebar-link>
 
+        <x-sidebar-link href="{{ route('memory.index') }}" :active="request()->routeIs('memory.*')" icon="circle-stack">
+            Memory
+        </x-sidebar-link>
+
         <x-sidebar-link href="{{ route('marketplace.index') }}" :active="request()->routeIs('marketplace.*')" icon="shopping-bag">
             Marketplace
         </x-sidebar-link>

--- a/resources/views/livewire/memory/memory-browser-page.blade.php
+++ b/resources/views/livewire/memory/memory-browser-page.blade.php
@@ -1,0 +1,139 @@
+<div>
+    {{-- Flash message --}}
+    @if(session()->has('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-3 text-sm text-green-700">
+            {{ session('message') }}
+        </div>
+    @endif
+
+    {{-- Filters --}}
+    <div class="mb-6 flex flex-wrap items-center gap-4">
+        <div class="relative flex-1">
+            <x-form-input wire:model.live.debounce.300ms="search" type="text" placeholder="Search memory content..." class="pl-10">
+                <x-slot:leadingIcon>
+                    <svg class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+                </x-slot:leadingIcon>
+            </x-form-input>
+        </div>
+
+        <x-form-select wire:model.live="agentFilter">
+            <option value="">All Agents</option>
+            @foreach($agents as $id => $name)
+                <option value="{{ $id }}">{{ $name }}</option>
+            @endforeach
+        </x-form-select>
+
+        <x-form-select wire:model.live="projectFilter">
+            <option value="">All Projects</option>
+            @foreach($projects as $id => $name)
+                <option value="{{ $id }}">{{ $name }}</option>
+            @endforeach
+        </x-form-select>
+
+        <x-form-select wire:model.live="sourceTypeFilter">
+            <option value="">All Sources</option>
+            @foreach($sourceTypes as $type)
+                <option value="{{ $type }}">{{ ucfirst($type) }}</option>
+            @endforeach
+        </x-form-select>
+    </div>
+
+    {{-- Table --}}
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    @php
+                        $sortIcon = fn($field) => $sortField === $field
+                            ? ($sortDirection === 'asc' ? '&#9650;' : '&#9660;')
+                            : '<span class="text-gray-300">&#9650;</span>';
+                    @endphp
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Agent</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Content</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Source</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Project</th>
+                    <th wire:click="sortBy('created_at')" class="cursor-pointer px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 hover:text-gray-700">
+                        Created {!! $sortIcon('created_at') !!}
+                    </th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500"></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse($memories as $memory)
+                    <tr class="cursor-pointer transition hover:bg-gray-50" wire:click="toggleExpand('{{ $memory->id }}')">
+                        <td class="px-6 py-4 text-sm font-medium text-primary-600">
+                            {{ $memory->agent?->name ?? '-' }}
+                        </td>
+                        <td class="max-w-xs truncate px-6 py-4 text-sm text-gray-500">
+                            {{ Str::limit($memory->content, 80) }}
+                        </td>
+                        <td class="px-6 py-4 text-sm">
+                            <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-800">
+                                {{ $memory->source_type }}
+                            </span>
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-500">
+                            {{ $memory->project?->name ?? '-' }}
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-500">
+                            {{ $memory->created_at->diffForHumans() }}
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-400">
+                            <svg class="h-4 w-4 transition {{ $expandedId === $memory->id ? 'rotate-90' : '' }}" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+                        </td>
+                    </tr>
+
+                    @if($expandedId === $memory->id)
+                        <tr>
+                            <td colspan="6" class="bg-gray-50 px-6 py-4">
+                                <div class="space-y-3">
+                                    {{-- Full content --}}
+                                    <div>
+                                        <h4 class="text-xs font-medium uppercase text-gray-500">Content</h4>
+                                        <div class="mt-1 rounded-lg bg-gray-900 p-4">
+                                            <pre class="overflow-auto whitespace-pre-wrap text-xs text-green-400">{{ $memory->content }}</pre>
+                                        </div>
+                                    </div>
+
+                                    {{-- Metadata --}}
+                                    @if($memory->metadata && count($memory->metadata) > 0)
+                                        <div>
+                                            <h4 class="text-xs font-medium uppercase text-gray-500">Metadata</h4>
+                                            <div class="mt-1 rounded-lg bg-gray-900 p-4">
+                                                <pre class="overflow-auto text-xs text-green-400">{{ json_encode($memory->metadata, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) }}</pre>
+                                            </div>
+                                        </div>
+                                    @endif
+
+                                    {{-- Actions --}}
+                                    <div class="flex items-center gap-4 pt-2">
+                                        <span class="text-xs text-gray-400">ID: {{ $memory->id }}</span>
+                                        @if($memory->source_id)
+                                            <span class="text-xs text-gray-400">Source ID: {{ $memory->source_id }}</span>
+                                        @endif
+                                        <span class="text-xs text-gray-400">{{ $memory->created_at->format('Y-m-d H:i:s') }}</span>
+                                        <button wire:click.stop="deleteMemory('{{ $memory->id }}')"
+                                            wire:confirm="Are you sure you want to delete this memory?"
+                                            class="ml-auto text-sm text-red-600 hover:text-red-800">
+                                            Delete
+                                        </button>
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
+                    @endif
+                @empty
+                    <tr>
+                        <td colspan="6" class="px-6 py-12 text-center text-sm text-gray-400">
+                            No memories found. Agents will store memories as they execute tasks.
+                        </td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ $memories->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/settings/global-settings-page.blade.php
+++ b/resources/views/livewire/settings/global-settings-page.blade.php
@@ -36,6 +36,10 @@
                     <x-form-input wire:model="telegramRateLimit" label="Telegram (per hour)" type="number" min="1" />
                     <x-form-input wire:model="slackRateLimit" label="Slack (per hour)" type="number" min="1" />
                     <x-form-input wire:model="webhookRateLimit" label="Webhook (per hour)" type="number" min="1" />
+                    <x-form-input wire:model="discordRateLimit" label="Discord (per hour)" type="number" min="1" />
+                    <x-form-input wire:model="teamsRateLimit" label="Teams (per hour)" type="number" min="1" />
+                    <x-form-input wire:model="googleChatRateLimit" label="Google Chat (per hour)" type="number" min="1" />
+                    <x-form-input wire:model="whatsappRateLimit" label="WhatsApp (per hour)" type="number" min="1" />
                 </div>
                 <x-form-input wire:model="targetCooldownDays" label="Target Cooldown (days)" type="number" min="0" />
 
@@ -160,6 +164,53 @@
                     <p class="text-sm text-gray-400">Local agents are disabled. Set <code class="text-xs">LOCAL_AGENTS_ENABLED=true</code> in .env to enable.</p>
                 @endif
             </div>
+        </div>
+
+        {{-- Outbound Connectors Status --}}
+        <div class="rounded-xl border border-gray-200 bg-white p-6">
+            <h3 class="text-sm font-medium text-gray-500">Outbound Connectors</h3>
+            <p class="mt-1 text-xs text-gray-400">Status of configured outbound channels. Configure credentials via .env file.</p>
+            <div class="mt-4 space-y-2">
+                @php
+                    $connectors = [
+                        ['name' => 'Email (SMTP)', 'configured' => !empty(config('mail.mailers.smtp.host'))],
+                        ['name' => 'Telegram', 'configured' => !empty(config('services.telegram.bot_token', env('TELEGRAM_BOT_TOKEN')))],
+                        ['name' => 'Slack', 'configured' => !empty(config('services.slack.notifications.bot_user_oauth_token'))],
+                        ['name' => 'WhatsApp', 'configured' => !empty(config('services.whatsapp.access_token'))],
+                        ['name' => 'Discord', 'configured' => !empty(config('services.discord.bot_token'))],
+                        ['name' => 'Microsoft Teams', 'configured' => !empty(config('services.teams.webhook_url'))],
+                        ['name' => 'Google Chat', 'configured' => !empty(config('services.google_chat.webhook_url'))],
+                        ['name' => 'Webhook (generic)', 'configured' => true],
+                    ];
+                @endphp
+                @foreach($connectors as $connector)
+                    <div class="flex items-center justify-between rounded-lg bg-gray-50 px-4 py-2">
+                        <span class="text-sm text-gray-900">{{ $connector['name'] }}</span>
+                        @if($connector['configured'])
+                            <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">Configured</span>
+                        @else
+                            <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">Not configured</span>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- Media Analysis --}}
+        <div class="rounded-xl border border-gray-200 bg-white p-6">
+            <h3 class="text-sm font-medium text-gray-500">Media Analysis</h3>
+            <p class="mt-1 text-xs text-gray-400">When enabled, signals with media attachments (images, PDFs) will be automatically analyzed using vision-capable LLMs.</p>
+            <form wire:submit="saveMediaAnalysisSettings" class="mt-4 space-y-4">
+                <label class="relative inline-flex cursor-pointer items-center gap-3">
+                    <input type="checkbox" wire:model="mediaAnalysisEnabled" class="peer sr-only" />
+                    <div class="peer h-6 w-11 shrink-0 rounded-full bg-gray-200 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all peer-checked:bg-primary-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-primary-300"></div>
+                    <span class="text-sm font-medium text-gray-700">Enable automatic media analysis</span>
+                </label>
+
+                <button type="submit" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700">
+                    Save Media Analysis Settings
+                </button>
+            </form>
         </div>
 
         {{-- Blacklist Management --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ use App\Livewire\Health\HealthPage;
 use App\Livewire\Marketplace\MarketplaceBrowsePage;
 use App\Livewire\Marketplace\MarketplaceDetailPage;
 use App\Livewire\Marketplace\PublishForm;
+use App\Livewire\Memory\MemoryBrowserPage;
 use App\Livewire\Projects\CreateProjectForm as CreateProjectFormPage;
 use App\Livewire\Projects\EditProjectForm;
 use App\Livewire\Projects\ProjectDetailPage;
@@ -89,6 +90,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/workflows/{workflow}', WorkflowDetailPage::class)->name('workflows.show');
 
     Route::get('/artifacts/{artifact}/render/{version?}', [ArtifactPreviewController::class, 'render'])->name('artifacts.render');
+
+    Route::get('/memory', MemoryBrowserPage::class)->name('memory.index');
 
     Route::get('/approvals', ApprovalInboxPage::class)->name('approvals.index');
     Route::get('/health', HealthPage::class)->name('health');


### PR DESCRIPTION
## Summary

Adds the missing UI/UX for the three OpenClaw-inspired backend features merged in PR #13:

- **Memory Browser** (`/memory`) — New Livewire page to browse, search, filter, expand, and delete agent memories with sortable columns and expandable content/metadata rows
- **Outbound Connector Settings** — Extended the Settings page with rate limits for 4 new channels (Discord, Teams, Google Chat, WhatsApp) and a connector status overview card showing configured/not-configured state
- **Media Analysis Toggle** — Added enable/disable toggle on the Settings page; `AnalyzeMediaAction` now checks `GlobalSetting` before processing

## Changes

| File | What |
|------|------|
| `app/Livewire/Memory/MemoryBrowserPage.php` | New Livewire component with search, filters, sort, expand, delete |
| `resources/views/livewire/memory/memory-browser-page.blade.php` | Blade view with filter toolbar, sortable table, expandable rows |
| `app/Livewire/Settings/GlobalSettingsPage.php` | Added 4 rate limit props, media toggle, new save methods |
| `resources/views/livewire/settings/global-settings-page.blade.php` | Added connector rate limits, status card, media analysis card |
| `app/Domain/Signal/Actions/AnalyzeMediaAction.php` | Check `media_analysis_enabled` setting before processing |
| `routes/web.php` | Added `/memory` route |
| `resources/views/components/sidebar.blade.php` | Added Memory nav link |
| `resources/views/components/sidebar-link.blade.php` | Added `circle-stack` icon |

## Test plan

- [x] PHPStan — 0 errors
- [x] Pint — passes
- [x] Test suite — 340 tests, 743 assertions, all passing
- [ ] Navigate to `/memory` and verify table loads with search/filter/sort/expand
- [ ] Verify Settings page shows new rate limit fields, connector status, and media toggle
- [ ] Toggle media analysis and confirm setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)