### PR TITLE
feat(assistant): AI-powered platform assistant chat panel

### DIFF
--- a/app/Domain/Assistant/Actions/SendAssistantMessageAction.php
+++ b/app/Domain/Assistant/Actions/SendAssistantMessageAction.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Domain\Assistant\Actions;
+
+use App\Domain\Assistant\Models\AssistantConversation;
+use App\Domain\Assistant\Services\AssistantToolRegistry;
+use App\Domain\Assistant\Services\ContextResolver;
+use App\Domain\Assistant\Services\ConversationManager;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Models\GlobalSetting;
+use App\Models\User;
+
+class SendAssistantMessageAction
+{
+    public function __construct(
+        private readonly AiGatewayInterface $gateway,
+        private readonly ConversationManager $conversationManager,
+        private readonly ContextResolver $contextResolver,
+        private readonly AssistantToolRegistry $toolRegistry,
+    ) {}
+
+    /**
+     * Execute with tool calling (synchronous, non-streaming).
+     */
+    public function execute(
+        AssistantConversation $conversation,
+        string $userMessage,
+        User $user,
+        ?string $contextType = null,
+        ?string $contextId = null,
+    ): AiResponseDTO {
+        // Save user message
+        $this->conversationManager->addMessage($conversation, 'user', $userMessage);
+
+        // Build system prompt with context
+        $context = $this->contextResolver->resolve($contextType, $contextId);
+        $systemPrompt = $this->buildSystemPrompt($context);
+
+        // Build conversation history as a combined user prompt
+        $history = $this->conversationManager->buildMessageHistory($conversation);
+        $userPrompt = $this->buildUserPrompt($history, $userMessage);
+
+        // Resolve tools for user
+        $tools = $this->toolRegistry->getTools($user);
+
+        // Build AI request
+        $provider = GlobalSetting::get('assistant_llm_provider')
+            ?? GlobalSetting::get('default_llm_provider', 'anthropic');
+        $model = GlobalSetting::get('assistant_llm_model')
+            ?? GlobalSetting::get('default_llm_model', 'claude-sonnet-4-5');
+
+        $request = new AiRequestDTO(
+            provider: $provider,
+            model: $model,
+            systemPrompt: $systemPrompt,
+            userPrompt: $userPrompt,
+            maxTokens: 4096,
+            userId: $user->id,
+            teamId: $user->current_team_id,
+            purpose: 'platform_assistant',
+            tools: $tools,
+            maxSteps: 5,
+            temperature: 0.3,
+        );
+
+        // Call LLM (falls back to synchronous when tools present)
+        $response = $this->gateway->complete($request);
+
+        // Log tool executions for audit
+        if ($response->toolCallsCount > 0) {
+            $this->logToolExecutions($conversation, $response, $user);
+        }
+
+        // Save assistant response
+        $this->conversationManager->addMessage(
+            conversation: $conversation,
+            role: 'assistant',
+            content: $response->content,
+            toolCalls: $response->toolResults,
+            tokenUsage: [
+                'prompt_tokens' => $response->usage->promptTokens,
+                'completion_tokens' => $response->usage->completionTokens,
+                'cost_credits' => $response->usage->costCredits,
+            ],
+        );
+
+        // Auto-generate title from first message
+        $this->conversationManager->generateTitle($conversation);
+
+        return $response;
+    }
+
+    /**
+     * Execute streaming (text-only, no tools).
+     */
+    public function executeStreaming(
+        AssistantConversation $conversation,
+        string $userMessage,
+        User $user,
+        ?string $contextType = null,
+        ?string $contextId = null,
+        ?callable $onChunk = null,
+    ): AiResponseDTO {
+        // Save user message
+        $this->conversationManager->addMessage($conversation, 'user', $userMessage);
+
+        $context = $this->contextResolver->resolve($contextType, $contextId);
+        $systemPrompt = $this->buildSystemPrompt($context);
+
+        $history = $this->conversationManager->buildMessageHistory($conversation);
+        $userPrompt = $this->buildUserPrompt($history, $userMessage);
+
+        $provider = GlobalSetting::get('assistant_llm_provider')
+            ?? GlobalSetting::get('default_llm_provider', 'anthropic');
+        $model = GlobalSetting::get('assistant_llm_model')
+            ?? GlobalSetting::get('default_llm_model', 'claude-sonnet-4-5');
+
+        $request = new AiRequestDTO(
+            provider: $provider,
+            model: $model,
+            systemPrompt: $systemPrompt,
+            userPrompt: $userPrompt,
+            maxTokens: 4096,
+            userId: $user->id,
+            teamId: $user->current_team_id,
+            purpose: 'platform_assistant',
+            temperature: 0.3,
+        );
+
+        $response = $this->gateway->stream($request, $onChunk);
+
+        // Save assistant response
+        $this->conversationManager->addMessage(
+            conversation: $conversation,
+            role: 'assistant',
+            content: $response->content,
+            tokenUsage: [
+                'prompt_tokens' => $response->usage->promptTokens,
+                'completion_tokens' => $response->usage->completionTokens,
+                'cost_credits' => $response->usage->costCredits,
+            ],
+        );
+
+        $this->conversationManager->generateTitle($conversation);
+
+        return $response;
+    }
+
+    private function buildSystemPrompt(string $context): string
+    {
+        return <<<PROMPT
+        You are the Agent Fleet Platform Assistant. You help users manage their AI agent experiments, projects, workflows, and teams.
+
+        ## Current Context
+        {$context}
+
+        ## Available Actions
+        You can perform actions using the provided tools. Always use tools when the user asks you to do something -- do not just describe what to do.
+
+        ## Guidelines
+        - Be concise and direct.
+        - When listing entities, show the most relevant fields (name, status, created date).
+        - For write operations, clearly state what you will do before calling the tool.
+        - If something fails, explain the error and suggest alternatives.
+        - Use markdown formatting for readability.
+        - When you create something, include its URL in your response.
+        - If the user asks about something on the current page, use the context above to answer.
+        PROMPT;
+    }
+
+    /**
+     * Build a combined user prompt from conversation history.
+     */
+    private function buildUserPrompt(array $history, string $currentMessage): string
+    {
+        if (empty($history)) {
+            return $currentMessage;
+        }
+
+        // Include recent history as context, skip the last message (which is the current one we just saved)
+        $contextMessages = array_slice($history, 0, -1);
+
+        if (empty($contextMessages)) {
+            return $currentMessage;
+        }
+
+        $historyText = '';
+        foreach ($contextMessages as $msg) {
+            $role = $msg['role'] === 'user' ? 'User' : 'Assistant';
+            $historyText .= "[{$role}]: {$msg['content']}\n\n";
+        }
+
+        return "## Previous conversation:\n{$historyText}\n## Current message:\n{$currentMessage}";
+    }
+
+    private function logToolExecutions(AssistantConversation $conversation, AiResponseDTO $response, User $user): void
+    {
+        if (! $response->toolResults) {
+            return;
+        }
+
+        foreach ($response->toolResults as $toolResult) {
+            activity('assistant')
+                ->causedBy($user)
+                ->withProperties([
+                    'conversation_id' => $conversation->id,
+                    'tool_name' => $toolResult['toolName'] ?? 'unknown',
+                    'tool_args' => $toolResult['args'] ?? [],
+                ])
+                ->log('assistant.tool_executed');
+        }
+    }
+}

--- a/app/Domain/Assistant/Models/AssistantConversation.php
+++ b/app/Domain/Assistant/Models/AssistantConversation.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Domain\Assistant\Models;
+
+use App\Domain\Shared\Traits\BelongsToTeam;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Auth\User;
+
+class AssistantConversation extends Model
+{
+    use BelongsToTeam, HasUuids;
+
+    protected $fillable = [
+        'team_id',
+        'user_id',
+        'title',
+        'context_type',
+        'context_id',
+        'metadata',
+        'last_message_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'last_message_at' => 'datetime',
+        ];
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(AssistantMessage::class, 'conversation_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Domain/Assistant/Models/AssistantMessage.php
+++ b/app/Domain/Assistant/Models/AssistantMessage.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Domain\Assistant\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AssistantMessage extends Model
+{
+    use HasUuids;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'conversation_id',
+        'role',
+        'content',
+        'tool_calls',
+        'tool_results',
+        'token_usage',
+        'metadata',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'tool_calls' => 'array',
+            'tool_results' => 'array',
+            'token_usage' => 'array',
+            'metadata' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(AssistantConversation::class, 'conversation_id');
+    }
+}

--- a/app/Domain/Assistant/Services/AssistantToolRegistry.php
+++ b/app/Domain/Assistant/Services/AssistantToolRegistry.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Domain\Assistant\Services;
+
+use App\Domain\Assistant\Tools\GetEntityTools;
+use App\Domain\Assistant\Tools\ListEntitiesTools;
+use App\Domain\Assistant\Tools\MutationTools;
+use App\Domain\Assistant\Tools\StatusTools;
+use App\Models\User;
+use Prism\Prism\Tool as PrismToolObject;
+
+class AssistantToolRegistry
+{
+    /**
+     * Get all available tools for the given user, filtered by role.
+     *
+     * @return array<PrismToolObject>
+     */
+    public function getTools(User $user): array
+    {
+        $tools = [];
+
+        // READ tools - always available
+        $tools = array_merge($tools, ListEntitiesTools::tools());
+        $tools = array_merge($tools, GetEntityTools::tools());
+        $tools = array_merge($tools, StatusTools::tools());
+
+        // WRITE tools - available to Owner/Admin/Member
+        $role = $user->teamRole($user->currentTeam);
+        if ($role?->canEdit()) {
+            $tools = array_merge($tools, MutationTools::writeTools());
+        }
+
+        // DESTRUCTIVE tools - available to Owner/Admin only
+        if ($role?->canManageTeam()) {
+            $tools = array_merge($tools, MutationTools::destructiveTools());
+        }
+
+        return $tools;
+    }
+
+    /**
+     * Classify a tool name by its tier.
+     */
+    public static function toolTier(string $toolName): string
+    {
+        return match (true) {
+            in_array($toolName, ['kill_experiment', 'archive_project']) => 'destructive',
+            str_starts_with($toolName, 'create_') ||
+            str_starts_with($toolName, 'pause_') ||
+            str_starts_with($toolName, 'resume_') ||
+            str_starts_with($toolName, 'retry_') ||
+            str_starts_with($toolName, 'trigger_') ||
+            str_starts_with($toolName, 'approve_') ||
+            str_starts_with($toolName, 'reject_') => 'write',
+            default => 'read',
+        };
+    }
+}

--- a/app/Domain/Assistant/Services/AssistantToolRegistry.php
+++ b/app/Domain/Assistant/Services/AssistantToolRegistry.php
@@ -4,6 +4,7 @@ namespace App\Domain\Assistant\Services;
 
 use App\Domain\Assistant\Tools\GetEntityTools;
 use App\Domain\Assistant\Tools\ListEntitiesTools;
+use App\Domain\Assistant\Tools\MemoryTools;
 use App\Domain\Assistant\Tools\MutationTools;
 use App\Domain\Assistant\Tools\StatusTools;
 use App\Models\User;
@@ -24,6 +25,7 @@ class AssistantToolRegistry
         $tools = array_merge($tools, ListEntitiesTools::tools());
         $tools = array_merge($tools, GetEntityTools::tools());
         $tools = array_merge($tools, StatusTools::tools());
+        $tools = array_merge($tools, MemoryTools::tools());
 
         // WRITE tools - available to Owner/Admin/Member
         $role = $user->teamRole($user->currentTeam);

--- a/app/Domain/Assistant/Services/ContextResolver.php
+++ b/app/Domain/Assistant/Services/ContextResolver.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Domain\Assistant\Services;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Project\Models\Project;
+use App\Domain\Workflow\Models\Workflow;
+
+class ContextResolver
+{
+    public function resolve(?string $type, ?string $id): string
+    {
+        if (! $type || ! $id) {
+            return 'The user is on the dashboard or a list page.';
+        }
+
+        return match ($type) {
+            'experiment' => $this->experimentContext($id),
+            'project' => $this->projectContext($id),
+            'agent' => $this->agentContext($id),
+            'crew' => $this->crewContext($id),
+            'workflow' => $this->workflowContext($id),
+            default => "The user is viewing a {$type} page.",
+        };
+    }
+
+    private function experimentContext(string $id): string
+    {
+        $exp = Experiment::with('stages')->find($id);
+        if (! $exp) {
+            return '';
+        }
+
+        $parts = [
+            "The user is viewing Experiment '{$exp->title}' (ID: {$exp->id}).",
+            "Status: {$exp->status->value}.",
+            "Track: {$exp->track->value}.",
+            "Budget: {$exp->budget_spent_credits}/{$exp->budget_cap_credits} credits.",
+            "Created: {$exp->created_at->diffForHumans()}.",
+        ];
+
+        if ($exp->stages->isNotEmpty()) {
+            $parts[] = 'Stages: '.$exp->stages->pluck('type')->implode(', ').'.';
+        }
+
+        return implode(' ', $parts);
+    }
+
+    private function projectContext(string $id): string
+    {
+        $project = Project::find($id);
+        if (! $project) {
+            return '';
+        }
+
+        $parts = [
+            "The user is viewing Project '{$project->title}' (ID: {$project->id}).",
+            "Type: {$project->type}.",
+            "Status: {$project->status->value}.",
+            "Created: {$project->created_at->diffForHumans()}.",
+        ];
+
+        return implode(' ', $parts);
+    }
+
+    private function agentContext(string $id): string
+    {
+        $agent = Agent::find($id);
+        if (! $agent) {
+            return '';
+        }
+
+        $parts = [
+            "The user is viewing Agent '{$agent->name}' (ID: {$agent->id}).",
+            "Role: {$agent->role}.",
+            "Status: {$agent->status->value}.",
+            "Provider: {$agent->provider}/{$agent->model}.",
+        ];
+
+        return implode(' ', $parts);
+    }
+
+    private function crewContext(string $id): string
+    {
+        $crew = Crew::with('members')->find($id);
+        if (! $crew) {
+            return '';
+        }
+
+        $parts = [
+            "The user is viewing Crew '{$crew->name}' (ID: {$crew->id}).",
+            "Status: {$crew->status->value}.",
+            "Members: {$crew->members->count()}.",
+        ];
+
+        return implode(' ', $parts);
+    }
+
+    private function workflowContext(string $id): string
+    {
+        $workflow = Workflow::with('nodes')->find($id);
+        if (! $workflow) {
+            return '';
+        }
+
+        $parts = [
+            "The user is viewing Workflow '{$workflow->name}' (ID: {$workflow->id}).",
+            "Status: {$workflow->status->value}.",
+            "Nodes: {$workflow->nodes->count()}.",
+        ];
+
+        return implode(' ', $parts);
+    }
+}

--- a/app/Domain/Assistant/Services/ConversationManager.php
+++ b/app/Domain/Assistant/Services/ConversationManager.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Domain\Assistant\Services;
+
+use App\Domain\Assistant\Models\AssistantConversation;
+use App\Domain\Assistant\Models\AssistantMessage;
+
+class ConversationManager
+{
+    private const MAX_CONTEXT_MESSAGES = 30;
+
+    private const MAX_ESTIMATED_TOKENS = 50_000;
+
+    public function getOrCreateConversation(
+        string $userId,
+        string $teamId,
+        ?string $conversationId = null,
+        ?string $contextType = null,
+        ?string $contextId = null,
+    ): AssistantConversation {
+        if ($conversationId) {
+            $conversation = AssistantConversation::where('user_id', $userId)->find($conversationId);
+            if ($conversation) {
+                return $conversation;
+            }
+        }
+
+        return AssistantConversation::create([
+            'team_id' => $teamId,
+            'user_id' => $userId,
+            'context_type' => $contextType,
+            'context_id' => $contextId,
+            'last_message_at' => now(),
+        ]);
+    }
+
+    public function addMessage(
+        AssistantConversation $conversation,
+        string $role,
+        string $content,
+        ?array $toolCalls = null,
+        ?array $toolResults = null,
+        ?array $tokenUsage = null,
+        array $metadata = [],
+    ): AssistantMessage {
+        $message = AssistantMessage::create([
+            'conversation_id' => $conversation->id,
+            'role' => $role,
+            'content' => $content,
+            'tool_calls' => $toolCalls,
+            'tool_results' => $toolResults,
+            'token_usage' => $tokenUsage,
+            'metadata' => $metadata,
+            'created_at' => now(),
+        ]);
+
+        $conversation->update(['last_message_at' => now()]);
+
+        return $message;
+    }
+
+    /**
+     * Build message history for LLM context, with sliding window truncation.
+     *
+     * @return array<array{role: string, content: string}>
+     */
+    public function buildMessageHistory(AssistantConversation $conversation): array
+    {
+        $messages = $conversation->messages()
+            ->whereIn('role', ['user', 'assistant'])
+            ->orderByDesc('created_at')
+            ->limit(self::MAX_CONTEXT_MESSAGES)
+            ->get()
+            ->reverse()
+            ->values();
+
+        $estimatedTokens = 0;
+        $result = [];
+
+        foreach ($messages as $message) {
+            $messageTokens = (int) ceil(mb_strlen($message->content) / 4);
+            if ($estimatedTokens + $messageTokens > self::MAX_ESTIMATED_TOKENS) {
+                break;
+            }
+            $estimatedTokens += $messageTokens;
+            $result[] = [
+                'role' => $message->role,
+                'content' => $message->content,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get recent conversations for the sidebar list.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<AssistantConversation>
+     */
+    public function getRecentConversations(string $userId, int $limit = 20): \Illuminate\Database\Eloquent\Collection
+    {
+        return AssistantConversation::where('user_id', $userId)
+            ->orderByDesc('last_message_at')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * Auto-generate a title from the first user message.
+     */
+    public function generateTitle(AssistantConversation $conversation): void
+    {
+        if ($conversation->title) {
+            return;
+        }
+
+        $firstMessage = $conversation->messages()
+            ->where('role', 'user')
+            ->orderBy('created_at')
+            ->first();
+
+        if ($firstMessage) {
+            $title = mb_substr($firstMessage->content, 0, 80);
+            if (mb_strlen($firstMessage->content) > 80) {
+                $title .= '...';
+            }
+            $conversation->update(['title' => $title]);
+        }
+    }
+}

--- a/app/Domain/Assistant/Tools/GetEntityTools.php
+++ b/app/Domain/Assistant/Tools/GetEntityTools.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Domain\Assistant\Tools;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Project\Models\Project;
+use App\Domain\Workflow\Models\Workflow;
+use Prism\Prism\Facades\Tool as PrismTool;
+use Prism\Prism\Tool as PrismToolObject;
+
+class GetEntityTools
+{
+    /**
+     * @return array<PrismToolObject>
+     */
+    public static function tools(): array
+    {
+        return [
+            self::getExperiment(),
+            self::getProject(),
+            self::getAgent(),
+            self::getCrew(),
+            self::getWorkflow(),
+        ];
+    }
+
+    private static function getExperiment(): PrismToolObject
+    {
+        return PrismTool::as('get_experiment')
+            ->for('Get detailed information about a specific experiment')
+            ->withStringParameter('experiment_id', 'The experiment UUID', required: true)
+            ->using(function (string $experiment_id) {
+                $exp = Experiment::with('stages')->find($experiment_id);
+                if (! $exp) {
+                    return json_encode(['error' => 'Experiment not found']);
+                }
+
+                return json_encode([
+                    'id' => $exp->id,
+                    'title' => $exp->title,
+                    'thesis' => $exp->thesis,
+                    'status' => $exp->status->value,
+                    'track' => $exp->track->value,
+                    'budget_spent' => $exp->budget_spent_credits,
+                    'budget_cap' => $exp->budget_cap_credits,
+                    'max_iterations' => $exp->max_iterations,
+                    'current_iteration' => $exp->current_iteration,
+                    'stages' => $exp->stages->map(fn ($s) => [
+                        'type' => $s->type,
+                        'status' => $s->status,
+                        'output_preview' => mb_substr($s->output ?? '', 0, 200),
+                    ])->toArray(),
+                    'created' => $exp->created_at->toIso8601String(),
+                    'url' => route('experiments.show', $exp),
+                ]);
+            });
+    }
+
+    private static function getProject(): PrismToolObject
+    {
+        return PrismTool::as('get_project')
+            ->for('Get detailed information about a specific project')
+            ->withStringParameter('project_id', 'The project UUID', required: true)
+            ->using(function (string $project_id) {
+                $project = Project::with('runs')->find($project_id);
+                if (! $project) {
+                    return json_encode(['error' => 'Project not found']);
+                }
+
+                return json_encode([
+                    'id' => $project->id,
+                    'title' => $project->title,
+                    'type' => $project->type,
+                    'status' => $project->status->value,
+                    'description' => $project->description,
+                    'goal' => $project->goal,
+                    'recent_runs' => $project->runs->sortByDesc('created_at')->take(5)->map(fn ($r) => [
+                        'id' => $r->id,
+                        'status' => $r->status->value,
+                        'created' => $r->created_at->diffForHumans(),
+                    ])->values()->toArray(),
+                    'created' => $project->created_at->toIso8601String(),
+                    'url' => route('projects.show', $project),
+                ]);
+            });
+    }
+
+    private static function getAgent(): PrismToolObject
+    {
+        return PrismTool::as('get_agent')
+            ->for('Get detailed information about a specific AI agent')
+            ->withStringParameter('agent_id', 'The agent UUID', required: true)
+            ->using(function (string $agent_id) {
+                $agent = Agent::find($agent_id);
+                if (! $agent) {
+                    return json_encode(['error' => 'Agent not found']);
+                }
+
+                return json_encode([
+                    'id' => $agent->id,
+                    'name' => $agent->name,
+                    'role' => $agent->role,
+                    'goal' => $agent->goal,
+                    'backstory' => $agent->backstory,
+                    'provider' => $agent->provider,
+                    'model' => $agent->model,
+                    'status' => $agent->status->value,
+                    'budget_spent' => $agent->budget_spent_credits,
+                    'budget_cap' => $agent->budget_cap_credits,
+                    'url' => route('agents.show', $agent),
+                ]);
+            });
+    }
+
+    private static function getCrew(): PrismToolObject
+    {
+        return PrismTool::as('get_crew')
+            ->for('Get detailed information about a specific crew')
+            ->withStringParameter('crew_id', 'The crew UUID', required: true)
+            ->using(function (string $crew_id) {
+                $crew = Crew::with('members.agent')->find($crew_id);
+                if (! $crew) {
+                    return json_encode(['error' => 'Crew not found']);
+                }
+
+                return json_encode([
+                    'id' => $crew->id,
+                    'name' => $crew->name,
+                    'status' => $crew->status->value,
+                    'process_type' => $crew->process_type->value,
+                    'members' => $crew->members->map(fn ($m) => [
+                        'role' => $m->role->value,
+                        'agent_name' => $m->agent?->name,
+                    ])->toArray(),
+                    'url' => route('crews.show', $crew),
+                ]);
+            });
+    }
+
+    private static function getWorkflow(): PrismToolObject
+    {
+        return PrismTool::as('get_workflow')
+            ->for('Get detailed information about a specific workflow')
+            ->withStringParameter('workflow_id', 'The workflow UUID', required: true)
+            ->using(function (string $workflow_id) {
+                $workflow = Workflow::with('nodes', 'edges')->find($workflow_id);
+                if (! $workflow) {
+                    return json_encode(['error' => 'Workflow not found']);
+                }
+
+                return json_encode([
+                    'id' => $workflow->id,
+                    'name' => $workflow->name,
+                    'status' => $workflow->status->value,
+                    'description' => $workflow->description,
+                    'nodes' => $workflow->nodes->map(fn ($n) => [
+                        'id' => $n->id,
+                        'type' => $n->type->value,
+                        'label' => $n->label,
+                    ])->toArray(),
+                    'edges_count' => $workflow->edges->count(),
+                    'url' => route('workflows.show', $workflow),
+                ]);
+            });
+    }
+}

--- a/app/Domain/Assistant/Tools/ListEntitiesTools.php
+++ b/app/Domain/Assistant/Tools/ListEntitiesTools.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Domain\Assistant\Tools;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Project\Models\Project;
+use App\Domain\Skill\Models\Skill;
+use App\Domain\Workflow\Models\Workflow;
+use Prism\Prism\Facades\Tool as PrismTool;
+use Prism\Prism\Tool as PrismToolObject;
+
+class ListEntitiesTools
+{
+    /**
+     * @return array<PrismToolObject>
+     */
+    public static function tools(): array
+    {
+        return [
+            self::listExperiments(),
+            self::listProjects(),
+            self::listAgents(),
+            self::listSkills(),
+            self::listCrews(),
+            self::listWorkflows(),
+            self::listPendingApprovals(),
+        ];
+    }
+
+    private static function listExperiments(): PrismToolObject
+    {
+        return PrismTool::as('list_experiments')
+            ->for('List experiments with optional status filter')
+            ->withStringParameter('status', 'Filter by status (e.g. draft, running, completed, failed, paused, killed)')
+            ->withNumberParameter('limit', 'Max results to return (default 10)')
+            ->using(function (?string $status = null, ?int $limit = null) {
+                $query = Experiment::query()->orderByDesc('created_at');
+
+                if ($status) {
+                    $query->where('status', $status);
+                }
+
+                $experiments = $query->limit($limit ?? 10)->get(['id', 'title', 'status', 'track', 'budget_spent_credits', 'budget_cap_credits', 'created_at']);
+
+                return json_encode([
+                    'count' => $experiments->count(),
+                    'experiments' => $experiments->map(fn ($e) => [
+                        'id' => $e->id,
+                        'title' => $e->title,
+                        'status' => $e->status->value,
+                        'track' => $e->track->value,
+                        'budget' => "{$e->budget_spent_credits}/{$e->budget_cap_credits}",
+                        'created' => $e->created_at->diffForHumans(),
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function listProjects(): PrismToolObject
+    {
+        return PrismTool::as('list_projects')
+            ->for('List projects with optional status filter')
+            ->withStringParameter('status', 'Filter by status (e.g. draft, active, paused, completed, archived)')
+            ->withNumberParameter('limit', 'Max results to return (default 10)')
+            ->using(function (?string $status = null, ?int $limit = null) {
+                $query = Project::query()->orderByDesc('created_at');
+
+                if ($status) {
+                    $query->where('status', $status);
+                }
+
+                $projects = $query->limit($limit ?? 10)->get(['id', 'title', 'type', 'status', 'created_at']);
+
+                return json_encode([
+                    'count' => $projects->count(),
+                    'projects' => $projects->map(fn ($p) => [
+                        'id' => $p->id,
+                        'title' => $p->title,
+                        'type' => $p->type,
+                        'status' => $p->status->value,
+                        'created' => $p->created_at->diffForHumans(),
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function listAgents(): PrismToolObject
+    {
+        return PrismTool::as('list_agents')
+            ->for('List AI agents with optional status filter')
+            ->withStringParameter('status', 'Filter by status (e.g. active, disabled)')
+            ->withNumberParameter('limit', 'Max results to return (default 10)')
+            ->using(function (?string $status = null, ?int $limit = null) {
+                $query = Agent::query()->orderBy('name');
+
+                if ($status) {
+                    $query->where('status', $status);
+                }
+
+                $agents = $query->limit($limit ?? 10)->get(['id', 'name', 'role', 'provider', 'model', 'status']);
+
+                return json_encode([
+                    'count' => $agents->count(),
+                    'agents' => $agents->map(fn ($a) => [
+                        'id' => $a->id,
+                        'name' => $a->name,
+                        'role' => $a->role,
+                        'provider' => $a->provider,
+                        'model' => $a->model,
+                        'status' => $a->status->value,
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function listSkills(): PrismToolObject
+    {
+        return PrismTool::as('list_skills')
+            ->for('List available skills with optional type filter')
+            ->withStringParameter('type', 'Filter by type (e.g. llm, connector, rule, hybrid)')
+            ->withNumberParameter('limit', 'Max results to return (default 10)')
+            ->using(function (?string $type = null, ?int $limit = null) {
+                $query = Skill::query()->orderBy('name');
+
+                if ($type) {
+                    $query->where('type', $type);
+                }
+
+                $skills = $query->limit($limit ?? 10)->get(['id', 'name', 'type', 'status']);
+
+                return json_encode([
+                    'count' => $skills->count(),
+                    'skills' => $skills->map(fn ($s) => [
+                        'id' => $s->id,
+                        'name' => $s->name,
+                        'type' => $s->type->value,
+                        'status' => $s->status->value,
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function listCrews(): PrismToolObject
+    {
+        return PrismTool::as('list_crews')
+            ->for('List crews (multi-agent teams)')
+            ->withStringParameter('status', 'Filter by status')
+            ->withNumberParameter('limit', 'Max results to return (default 10)')
+            ->using(function (?string $status = null, ?int $limit = null) {
+                $query = Crew::query()->withCount('members')->orderBy('name');
+
+                if ($status) {
+                    $query->where('status', $status);
+                }
+
+                $crews = $query->limit($limit ?? 10)->get();
+
+                return json_encode([
+                    'count' => $crews->count(),
+                    'crews' => $crews->map(fn ($c) => [
+                        'id' => $c->id,
+                        'name' => $c->name,
+                        'status' => $c->status->value,
+                        'members_count' => $c->members_count,
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function listWorkflows(): PrismToolObject
+    {
+        return PrismTool::as('list_workflows')
+            ->for('List workflow templates')
+            ->withStringParameter('status', 'Filter by status (e.g. draft, active, archived)')
+            ->withNumberParameter('limit', 'Max results to return (default 10)')
+            ->using(function (?string $status = null, ?int $limit = null) {
+                $query = Workflow::query()->withCount('nodes')->orderBy('name');
+
+                if ($status) {
+                    $query->where('status', $status);
+                }
+
+                $workflows = $query->limit($limit ?? 10)->get();
+
+                return json_encode([
+                    'count' => $workflows->count(),
+                    'workflows' => $workflows->map(fn ($w) => [
+                        'id' => $w->id,
+                        'name' => $w->name,
+                        'status' => $w->status->value,
+                        'nodes_count' => $w->nodes_count,
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function listPendingApprovals(): PrismToolObject
+    {
+        return PrismTool::as('list_pending_approvals')
+            ->for('List pending approval requests that need review')
+            ->withNumberParameter('limit', 'Max results to return (default 10)')
+            ->using(function (?int $limit = null) {
+                $approvals = ApprovalRequest::where('status', 'pending')
+                    ->orderByDesc('created_at')
+                    ->limit($limit ?? 10)
+                    ->get(['id', 'type', 'payload', 'created_at']);
+
+                return json_encode([
+                    'count' => $approvals->count(),
+                    'approvals' => $approvals->map(fn ($a) => [
+                        'id' => $a->id,
+                        'type' => $a->type,
+                        'created' => $a->created_at->diffForHumans(),
+                    ])->toArray(),
+                ]);
+            });
+    }
+}

--- a/app/Domain/Assistant/Tools/MemoryTools.php
+++ b/app/Domain/Assistant/Tools/MemoryTools.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Domain\Assistant\Tools;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Memory\Models\Memory;
+use Prism\Prism\Facades\Tool as PrismTool;
+use Prism\Prism\Tool as PrismToolObject;
+
+class MemoryTools
+{
+    /**
+     * @return array<PrismToolObject>
+     */
+    public static function tools(): array
+    {
+        return [
+            self::searchMemories(),
+            self::listRecentMemories(),
+            self::getMemoryStats(),
+        ];
+    }
+
+    private static function searchMemories(): PrismToolObject
+    {
+        return PrismTool::as('search_memories')
+            ->for('Search through agent memories by keyword. Returns memories matching the search term.')
+            ->withStringParameter('query', 'Search term to find in memory content (required)')
+            ->withStringParameter('agent_id', 'Filter by agent UUID (optional)')
+            ->withNumberParameter('limit', 'Max results (default 10)')
+            ->using(function (string $query, ?string $agent_id = null, ?int $limit = null) {
+                $dbQuery = Memory::query()
+                    ->with(['agent:id,name', 'project:id,title'])
+                    ->where('content', 'ilike', "%{$query}%")
+                    ->orderByDesc('created_at');
+
+                if ($agent_id) {
+                    $dbQuery->where('agent_id', $agent_id);
+                }
+
+                $memories = $dbQuery->limit($limit ?? 10)->get();
+
+                return json_encode([
+                    'count' => $memories->count(),
+                    'memories' => $memories->map(fn ($m) => [
+                        'id' => $m->id,
+                        'agent' => $m->agent?->name ?? 'N/A',
+                        'project' => $m->project?->title ?? 'N/A',
+                        'source_type' => $m->source_type,
+                        'content' => \Illuminate\Support\Str::limit($m->content, 300),
+                        'created' => $m->created_at->diffForHumans(),
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function listRecentMemories(): PrismToolObject
+    {
+        return PrismTool::as('list_recent_memories')
+            ->for('List the most recent agent memories, optionally filtered by agent or source type')
+            ->withStringParameter('agent_id', 'Filter by agent UUID (optional)')
+            ->withStringParameter('source_type', 'Filter by source type, e.g. experiment_execution, skill_execution (optional)')
+            ->withNumberParameter('limit', 'Max results (default 10)')
+            ->using(function (?string $agent_id = null, ?string $source_type = null, ?int $limit = null) {
+                $query = Memory::query()
+                    ->with(['agent:id,name', 'project:id,title'])
+                    ->orderByDesc('created_at');
+
+                if ($agent_id) {
+                    $query->where('agent_id', $agent_id);
+                }
+
+                if ($source_type) {
+                    $query->where('source_type', $source_type);
+                }
+
+                $memories = $query->limit($limit ?? 10)->get();
+
+                return json_encode([
+                    'count' => $memories->count(),
+                    'memories' => $memories->map(fn ($m) => [
+                        'id' => $m->id,
+                        'agent' => $m->agent?->name ?? 'N/A',
+                        'project' => $m->project?->title ?? 'N/A',
+                        'source_type' => $m->source_type,
+                        'content' => \Illuminate\Support\Str::limit($m->content, 300),
+                        'created' => $m->created_at->diffForHumans(),
+                    ])->toArray(),
+                ]);
+            });
+    }
+
+    private static function getMemoryStats(): PrismToolObject
+    {
+        return PrismTool::as('get_memory_stats')
+            ->for('Get memory statistics: total count, per-agent breakdown, and source type distribution')
+            ->using(function () {
+                $total = Memory::count();
+
+                $byAgent = Memory::query()
+                    ->join('agents', 'memories.agent_id', '=', 'agents.id')
+                    ->selectRaw('agents.name, count(*) as count')
+                    ->groupBy('agents.name')
+                    ->orderByDesc('count')
+                    ->limit(10)
+                    ->pluck('count', 'name')
+                    ->toArray();
+
+                $bySource = Memory::query()
+                    ->selectRaw('source_type, count(*) as count')
+                    ->groupBy('source_type')
+                    ->orderByDesc('count')
+                    ->pluck('count', 'source_type')
+                    ->toArray();
+
+                return json_encode([
+                    'total_memories' => $total,
+                    'by_agent' => $byAgent,
+                    'by_source_type' => $bySource,
+                ]);
+            });
+    }
+}

--- a/app/Domain/Assistant/Tools/MutationTools.php
+++ b/app/Domain/Assistant/Tools/MutationTools.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace App\Domain\Assistant\Tools;
+
+use App\Domain\Agent\Actions\CreateAgentAction;
+use App\Domain\Approval\Actions\ApproveAction;
+use App\Domain\Approval\Actions\RejectAction;
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\Experiment\Actions\KillExperimentAction;
+use App\Domain\Experiment\Actions\PauseExperimentAction;
+use App\Domain\Experiment\Actions\ResumeExperimentAction;
+use App\Domain\Experiment\Actions\RetryExperimentAction;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Project\Actions\ArchiveProjectAction;
+use App\Domain\Project\Actions\CreateProjectAction;
+use App\Domain\Project\Actions\TriggerProjectRunAction;
+use App\Domain\Project\Enums\ProjectType;
+use App\Domain\Project\Models\Project;
+use Prism\Prism\Facades\Tool as PrismTool;
+use Prism\Prism\Tool as PrismToolObject;
+
+class MutationTools
+{
+    /**
+     * @return array<PrismToolObject>
+     */
+    public static function writeTools(): array
+    {
+        return [
+            self::createProject(),
+            self::createAgent(),
+            self::pauseExperiment(),
+            self::resumeExperiment(),
+            self::retryExperiment(),
+            self::triggerProjectRun(),
+            self::approveRequest(),
+            self::rejectRequest(),
+        ];
+    }
+
+    /**
+     * @return array<PrismToolObject>
+     */
+    public static function destructiveTools(): array
+    {
+        return [
+            self::killExperiment(),
+            self::archiveProject(),
+        ];
+    }
+
+    private static function createProject(): PrismToolObject
+    {
+        return PrismTool::as('create_project')
+            ->for('Create a new project in Agent Fleet')
+            ->withStringParameter('title', 'Project title', required: true)
+            ->withStringParameter('description', 'Project description')
+            ->withStringParameter('type', 'Project type: one_shot or continuous (default: one_shot)')
+            ->using(function (string $title, ?string $description = null, ?string $type = null) {
+                try {
+                    $project = app(CreateProjectAction::class)->execute(
+                        userId: auth()->id(),
+                        title: $title,
+                        type: $type && ProjectType::tryFrom($type) ? $type : ProjectType::OneShot->value,
+                        description: $description,
+                        teamId: auth()->user()->current_team_id,
+                    );
+
+                    return json_encode([
+                        'success' => true,
+                        'project_id' => $project->id,
+                        'title' => $project->title,
+                        'status' => $project->status->value,
+                        'url' => route('projects.show', $project),
+                    ]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function createAgent(): PrismToolObject
+    {
+        return PrismTool::as('create_agent')
+            ->for('Create a new AI agent')
+            ->withStringParameter('name', 'Agent name', required: true)
+            ->withStringParameter('role', 'Agent role description')
+            ->withStringParameter('goal', 'Agent goal')
+            ->withStringParameter('backstory', 'Agent backstory')
+            ->withStringParameter('provider', 'LLM provider (anthropic, openai, google). Default: anthropic')
+            ->withStringParameter('model', 'LLM model name. Default: claude-sonnet-4-5')
+            ->using(function (string $name, ?string $role = null, ?string $goal = null, ?string $backstory = null, ?string $provider = null, ?string $model = null) {
+                try {
+                    $agent = app(CreateAgentAction::class)->execute(
+                        name: $name,
+                        provider: $provider ?? 'anthropic',
+                        model: $model ?? 'claude-sonnet-4-5',
+                        role: $role,
+                        goal: $goal,
+                        backstory: $backstory,
+                        teamId: auth()->user()->current_team_id,
+                    );
+
+                    return json_encode([
+                        'success' => true,
+                        'agent_id' => $agent->id,
+                        'name' => $agent->name,
+                        'status' => $agent->status->value,
+                        'url' => route('agents.show', $agent),
+                    ]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function pauseExperiment(): PrismToolObject
+    {
+        return PrismTool::as('pause_experiment')
+            ->for('Pause a running experiment')
+            ->withStringParameter('experiment_id', 'The experiment UUID', required: true)
+            ->using(function (string $experiment_id) {
+                $experiment = Experiment::find($experiment_id);
+                if (! $experiment) {
+                    return json_encode(['error' => 'Experiment not found']);
+                }
+
+                try {
+                    app(PauseExperimentAction::class)->execute($experiment, auth()->id());
+
+                    return json_encode(['success' => true, 'message' => "Experiment '{$experiment->title}' paused."]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function resumeExperiment(): PrismToolObject
+    {
+        return PrismTool::as('resume_experiment')
+            ->for('Resume a paused experiment')
+            ->withStringParameter('experiment_id', 'The experiment UUID', required: true)
+            ->using(function (string $experiment_id) {
+                $experiment = Experiment::find($experiment_id);
+                if (! $experiment) {
+                    return json_encode(['error' => 'Experiment not found']);
+                }
+
+                try {
+                    app(ResumeExperimentAction::class)->execute($experiment, auth()->id());
+
+                    return json_encode(['success' => true, 'message' => "Experiment '{$experiment->title}' resumed."]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function retryExperiment(): PrismToolObject
+    {
+        return PrismTool::as('retry_experiment')
+            ->for('Retry a failed experiment')
+            ->withStringParameter('experiment_id', 'The experiment UUID', required: true)
+            ->using(function (string $experiment_id) {
+                $experiment = Experiment::find($experiment_id);
+                if (! $experiment) {
+                    return json_encode(['error' => 'Experiment not found']);
+                }
+
+                try {
+                    app(RetryExperimentAction::class)->execute($experiment, auth()->id());
+
+                    return json_encode(['success' => true, 'message' => "Experiment '{$experiment->title}' retrying."]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function triggerProjectRun(): PrismToolObject
+    {
+        return PrismTool::as('trigger_project_run')
+            ->for('Trigger a new run for a project')
+            ->withStringParameter('project_id', 'The project UUID', required: true)
+            ->using(function (string $project_id) {
+                $project = Project::find($project_id);
+                if (! $project) {
+                    return json_encode(['error' => 'Project not found']);
+                }
+
+                try {
+                    $run = app(TriggerProjectRunAction::class)->execute($project, 'assistant');
+
+                    return json_encode([
+                        'success' => true,
+                        'run_id' => $run->id,
+                        'message' => "Project run triggered for '{$project->title}'.",
+                    ]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function approveRequest(): PrismToolObject
+    {
+        return PrismTool::as('approve_request')
+            ->for('Approve a pending approval request')
+            ->withStringParameter('approval_id', 'The approval request UUID', required: true)
+            ->withStringParameter('notes', 'Optional approval notes')
+            ->using(function (string $approval_id, ?string $notes = null) {
+                $approval = ApprovalRequest::find($approval_id);
+                if (! $approval) {
+                    return json_encode(['error' => 'Approval request not found']);
+                }
+
+                try {
+                    app(ApproveAction::class)->execute($approval, auth()->id(), $notes);
+
+                    return json_encode(['success' => true, 'message' => 'Request approved.']);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function rejectRequest(): PrismToolObject
+    {
+        return PrismTool::as('reject_request')
+            ->for('Reject a pending approval request')
+            ->withStringParameter('approval_id', 'The approval request UUID', required: true)
+            ->withStringParameter('reason', 'Reason for rejection', required: true)
+            ->withStringParameter('notes', 'Optional rejection notes')
+            ->using(function (string $approval_id, string $reason, ?string $notes = null) {
+                $approval = ApprovalRequest::find($approval_id);
+                if (! $approval) {
+                    return json_encode(['error' => 'Approval request not found']);
+                }
+
+                try {
+                    app(RejectAction::class)->execute($approval, auth()->id(), $reason, $notes);
+
+                    return json_encode(['success' => true, 'message' => 'Request rejected.']);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function killExperiment(): PrismToolObject
+    {
+        return PrismTool::as('kill_experiment')
+            ->for('Kill/terminate an experiment permanently. This is a destructive action.')
+            ->withStringParameter('experiment_id', 'The experiment UUID', required: true)
+            ->withStringParameter('reason', 'Reason for killing the experiment')
+            ->using(function (string $experiment_id, ?string $reason = null) {
+                $experiment = Experiment::find($experiment_id);
+                if (! $experiment) {
+                    return json_encode(['error' => 'Experiment not found']);
+                }
+
+                try {
+                    app(KillExperimentAction::class)->execute($experiment, auth()->id(), $reason ?? 'Killed via assistant');
+
+                    return json_encode(['success' => true, 'message' => "Experiment '{$experiment->title}' killed."]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+
+    private static function archiveProject(): PrismToolObject
+    {
+        return PrismTool::as('archive_project')
+            ->for('Archive a project permanently. This is a destructive action.')
+            ->withStringParameter('project_id', 'The project UUID', required: true)
+            ->using(function (string $project_id) {
+                $project = Project::find($project_id);
+                if (! $project) {
+                    return json_encode(['error' => 'Project not found']);
+                }
+
+                try {
+                    app(ArchiveProjectAction::class)->execute($project);
+
+                    return json_encode(['success' => true, 'message' => "Project '{$project->title}' archived."]);
+                } catch (\Throwable $e) {
+                    return json_encode(['error' => $e->getMessage()]);
+                }
+            });
+    }
+}

--- a/app/Domain/Assistant/Tools/StatusTools.php
+++ b/app/Domain/Assistant/Tools/StatusTools.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Domain\Assistant\Tools;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Budget\Models\CreditLedger;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Project\Models\Project;
+use App\Models\GlobalSetting;
+use Prism\Prism\Facades\Tool as PrismTool;
+use Prism\Prism\Tool as PrismToolObject;
+
+class StatusTools
+{
+    /**
+     * @return array<PrismToolObject>
+     */
+    public static function tools(): array
+    {
+        return [
+            self::getBudgetSummary(),
+            self::getDashboardKpis(),
+            self::getSystemHealth(),
+        ];
+    }
+
+    private static function getBudgetSummary(): PrismToolObject
+    {
+        return PrismTool::as('get_budget_summary')
+            ->for('Get the current team budget summary including total spent, cap, and remaining credits')
+            ->using(function () {
+                $globalCap = GlobalSetting::get('global_budget_cap', 100000);
+
+                $totalSpent = CreditLedger::sum('amount');
+                $totalReserved = CreditLedger::where('type', 'reservation')->sum('amount');
+
+                return json_encode([
+                    'global_budget_cap' => $globalCap,
+                    'total_spent' => abs($totalSpent),
+                    'total_reserved' => abs($totalReserved),
+                    'remaining' => $globalCap - abs($totalSpent),
+                    'utilization_pct' => $globalCap > 0 ? round(abs($totalSpent) / $globalCap * 100, 1) : 0,
+                ]);
+            });
+    }
+
+    private static function getDashboardKpis(): PrismToolObject
+    {
+        return PrismTool::as('get_dashboard_kpis')
+            ->for('Get key performance indicators: experiment counts by status, project counts, agent counts')
+            ->using(function () {
+                return json_encode([
+                    'experiments' => [
+                        'total' => Experiment::count(),
+                        'running' => Experiment::where('status', 'running')->count(),
+                        'completed' => Experiment::where('status', 'completed')->count(),
+                        'failed' => Experiment::where('status', 'failed')->count(),
+                        'paused' => Experiment::where('status', 'paused')->count(),
+                    ],
+                    'projects' => [
+                        'total' => Project::count(),
+                        'active' => Project::where('status', 'active')->count(),
+                    ],
+                    'agents' => [
+                        'total' => Agent::count(),
+                        'active' => Agent::where('status', 'active')->count(),
+                    ],
+                ]);
+            });
+    }
+
+    private static function getSystemHealth(): PrismToolObject
+    {
+        return PrismTool::as('get_system_health')
+            ->for('Get system health status including queue, database, and cache connectivity')
+            ->using(function () {
+                $health = [];
+
+                // Database check
+                try {
+                    \DB::select('SELECT 1');
+                    $health['database'] = 'ok';
+                } catch (\Throwable) {
+                    $health['database'] = 'error';
+                }
+
+                // Redis/Cache check
+                try {
+                    \Cache::store('redis')->put('health_check', true, 10);
+                    $health['cache'] = \Cache::store('redis')->get('health_check') ? 'ok' : 'error';
+                } catch (\Throwable) {
+                    $health['cache'] = 'error';
+                }
+
+                // Queue check (Horizon)
+                try {
+                    $horizonStatus = app('horizon.status')->current();
+                    $health['queue'] = $horizonStatus === 'running' ? 'ok' : $horizonStatus;
+                } catch (\Throwable) {
+                    $health['queue'] = 'unknown';
+                }
+
+                return json_encode($health);
+            });
+    }
+}

--- a/app/Livewire/Assistant/AssistantPanel.php
+++ b/app/Livewire/Assistant/AssistantPanel.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Livewire\Assistant;
+
+use App\Domain\Assistant\Actions\SendAssistantMessageAction;
+use App\Domain\Assistant\Services\AssistantToolRegistry;
+use App\Domain\Assistant\Services\ConversationManager;
+use Livewire\Component;
+
+class AssistantPanel extends Component
+{
+    public string $userMessage = '';
+
+    public string $conversationId = '';
+
+    public array $messages = [];
+
+    public bool $isProcessing = false;
+
+    public string $contextType = '';
+
+    public string $contextId = '';
+
+    public string $streamedResponse = '';
+
+    public array $conversations = [];
+
+    public bool $showHistory = false;
+
+    public function mount(): void
+    {
+        $this->loadRecentConversations();
+    }
+
+    public function sendMessage(): void
+    {
+        $message = trim($this->userMessage);
+        if ($message === '' || $this->isProcessing) {
+            return;
+        }
+
+        $this->userMessage = '';
+        $this->isProcessing = true;
+
+        // Add user message to UI immediately
+        $this->messages[] = [
+            'role' => 'user',
+            'content' => $message,
+        ];
+
+        try {
+            $user = auth()->user();
+            $manager = app(ConversationManager::class);
+
+            // Get or create conversation
+            $conversation = $manager->getOrCreateConversation(
+                userId: $user->id,
+                teamId: $user->current_team_id,
+                conversationId: $this->conversationId ?: null,
+                contextType: $this->contextType ?: null,
+                contextId: $this->contextId ?: null,
+            );
+            $this->conversationId = $conversation->id;
+
+            $action = app(SendAssistantMessageAction::class);
+
+            // Use tool-calling (synchronous) path - handles both tools and text
+            $response = $action->execute(
+                conversation: $conversation,
+                userMessage: $message,
+                user: $user,
+                contextType: $this->contextType ?: null,
+                contextId: $this->contextId ?: null,
+            );
+
+            // Add assistant response to UI
+            $this->messages[] = [
+                'role' => 'assistant',
+                'content' => $response->content,
+                'tool_calls_count' => $response->toolCallsCount,
+                'cost_credits' => $response->usage->costCredits,
+            ];
+
+            $this->loadRecentConversations();
+        } catch (\Throwable $e) {
+            $this->messages[] = [
+                'role' => 'assistant',
+                'content' => 'Sorry, an error occurred: '.$e->getMessage(),
+            ];
+        }
+
+        $this->isProcessing = false;
+        $this->dispatch('assistant-message-sent');
+    }
+
+    public function newConversation(): void
+    {
+        $this->conversationId = '';
+        $this->messages = [];
+        $this->streamedResponse = '';
+        $this->showHistory = false;
+    }
+
+    public function loadConversation(string $id): void
+    {
+        $user = auth()->user();
+        $manager = app(ConversationManager::class);
+
+        $conversation = $manager->getOrCreateConversation(
+            userId: $user->id,
+            teamId: $user->current_team_id,
+            conversationId: $id,
+        );
+
+        $this->conversationId = $conversation->id;
+        $this->contextType = $conversation->context_type ?? '';
+        $this->contextId = $conversation->context_id ?? '';
+
+        // Load messages
+        $this->messages = $conversation->messages()
+            ->whereIn('role', ['user', 'assistant'])
+            ->orderBy('created_at')
+            ->get()
+            ->map(fn ($m) => [
+                'role' => $m->role,
+                'content' => $m->content,
+                'tool_calls_count' => $m->tool_calls ? count($m->tool_calls) : 0,
+                'cost_credits' => $m->token_usage['cost_credits'] ?? 0,
+            ])
+            ->toArray();
+
+        $this->showHistory = false;
+        $this->dispatch('assistant-message-sent');
+    }
+
+    public function setContext(string $type, string $id): void
+    {
+        $this->contextType = $type;
+        $this->contextId = $id;
+    }
+
+    public function toggleHistory(): void
+    {
+        $this->showHistory = ! $this->showHistory;
+        if ($this->showHistory) {
+            $this->loadRecentConversations();
+        }
+    }
+
+    private function loadRecentConversations(): void
+    {
+        $manager = app(ConversationManager::class);
+        $this->conversations = $manager->getRecentConversations(auth()->id())
+            ->map(fn ($c) => [
+                'id' => $c->id,
+                'title' => $c->title ?? 'New conversation',
+                'last_message_at' => $c->last_message_at?->diffForHumans() ?? '',
+            ])
+            ->toArray();
+    }
+
+    public function render()
+    {
+        return view('livewire.assistant.assistant-panel');
+    }
+}

--- a/app/Livewire/Settings/GlobalSettingsPage.php
+++ b/app/Livewire/Settings/GlobalSettingsPage.php
@@ -46,6 +46,11 @@ class GlobalSettingsPage extends Component
 
     public string $defaultLlmModel = 'claude-sonnet-4-5';
 
+    // Assistant LLM
+    public string $assistantProvider = 'anthropic';
+
+    public string $assistantModel = 'claude-sonnet-4-5';
+
     // Approval settings
     public int $approvalTimeoutHours = 48;
 
@@ -81,6 +86,9 @@ class GlobalSettingsPage extends Component
 
         $this->defaultLlmProvider = GlobalSetting::get('default_llm_provider', 'anthropic') ?? 'anthropic';
         $this->defaultLlmModel = GlobalSetting::get('default_llm_model', 'claude-sonnet-4-5') ?? 'claude-sonnet-4-5';
+
+        $this->assistantProvider = GlobalSetting::get('assistant_llm_provider', 'anthropic') ?? 'anthropic';
+        $this->assistantModel = GlobalSetting::get('assistant_llm_model', 'claude-sonnet-4-5') ?? 'claude-sonnet-4-5';
     }
 
     public function saveBudgetSettings(): void
@@ -183,6 +191,19 @@ class GlobalSettingsPage extends Component
         GlobalSetting::set('default_llm_model', $this->defaultLlmModel);
 
         session()->flash('message', 'Default pipeline LLM saved.');
+    }
+
+    public function saveAssistantLlm(): void
+    {
+        $this->validate([
+            'assistantProvider' => 'required|string',
+            'assistantModel' => 'required|string',
+        ]);
+
+        GlobalSetting::set('assistant_llm_provider', $this->assistantProvider);
+        GlobalSetting::set('assistant_llm_model', $this->assistantModel);
+
+        session()->flash('message', 'Assistant LLM saved.');
     }
 
     public function rescanLocalAgents(): void

--- a/database/migrations/2026_02_15_100001_create_assistant_tables.php
+++ b/database/migrations/2026_02_15_100001_create_assistant_tables.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('assistant_conversations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title', 255)->nullable();
+            $table->string('context_type', 100)->nullable();
+            $table->uuid('context_id')->nullable();
+            $table->jsonb('metadata')->default('{}');
+            $table->timestampTz('last_message_at')->nullable();
+            $table->timestampsTz();
+
+            $table->index(['team_id', 'user_id', 'last_message_at']);
+            $table->index(['context_type', 'context_id']);
+        });
+
+        Schema::create('assistant_messages', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('conversation_id')->constrained('assistant_conversations')->cascadeOnDelete();
+            $table->string('role', 20);
+            $table->text('content');
+            $table->jsonb('tool_calls')->nullable();
+            $table->jsonb('tool_results')->nullable();
+            $table->jsonb('token_usage')->nullable();
+            $table->jsonb('metadata')->default('{}');
+            $table->timestampTz('created_at');
+
+            $table->index(['conversation_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('assistant_messages');
+        Schema::dropIfExists('assistant_conversations');
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -51,6 +51,10 @@
         </div>
     </div>
 
+    @auth
+        <livewire:assistant.assistant-panel />
+    @endauth
+
     @livewireScripts
     @stack('scripts')
 </body>

--- a/resources/views/livewire/assistant/assistant-panel.blade.php
+++ b/resources/views/livewire/assistant/assistant-panel.blade.php
@@ -1,0 +1,224 @@
+<div
+    x-data="{
+        open: false,
+        init() {
+            // Watch for Livewire navigation to detect page context
+            document.addEventListener('livewire:navigated', () => {
+                const path = window.location.pathname;
+                const match = path.match(/\/(experiments|projects|agents|crews|workflows|skills|tools|credentials)\/([^\/]+)$/);
+                if (match) {
+                    $wire.setContext(match[1].replace(/s$/, ''), match[2]);
+                } else {
+                    $wire.setContext('', '');
+                }
+            });
+
+            // Keyboard shortcut: Cmd+K / Ctrl+K
+            document.addEventListener('keydown', (e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+                    e.preventDefault();
+                    this.open = !this.open;
+                    if (this.open) {
+                        this.$nextTick(() => this.$refs.messageInput?.focus());
+                    }
+                }
+            });
+        },
+        scrollToBottom() {
+            this.$nextTick(() => {
+                const container = this.$refs.messagesContainer;
+                if (container) {
+                    container.scrollTop = container.scrollHeight;
+                }
+            });
+        }
+    }"
+    x-on:assistant-message-sent.window="scrollToBottom()"
+    class="relative z-50"
+>
+    {{-- Toggle Button (FAB) --}}
+    <button
+        x-on:click="open = !open; if (open) $nextTick(() => $refs.messageInput?.focus())"
+        x-show="!open"
+        x-transition:enter="transition ease-out duration-200"
+        x-transition:enter-start="scale-75 opacity-0"
+        x-transition:enter-end="scale-100 opacity-100"
+        class="fixed bottom-6 right-6 flex h-14 w-14 items-center justify-center rounded-full bg-indigo-600 text-white shadow-lg transition-colors hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        title="Open Assistant (Cmd+K)"
+    >
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+        </svg>
+    </button>
+
+    {{-- Slide-out Panel --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-300"
+        x-transition:enter-start="translate-x-full"
+        x-transition:enter-end="translate-x-0"
+        x-transition:leave="transition ease-in duration-200"
+        x-transition:leave-start="translate-x-0"
+        x-transition:leave-end="translate-x-full"
+        class="fixed inset-y-0 right-0 flex w-full flex-col border-l border-gray-200 bg-white shadow-2xl sm:w-[420px]"
+    >
+        {{-- Panel Header --}}
+        <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+            <div class="flex items-center gap-2">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5 text-indigo-600">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456Z" />
+                </svg>
+                <h2 class="text-sm font-semibold text-gray-900">Assistant</h2>
+            </div>
+            <div class="flex items-center gap-1">
+                {{-- History Toggle --}}
+                <button
+                    wire:click="toggleHistory"
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="Conversation History"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                    </svg>
+                </button>
+                {{-- New Conversation --}}
+                <button
+                    wire:click="newConversation"
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="New Conversation"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                    </svg>
+                </button>
+                {{-- Close --}}
+                <button
+                    x-on:click="open = false"
+                    class="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+                    title="Close (Esc)"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-4 w-4">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+
+        {{-- Conversation History Sidebar --}}
+        @if($showHistory)
+            <div class="border-b border-gray-200 bg-gray-50 px-4 py-2">
+                <h3 class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500">Recent Conversations</h3>
+                <div class="max-h-60 space-y-1 overflow-y-auto">
+                    @forelse($conversations as $conv)
+                        <button
+                            wire:click="loadConversation('{{ $conv['id'] }}')"
+                            class="block w-full rounded px-2 py-1.5 text-left text-sm transition-colors hover:bg-gray-200 {{ $conversationId === $conv['id'] ? 'bg-indigo-50 text-indigo-700' : 'text-gray-700' }}"
+                        >
+                            <div class="truncate font-medium">{{ $conv['title'] }}</div>
+                            <div class="text-xs text-gray-400">{{ $conv['last_message_at'] }}</div>
+                        </button>
+                    @empty
+                        <p class="py-2 text-center text-xs text-gray-400">No conversations yet</p>
+                    @endforelse
+                </div>
+            </div>
+        @endif
+
+        {{-- Messages Area --}}
+        <div
+            x-ref="messagesContainer"
+            class="flex-1 space-y-4 overflow-y-auto px-4 py-4"
+        >
+            @if(empty($messages))
+                <div class="flex h-full flex-col items-center justify-center text-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1" stroke="currentColor" class="mb-3 h-12 w-12 text-gray-300">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456Z" />
+                    </svg>
+                    <p class="text-sm font-medium text-gray-500">Agent Fleet Assistant</p>
+                    <p class="mt-1 text-xs text-gray-400">Ask me anything about your projects,<br>experiments, agents, and more.</p>
+                    <div class="mt-4 flex flex-wrap justify-center gap-2">
+                        <button wire:click="$set('userMessage', 'List my recent experiments')" class="rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 transition-colors hover:border-indigo-300 hover:text-indigo-600">
+                            List experiments
+                        </button>
+                        <button wire:click="$set('userMessage', 'Show dashboard KPIs')" class="rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 transition-colors hover:border-indigo-300 hover:text-indigo-600">
+                            Dashboard KPIs
+                        </button>
+                        <button wire:click="$set('userMessage', 'What is my budget status?')" class="rounded-full border border-gray-200 px-3 py-1 text-xs text-gray-600 transition-colors hover:border-indigo-300 hover:text-indigo-600">
+                            Budget status
+                        </button>
+                    </div>
+                </div>
+            @else
+                @foreach($messages as $msg)
+                    <div class="{{ $msg['role'] === 'user' ? 'flex justify-end' : 'flex justify-start' }}">
+                        <div class="{{ $msg['role'] === 'user'
+                            ? 'max-w-[85%] rounded-2xl rounded-br-md bg-indigo-600 px-4 py-2.5 text-white'
+                            : 'max-w-[85%] rounded-2xl rounded-bl-md bg-gray-100 px-4 py-2.5 text-gray-900' }}">
+                            @if($msg['role'] === 'assistant')
+                                <div class="assistant-response prose prose-sm max-w-none">
+                                    {!! \Illuminate\Support\Str::markdown($msg['content']) !!}
+                                </div>
+                                @if(!empty($msg['tool_calls_count']))
+                                    <div class="mt-2 flex items-center gap-1 text-xs text-gray-400">
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-3 w-3">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008Z" />
+                                        </svg>
+                                        {{ $msg['tool_calls_count'] }} tool call{{ $msg['tool_calls_count'] > 1 ? 's' : '' }}
+                                    </div>
+                                @endif
+                            @else
+                                <p class="text-sm whitespace-pre-wrap">{{ $msg['content'] }}</p>
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
+            @endif
+
+            {{-- Processing Indicator --}}
+            @if($isProcessing)
+                <div class="flex justify-start">
+                    <div class="max-w-[85%] rounded-2xl rounded-bl-md bg-gray-100 px-4 py-3">
+                        <div class="flex items-center gap-2">
+                            <div class="flex gap-1">
+                                <span class="h-2 w-2 animate-bounce rounded-full bg-gray-400" style="animation-delay: 0ms"></span>
+                                <span class="h-2 w-2 animate-bounce rounded-full bg-gray-400" style="animation-delay: 150ms"></span>
+                                <span class="h-2 w-2 animate-bounce rounded-full bg-gray-400" style="animation-delay: 300ms"></span>
+                            </div>
+                            <span class="text-xs text-gray-500">Thinking...</span>
+                        </div>
+                    </div>
+                </div>
+            @endif
+        </div>
+
+        {{-- Input Area --}}
+        <div class="border-t border-gray-200 px-4 py-3">
+            <form wire:submit="sendMessage" class="flex items-end gap-2">
+                <div class="flex-1">
+                    <textarea
+                        x-ref="messageInput"
+                        wire:model="userMessage"
+                        placeholder="Ask anything... (Cmd+K to toggle)"
+                        rows="1"
+                        class="block w-full resize-none rounded-xl border border-gray-300 px-4 py-2.5 text-sm text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                        x-on:keydown.enter.prevent="if (!$event.shiftKey) { $wire.sendMessage(); }"
+                        x-on:input="$el.style.height = 'auto'; $el.style.height = Math.min($el.scrollHeight, 120) + 'px'"
+                        :disabled="$wire.isProcessing"
+                    ></textarea>
+                </div>
+                <button
+                    type="submit"
+                    :disabled="$wire.isProcessing"
+                    class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-indigo-600 text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
+                    </svg>
+                </button>
+            </form>
+            <p class="mt-1.5 text-center text-[10px] text-gray-400">
+                Press Enter to send, Shift+Enter for new line
+            </p>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/settings/global-settings-page.blade.php
+++ b/resources/views/livewire/settings/global-settings-page.blade.php
@@ -85,6 +85,31 @@
             </form>
         </div>
 
+        {{-- Assistant LLM --}}
+        <div class="rounded-xl border border-gray-200 bg-white p-6">
+            <h3 class="text-sm font-medium text-gray-500">Assistant LLM</h3>
+            <p class="mt-1 text-xs text-gray-400">The AI model used by the platform assistant chat. Falls back to the default pipeline LLM if not set.</p>
+            <form wire:submit="saveAssistantLlm" class="mt-4 space-y-4">
+                <x-form-select wire:model.live="assistantProvider" label="Provider">
+                    @foreach($providers as $key => $p)
+                        @if(empty($p['local']))
+                            <option value="{{ $key }}">{{ $p['name'] }}</option>
+                        @endif
+                    @endforeach
+                </x-form-select>
+
+                <x-form-select wire:model="assistantModel" label="Model">
+                    @foreach($providers[$assistantProvider]['models'] ?? [] as $modelKey => $modelInfo)
+                        <option value="{{ $modelKey }}">{{ $modelInfo['label'] }}</option>
+                    @endforeach
+                </x-form-select>
+
+                <button type="submit" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700">
+                    Save Assistant LLM
+                </button>
+            </form>
+        </div>
+
         {{-- Agent Management --}}
         <div class="rounded-xl border border-gray-200 bg-white p-6">
             <h3 class="text-sm font-medium text-gray-500">Agent Management</h3>

--- a/resources/views/livewire/settings/global-settings-page.blade.php
+++ b/resources/views/livewire/settings/global-settings-page.blade.php
@@ -92,9 +92,7 @@
             <form wire:submit="saveAssistantLlm" class="mt-4 space-y-4">
                 <x-form-select wire:model.live="assistantProvider" label="Provider">
                     @foreach($providers as $key => $p)
-                        @if(empty($p['local']))
-                            <option value="{{ $key }}">{{ $p['name'] }}</option>
-                        @endif
+                        <option value="{{ $key }}">{{ $p['name'] }}</option>
                     @endforeach
                 </x-form-select>
 


### PR DESCRIPTION
## Summary

- **AI Chat Panel**: Slide-out assistant accessible from every authenticated page via FAB button (bottom-right) or `Cmd+K` shortcut
- **22 Platform Tools**: List/get entities, create projects/agents, pause/resume/retry/kill experiments, check budget & health — all via natural language through PrismPHP tool calling
- **Role-Based Access**: READ tools always available, WRITE tools for editors, DESTRUCTIVE tools for admins only
- **Context-Aware**: Automatically detects the current page/entity and injects context into the system prompt
- **Conversation Persistence**: PostgreSQL-backed conversations with sliding window truncation (30 messages, ~50K token limit)
- **Configurable LLM**: Separate assistant provider/model setting in Settings page

## New Files

```
app/Domain/Assistant/
  Actions/SendAssistantMessageAction.php     # Core action: tool-calling + streaming
  Models/AssistantConversation.php           # UUIDv7, BelongsToTeam
  Models/AssistantMessage.php                # UUIDv7, JSONB tool_calls/results
  Services/AssistantToolRegistry.php         # Role-based tool filtering
  Services/ContextResolver.php              # Page-aware entity context
  Services/ConversationManager.php           # History, truncation, title generation
  Tools/ListEntitiesTools.php               # 7 tools: list experiments/projects/agents/skills/crews/workflows/approvals
  Tools/GetEntityTools.php                  # 5 tools: get experiment/project/agent/crew/workflow
  Tools/MutationTools.php                   # 10 tools: create/pause/resume/retry/kill/archive/approve/reject
  Tools/StatusTools.php                     # 3 tools: budget summary, dashboard KPIs, system health

app/Livewire/Assistant/AssistantPanel.php   # Livewire component
resources/views/livewire/assistant/assistant-panel.blade.php  # Chat UI
database/migrations/2026_02_15_100001_create_assistant_tables.php
```

## Modified Files

- `resources/views/layouts/app.blade.php` — inject `<livewire:assistant.assistant-panel />` for auth users
- `app/Livewire/Settings/GlobalSettingsPage.php` — add assistant LLM settings
- `resources/views/livewire/settings/global-settings-page.blade.php` — assistant LLM UI section

## Test plan

- [x] All 340 existing tests pass (0 regressions)
- [x] Migration runs cleanly on PostgreSQL
- [x] All 16 new PHP files pass syntax check
- [x] Livewire component class autoloads correctly
- [ ] Manual: Open any authenticated page → verify FAB button appears bottom-right
- [ ] Manual: Click FAB or press Cmd+K → panel slides out
- [ ] Manual: Send "List my experiments" → verify tool calling works
- [ ] Manual: Navigate to experiment detail → verify context injection
- [ ] Manual: Settings page → verify Assistant LLM section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)