### PR TITLE
fix(budget): allow jobs when no credit ledger entries exist (community installs)

### DIFF
--- a/app/Jobs/Middleware/CheckBudgetAvailable.php
+++ b/app/Jobs/Middleware/CheckBudgetAvailable.php
@@ -38,16 +38,18 @@ class CheckBudgetAvailable
             return;
         }
 
-        // Check global team balance (billing is team-based)
-        $balance = CreditLedger::where('team_id', $experiment->team_id)
+        // Check global team balance — only enforce if credits have been issued.
+        // Community installs have no credit ledger entries, so we skip this check
+        // entirely to avoid blocking all jobs on self-hosted deployments.
+        $latestEntry = CreditLedger::where('team_id', $experiment->team_id)
             ->orderByDesc('created_at')
-            ->value('balance_after') ?? 0;
+            ->first(['balance_after']);
 
-        if ($balance <= 0) {
+        if ($latestEntry !== null && $latestEntry->balance_after <= 0) {
             Log::warning('CheckBudgetAvailable: User has no credits, skipping job', [
                 'experiment_id' => $experiment->id,
                 'user_id' => $experiment->user_id,
-                'balance' => $balance,
+                'balance' => $latestEntry->balance_after,
                 'job' => class_basename($job),
             ]);
 

--- a/tests/Feature/Api/V1/ProjectControllerTest.php
+++ b/tests/Feature/Api/V1/ProjectControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\V1;
 
+use App\Domain\Project\Actions\TriggerProjectRunAction;
 use App\Domain\Project\Models\Project;
 
 class ProjectControllerTest extends ApiTestCase
@@ -145,6 +146,10 @@ class ProjectControllerTest extends ApiTestCase
     {
         $this->actingAsApiUser();
         $project = $this->createProject(['status' => 'draft']);
+
+        $this->mock(TriggerProjectRunAction::class)
+            ->shouldReceive('execute')
+            ->once();
 
         $response = $this->postJson("/api/v1/projects/{$project->id}/activate");
 

--- a/tests/Feature/Jobs/Middleware/CheckBudgetAvailableTest.php
+++ b/tests/Feature/Jobs/Middleware/CheckBudgetAvailableTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature\Jobs\Middleware;
+
+use App\Domain\Budget\Models\CreditLedger;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Shared\Models\Team;
+use App\Jobs\Middleware\CheckBudgetAvailable;
+use App\Models\User;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CheckBudgetAvailableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private Experiment $experiment;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Test Team',
+            'slug' => 'test-team-budget',
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+
+        $this->experiment = Experiment::create([
+            'team_id' => $this->team->id,
+            'user_id' => $user->id,
+            'title' => 'Test Experiment',
+            'status' => 'scoring',
+            'track' => 'growth',
+            'budget_cap_credits' => 0,
+            'budget_spent_credits' => 0,
+        ]);
+    }
+
+    private function runMiddleware(object $job): bool
+    {
+        $called = false;
+        (new CheckBudgetAvailable)->handle($job, function () use (&$called) {
+            $called = true;
+        });
+
+        return $called;
+    }
+
+    private function makeJob(): object
+    {
+        return new class($this->experiment->id) {
+            public string $experimentId;
+
+            public function __construct(string $id)
+            {
+                $this->experimentId = $id;
+            }
+        };
+    }
+
+    public function test_allows_job_when_no_ledger_entries_exist(): void
+    {
+        // Community edition: no credits ever deposited — jobs must not be blocked
+        $called = $this->runMiddleware($this->makeJob());
+
+        $this->assertTrue($called, 'Job should proceed when no credit ledger entries exist (community install)');
+    }
+
+    public function test_blocks_job_when_balance_is_zero(): void
+    {
+        CreditLedger::create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->experiment->user_id,
+            'experiment_id' => $this->experiment->id,
+            'type' => 'deduction',
+            'amount' => 0,
+            'balance_after' => 0,
+            'description' => 'Zero balance',
+        ]);
+
+        $called = $this->runMiddleware($this->makeJob());
+
+        $this->assertFalse($called, 'Job should be blocked when balance is 0');
+    }
+
+    public function test_blocks_job_when_balance_is_negative(): void
+    {
+        CreditLedger::create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->experiment->user_id,
+            'experiment_id' => $this->experiment->id,
+            'type' => 'deduction',
+            'amount' => 10,
+            'balance_after' => -5,
+            'description' => 'Overdraft',
+        ]);
+
+        $called = $this->runMiddleware($this->makeJob());
+
+        $this->assertFalse($called, 'Job should be blocked when balance is negative');
+    }
+
+    public function test_allows_job_when_balance_is_positive(): void
+    {
+        CreditLedger::create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->experiment->user_id,
+            'experiment_id' => $this->experiment->id,
+            'type' => 'purchase',
+            'amount' => 100,
+            'balance_after' => 100,
+            'description' => 'Top-up',
+        ]);
+
+        $called = $this->runMiddleware($this->makeJob());
+
+        $this->assertTrue($called, 'Job should proceed when balance is positive');
+    }
+
+    public function test_allows_job_with_no_experiment_id(): void
+    {
+        $job = new class {
+            public string $someOtherProp = 'value';
+        };
+
+        $called = $this->runMiddleware($job);
+
+        $this->assertTrue($called, 'Job without experimentId property should always proceed');
+    }
+
+    public function test_blocks_job_when_experiment_budget_cap_exceeded(): void
+    {
+        $this->experiment->update([
+            'budget_cap_credits' => 50,
+            'budget_spent_credits' => 60,
+        ]);
+
+        $called = $this->runMiddleware($this->makeJob());
+
+        $this->assertFalse($called, 'Job should be blocked when experiment budget cap is exceeded');
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `CheckBudgetAvailable` was blocking all experiment pipeline jobs on self-hosted (community) installs because `CreditLedger` is empty by default. The query `value('balance_after') ?? 0` returned `0`, and `0 <= 0` always evaluated to true — silently dropping every job.
- **Fix**: Check if any ledger entry exists first; only enforce the balance check when credits have actually been issued. Community installs with an empty credit ledger pass through unconditionally.
- **Test**: Added `CheckBudgetAvailableTest` (6 cases) covering the community install path, zero/negative balance blocking, positive balance allowing, experiment budget cap, and no-experimentId bypass.
- **Side fix**: `ProjectControllerTest::test_can_activate_draft_project` was a false positive — it only passed before because the budget middleware was silently dropping the planning job. Added `TriggerProjectRunAction` mock to properly test just the activation, not the full pipeline.

## Impact

Community users who self-host and try to run experiments would get `CheckBudgetAvailable: User has no credits, skipping job` and no experiment would ever progress past the initial stage.

## Test plan

- [x] `php artisan test tests/Feature/Jobs/Middleware/CheckBudgetAvailableTest.php` — 6 new tests pass
- [x] `php artisan test tests/Feature/Api/V1/ProjectControllerTest.php` — 14 tests pass
- [x] Full suite: 693 tests pass (7 skipped, 1 incomplete — pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)