### PR TITLE
fix(tests): mock pipeline in tests masked by budget middleware

### DIFF
--- a/tests/Feature/Api/V1/ApprovalControllerTest.php
+++ b/tests/Feature/Api/V1/ApprovalControllerTest.php
@@ -100,6 +100,7 @@ class ApprovalControllerTest extends ApiTestCase
 
     public function test_can_reject_request(): void
     {
+        Event::fake([ExperimentTransitioned::class]);
         $this->actingAsApiUser();
         $approval = $this->createApproval();
 

--- a/tests/Feature/Api/V1/ProjectControllerTest.php
+++ b/tests/Feature/Api/V1/ProjectControllerTest.php
@@ -78,6 +78,9 @@ class ProjectControllerTest extends ApiTestCase
     public function test_can_create_project(): void
     {
         $this->actingAsApiUser();
+        $this->mock(TriggerProjectRunAction::class)
+            ->shouldReceive('execute')
+            ->once();
 
         $response = $this->postJson('/api/v1/projects', [
             'title' => 'New Project',


### PR DESCRIPTION
Tests that were previously passing only because CheckBudgetAvailable silently blocked all jobs now need proper isolation.