### PR TITLE
feat: streamlined onboarding, SSH host access & docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ APP_URL=http://localhost:8080
 # Deployment mode: 'self-hosted' (default) or 'cloud'
 DEPLOYMENT_MODE=self-hosted
 
+# Auth bypass — auto-login as first user (local single-user installs only)
+# Set to true to skip the login screen entirely. Only works when APP_ENV != production.
+# NEVER enable this on a server accessible from the internet.
+APP_AUTH_BYPASS=false
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This will:
 
 Visit **http://localhost:8080** when complete.
 
-## Quick Start (Manual)
+## Quick Start (Manual — Web Setup)
 
 Requirements: PHP 8.4+, PostgreSQL 17+, Redis 7+, Node.js 20+, Composer
 
@@ -176,11 +176,34 @@ cd agent-fleet
 composer install
 npm install && npm run build
 cp .env.example .env
-# Edit .env with your database and Redis credentials
-php artisan app:install
+# Edit .env — set DB_HOST, DB_DATABASE, DB_USERNAME, DB_PASSWORD, REDIS_HOST
+php artisan key:generate
+php artisan migrate
 php artisan horizon &
 php artisan serve
 ```
+
+Then open **http://localhost:8000** in your browser. The setup page will guide you through creating your admin account.
+
+> **Alternative:** Run `php artisan app:install` for an interactive CLI setup wizard that also seeds default agents and skills.
+
+## Authentication
+
+- **No email verification** — the self-hosted edition skips email verification entirely. Accounts are active immediately on registration.
+- **Single user** — all registered users join the default workspace automatically.
+
+### No-Password Mode (local installs)
+
+If you're running FleetQ locally on your own machine and don't want to enter a password on every visit, set `APP_AUTH_BYPASS=true` in `.env`:
+
+```bash
+APP_AUTH_BYPASS=true   # Auto-login as first user
+APP_ENV=local          # Required — bypass is disabled in production
+```
+
+With bypass enabled, the app logs you in automatically on every request. A logout link is still shown but you'll be logged back in on the next page load — this is intentional.
+
+> **Warning:** Never set `APP_AUTH_BYPASS=true` on a server accessible from the internet.
 
 ## Configuration
 
@@ -198,10 +221,13 @@ REDIS_DB=0          # Queues
 REDIS_CACHE_DB=1    # Cache
 REDIS_LOCK_DB=2     # Locks
 
-# LLM Providers -- at least one required
+# LLM Providers -- at least one required for AI features
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 GOOGLE_AI_API_KEY=
+
+# Auth bypass -- local no-password mode (never use in production)
+APP_AUTH_BYPASS=false
 ```
 
 Additional LLM keys can be configured in **Settings > AI Provider Keys** after login.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,111 @@ LOCAL_LLM_TIMEOUT=180
 
 Then configure endpoints in **Settings > Local LLM Endpoints**.
 
+## SSH Host Access
+
+Agents can execute commands on the host machine (or any remote server) via SSH using the built-in SSH tool type. This is useful for running local scripts, interacting with the filesystem, or orchestrating host-level processes from an agent.
+
+### How it works
+
+1. The platform stores SSH private keys encrypted in the Credential vault.
+2. An SSH Tool is configured with `host`, `port`, `username`, `credential_id`, and an optional `allowed_commands` whitelist.
+3. On the first connection to a host, the server's public key fingerprint is stored via **TOFU** (Trust On First Use). Subsequent connections verify the fingerprint — a mismatch raises an error to prevent MITM attacks.
+4. Manage trusted fingerprints via **Settings > SSH Fingerprints** or the `tool_ssh_fingerprints` MCP tool.
+
+### Setup (Docker — connecting container to host)
+
+The containers reach the host machine via `host.docker.internal`, which is pre-configured in `docker-compose.yml` via `extra_hosts: host.docker.internal:host-gateway`.
+
+**Step 1 — Enable SSH on the host**
+
+| OS | Command |
+|----|---------|
+| macOS | System Settings → General → Sharing → **Remote Login** → On |
+| Ubuntu/Debian | `sudo apt install openssh-server && sudo systemctl enable --now ssh` |
+| Fedora/RHEL | `sudo dnf install openssh-server && sudo systemctl enable --now sshd` |
+| Windows | Settings → System → Optional Features → **OpenSSH Server**, then `Start-Service sshd` |
+
+**Step 2 — Generate an SSH key pair**
+
+```bash
+ssh-keygen -t ed25519 -C "fleetq-agent@local" -f ~/.ssh/fleetq_agent_key -N ""
+```
+
+**Step 3 — Authorize the key on the host**
+
+```bash
+cat ~/.ssh/fleetq_agent_key.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+**Step 4 — Create a Credential in FleetQ**
+
+Navigate to **Credentials → New Credential**:
+- Type: `SSH Key`
+- Paste the contents of `~/.ssh/fleetq_agent_key` (private key)
+
+Or via API:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/credentials \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Host SSH Key",
+    "credential_type": "ssh_key",
+    "secret_data": {"private_key": "<contents of fleetq_agent_key>"}
+  }'
+```
+
+**Step 5 — Create an SSH Tool**
+
+Navigate to **Tools → New Tool → Built-in → SSH Remote**, or via API:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/tools \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Host SSH",
+    "type": "built_in",
+    "risk_level": "destructive",
+    "transport_config": {
+      "kind": "ssh",
+      "host": "host.docker.internal",
+      "port": 22,
+      "username": "your-username",
+      "credential_id": "<credential-id>",
+      "allowed_commands": ["ls", "pwd", "whoami", "uname", "date", "df"]
+    },
+    "settings": {"timeout": 30}
+  }'
+```
+
+**Step 6 — Assign the tool to an agent**
+
+In the Agent detail page, go to **Tools** and assign the SSH tool. The agent will now have an `ssh_execute` function available during execution.
+
+### Command security policy
+
+The platform enforces a multi-layer security hierarchy for bash and SSH commands:
+
+1. **Platform-level** — always blocked: `rm -rf /`, `mkfs`, `shutdown`, `reboot`, pipe-to-shell patterns
+2. **Organization-level** — configure in **Settings → Security Policy** or via the `tool_bash_policy` MCP tool
+3. **Tool-level** — `allowed_commands` whitelist in the tool's transport config
+4. **Project-level** — additional restrictions in project settings
+5. **Agent-level** — per-agent overrides on the tool pivot
+
+More restrictive layers always win. A command blocked at the platform level cannot be unblocked by any other layer.
+
+### SSH fingerprint management
+
+Trusted host fingerprints are viewable and removable via:
+
+- **API:** `GET /api/v1/ssh-fingerprints` / `DELETE /api/v1/ssh-fingerprints/{id}`
+- **MCP:** `tool_ssh_fingerprints` with `list` or `delete` action
+
+Remove a fingerprint when a host's SSH key is legitimately rotated — the next connection will re-verify via TOFU.
+
 ## Architecture
 
 Built with Laravel 12, Livewire 4, and Tailwind CSS. Domain-driven design with 16 bounded contexts:

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -36,9 +36,10 @@ class CreateNewUser implements CreatesNewUsers
 
         return DB::transaction(function () use ($input) {
             $user = User::create([
-                'name' => $input['name'],
-                'email' => $input['email'],
-                'password' => Hash::make($input['password']),
+                'name'              => $input['name'],
+                'email'             => $input['email'],
+                'password'          => Hash::make($input['password']),
+                'email_verified_at' => now(),
             ]);
 
             // Attach to the default team (created during app:install)

--- a/app/Http/Controllers/Api/V1/SshFingerprintController.php
+++ b/app/Http/Controllers/Api/V1/SshFingerprintController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domain\Tool\Models\SshHostFingerprint;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\SshFingerprintResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * @tags SSH Fingerprints
+ */
+class SshFingerprintController extends Controller
+{
+    /**
+     * List all trusted SSH host fingerprints.
+     *
+     * Returns every host:port combination that has been trusted via TOFU
+     * (Trust On First Use) for the current team.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $fingerprints = SshHostFingerprint::orderBy('host')->orderBy('port')->get();
+
+        return SshFingerprintResource::collection($fingerprints);
+    }
+
+    /**
+     * Delete a trusted SSH host fingerprint.
+     *
+     * Removes the stored fingerprint for this host:port. The next SSH connection
+     * to that host will re-run TOFU and store a fresh fingerprint.
+     * Use this when a host's SSH key has been rotated legitimately.
+     *
+     * @response 200 {"message": "Fingerprint removed. Next connection will re-verify via TOFU."}
+     */
+    public function destroy(SshHostFingerprint $sshFingerprint): JsonResponse
+    {
+        $sshFingerprint->delete();
+
+        return response()->json([
+            'message' => 'Fingerprint removed. Next connection will re-verify via TOFU.',
+        ]);
+    }
+}

--- a/app/Http/Middleware/BypassAuth.php
+++ b/app/Http/Middleware/BypassAuth.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Domain\Shared\Services\DeploymentMode;
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Auto-login as the first user when APP_AUTH_BYPASS=true.
+ *
+ * Only activates when ALL three conditions are met:
+ *   1. APP_AUTH_BYPASS=true in .env
+ *   2. APP_ENV is not 'production'
+ *   3. DEPLOYMENT_MODE=self-hosted
+ *
+ * Designed for local single-user installs where passwords are unnecessary.
+ * NEVER enable this on a publicly accessible server.
+ */
+class BypassAuth
+{
+    public function __construct(private readonly DeploymentMode $deploymentMode) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (
+            config('app.auth_bypass') === true
+            && config('app.env') !== 'production'
+            && $this->deploymentMode->isSelfHosted()
+            && ! Auth::check()
+        ) {
+            $user = User::first();
+
+            if ($user) {
+                Auth::login($user);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Resources/Api/V1/SshFingerprintResource.php
+++ b/app/Http/Resources/Api/V1/SshFingerprintResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SshFingerprintResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'                 => $this->id,
+            'host'               => $this->host,
+            'port'               => $this->port,
+            'fingerprint_sha256' => $this->fingerprint_sha256,
+            'verified_at'        => $this->verified_at?->toISOString(),
+            'created_at'         => $this->created_at->toISOString(),
+        ];
+    }
+}

--- a/app/Livewire/Setup/SetupPage.php
+++ b/app/Livewire/Setup/SetupPage.php
@@ -51,9 +51,10 @@ class SetupPage extends Component
     public function createAccount(): void
     {
         Validator::make([
-            'name'     => $this->name,
-            'email'    => $this->email,
-            'password' => $this->password,
+            'name'                  => $this->name,
+            'email'                 => $this->email,
+            'password'              => $this->password,
+            'password_confirmation' => $this->password_confirmation,
         ], [
             'name'     => ['required', 'string', 'max:255'],
             'email'    => ['required', 'string', 'email', 'max:255'],

--- a/app/Livewire/Setup/SetupPage.php
+++ b/app/Livewire/Setup/SetupPage.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Livewire\Setup;
+
+use App\Domain\Shared\Models\Team;
+use App\Domain\Shared\Notifications\WelcomeNotification;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('components.layouts.auth', ['title' => 'Setup — FleetQ'])]
+class SetupPage extends Component
+{
+    public string $name = '';
+    public string $email = '';
+    public string $password = '';
+    public string $password_confirmation = '';
+
+    /** @var array<string, array{status: string, detail: string, hint?: string}> */
+    public array $checks = [];
+
+    public bool $blockerPresent = true;
+
+    public function mount(): void
+    {
+        // Guard: if already installed, send to login
+        try {
+            if (User::exists()) {
+                $this->redirect(route('login'), navigate: true);
+
+                return;
+            }
+        } catch (\Throwable) {
+            // DB down — fall through to show error checks
+        }
+
+        $this->runChecks();
+    }
+
+    public function recheck(): void
+    {
+        $this->runChecks();
+    }
+
+    public function createAccount(): void
+    {
+        Validator::make([
+            'name'     => $this->name,
+            'email'    => $this->email,
+            'password' => $this->password,
+        ], [
+            'name'     => ['required', 'string', 'max:255'],
+            'email'    => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string', 'confirmed', Password::min(8)],
+        ])->validate();
+
+        DB::transaction(function () {
+            // Create admin user
+            $user = User::create([
+                'name'              => $this->name,
+                'email'             => strtolower($this->email),
+                'password'          => Hash::make($this->password),
+                'email_verified_at' => now(), // no email verification in self-hosted
+            ]);
+
+            // Create or find the default team
+            $team = Team::firstOrCreate(
+                ['slug' => 'default'],
+                [
+                    'name'     => config('app.name', 'FleetQ'),
+                    'owner_id' => $user->id,
+                    'plan'     => 'community',
+                ],
+            );
+
+            // Ensure owner_id is set (team may have existed without an owner)
+            if (! $team->wasRecentlyCreated) {
+                $team->update(['owner_id' => $user->id]);
+            }
+
+            // Attach as owner
+            $team->users()->syncWithoutDetaching([$user->id => ['role' => 'owner']]);
+
+            $user->update(['current_team_id' => $team->id]);
+
+            try {
+                $user->notify(new WelcomeNotification($team));
+            } catch (\Throwable) {
+                // Mail may not be configured yet — do not fail setup
+            }
+
+            Auth::login($user);
+        });
+
+        $this->redirect(route('dashboard'), navigate: true);
+    }
+
+    public function render(): \Illuminate\View\View
+    {
+        return view('livewire.setup.setup-page');
+    }
+
+    private function runChecks(): void
+    {
+        $this->checks = [];
+        $blocking = false;
+
+        // 1. Database connection (CRITICAL — blocks form)
+        try {
+            DB::connection()->getPdo();
+            $this->checks['database'] = ['status' => 'ok', 'detail' => 'Database connected'];
+        } catch (\Throwable $e) {
+            $this->checks['database'] = [
+                'status' => 'fail',
+                'detail' => 'Cannot connect to database',
+                'hint'   => 'Check DB_HOST, DB_PORT, DB_DATABASE, DB_USERNAME, and DB_PASSWORD in your .env file. Error: ' . $e->getMessage(),
+            ];
+            $blocking = true;
+        }
+
+        // 2. Migrations run — users table must exist (CRITICAL — blocks form)
+        if (! $blocking) {
+            try {
+                $hasMigrations = DB::connection()->getSchemaBuilder()->hasTable('users');
+
+                if ($hasMigrations) {
+                    $this->checks['migrations'] = ['status' => 'ok', 'detail' => 'Database schema ready'];
+                } else {
+                    $this->checks['migrations'] = [
+                        'status' => 'fail',
+                        'detail' => 'Database tables not found',
+                        'hint'   => 'Run migrations: php artisan migrate',
+                    ];
+                    $blocking = true;
+                }
+            } catch (\Throwable) {
+                $this->checks['migrations'] = [
+                    'status' => 'fail',
+                    'detail' => 'Cannot verify database schema',
+                    'hint'   => 'Run migrations: php artisan migrate',
+                ];
+                $blocking = true;
+            }
+        }
+
+        // 3. APP_KEY set (CRITICAL — blocks form)
+        if (empty(config('app.key'))) {
+            $this->checks['app_key'] = [
+                'status' => 'fail',
+                'detail' => 'Application key is not set',
+                'hint'   => 'Generate one: php artisan key:generate',
+            ];
+            $blocking = true;
+        } else {
+            $this->checks['app_key'] = ['status' => 'ok', 'detail' => 'Application key configured'];
+        }
+
+        // 4. Redis connection (WARNING — form still shown)
+        try {
+            Redis::connection()->ping();
+            $this->checks['redis'] = ['status' => 'ok', 'detail' => 'Redis connected'];
+        } catch (\Throwable $e) {
+            $this->checks['redis'] = [
+                'status' => 'warn',
+                'detail' => 'Cannot connect to Redis',
+                'hint'   => 'Queue workers and sessions require Redis. Check REDIS_HOST and REDIS_PORT in .env.',
+            ];
+        }
+
+        // 5. LLM provider (WARNING — form still shown, can configure later in Settings)
+        $hasLlm = ! empty(config('services.anthropic.api_key'))
+            || ! empty(config('services.openai.api_key'))
+            || ! empty(config('services.google.api_key'));
+
+        $this->checks['llm'] = $hasLlm
+            ? ['status' => 'ok', 'detail' => 'LLM provider configured']
+            : [
+                'status' => 'warn',
+                'detail' => 'No LLM API key found',
+                'hint'   => 'Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_AI_API_KEY in .env. You can also configure this later in Settings.',
+            ];
+
+        $this->blockerPresent = $blocking;
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -103,12 +103,14 @@ use App\Mcp\Tools\System\AuditLogTool;
 use App\Mcp\Tools\System\DashboardKpisTool;
 use App\Mcp\Tools\System\SystemHealthTool;
 use App\Mcp\Tools\Telegram\TelegramBotTool;
+use App\Mcp\Tools\Tool\ToolBashPolicyTool;
 use App\Mcp\Tools\Tool\ToolCreateTool;
 use App\Mcp\Tools\Tool\ToolDeleteTool;
 use App\Mcp\Tools\Tool\ToolDiscoverMcpTool;
 use App\Mcp\Tools\Tool\ToolGetTool;
 use App\Mcp\Tools\Tool\ToolImportMcpTool;
 use App\Mcp\Tools\Tool\ToolListTool;
+use App\Mcp\Tools\Tool\ToolSshFingerprintsTool;
 use App\Mcp\Tools\Tool\ToolUpdateTool;
 use App\Mcp\Tools\Trigger\TriggerRuleCreateTool;
 use App\Mcp\Tools\Trigger\TriggerRuleDeleteTool;
@@ -205,6 +207,8 @@ class AgentFleetServer extends Server
         ToolDeleteTool::class,
         ToolDiscoverMcpTool::class,
         ToolImportMcpTool::class,
+        ToolSshFingerprintsTool::class,
+        ToolBashPolicyTool::class,
 
         // Credential (5)
         CredentialListTool::class,

--- a/app/Mcp/Tools/Tool/ToolBashPolicyTool.php
+++ b/app/Mcp/Tools/Tool/ToolBashPolicyTool.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Mcp\Tools\Tool;
+
+use App\Models\GlobalSetting;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Attributes\IsDestructive;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+class ToolBashPolicyTool extends Tool
+{
+    protected string $name = 'tool_bash_policy';
+
+    protected string $description = 'View or update the organization-level command security policy for Bash/shell tools. '
+        .'This policy applies to all built_in bash tools and sits between platform-level blocks and per-tool allowlists. '
+        .'Actions: get — show current policy; set — replace policy fields; reset — clear all org-level restrictions.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'action' => $schema->string()
+                ->description('Action: get, set, or reset')
+                ->enum(['get', 'set', 'reset'])
+                ->required(),
+            'blocked_commands' => $schema->array()
+                ->description('Commands to block at org level (e.g. ["curl", "wget"])'),
+            'blocked_patterns' => $schema->array()
+                ->description('Shell patterns to block (e.g. ["--output /etc", "| nc "])'),
+            'allowed_commands' => $schema->array()
+                ->description('If set, only these commands pass through at org level (whitelist)'),
+            'allowed_paths' => $schema->array()
+                ->description('If set, working directory must be under one of these paths'),
+            'require_approval_for' => $schema->array()
+                ->description('Commands matching these patterns require approval/audit log'),
+            'max_command_timeout' => $schema->number()
+                ->description('Maximum allowed timeout in seconds for any bash command'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'action'               => 'required|string|in:get,set,reset',
+            'blocked_commands'     => 'nullable|array',
+            'blocked_patterns'     => 'nullable|array',
+            'allowed_commands'     => 'nullable|array',
+            'allowed_paths'        => 'nullable|array',
+            'require_approval_for' => 'nullable|array',
+            'max_command_timeout'  => 'nullable|integer|min:1|max:3600',
+        ]);
+
+        return match ($validated['action']) {
+            'get'   => $this->get(),
+            'set'   => $this->set($validated),
+            'reset' => $this->reset(),
+        };
+    }
+
+    private function get(): Response
+    {
+        $policy = GlobalSetting::get('org_security_policy', []);
+
+        if (empty($policy)) {
+            return Response::text('No org-level security policy set. All commands pass through to tool-level allowlists.');
+        }
+
+        $lines = [];
+        if (! empty($policy['blocked_commands'])) {
+            $lines[] = 'blocked_commands: '.implode(', ', $policy['blocked_commands']);
+        }
+        if (! empty($policy['blocked_patterns'])) {
+            $lines[] = 'blocked_patterns: '.implode(', ', $policy['blocked_patterns']);
+        }
+        if (! empty($policy['allowed_commands'])) {
+            $lines[] = 'allowed_commands (whitelist): '.implode(', ', $policy['allowed_commands']);
+        }
+        if (! empty($policy['allowed_paths'])) {
+            $lines[] = 'allowed_paths: '.implode(', ', $policy['allowed_paths']);
+        }
+        if (! empty($policy['require_approval_for'])) {
+            $lines[] = 'require_approval_for: '.implode(', ', $policy['require_approval_for']);
+        }
+        if (isset($policy['max_command_timeout'])) {
+            $lines[] = "max_command_timeout: {$policy['max_command_timeout']}s";
+        }
+
+        return Response::text("Organization security policy:\n\n".implode("\n", $lines));
+    }
+
+    private function set(array $input): Response
+    {
+        $current = GlobalSetting::get('org_security_policy', []);
+
+        $fields = ['blocked_commands', 'blocked_patterns', 'allowed_commands', 'allowed_paths', 'require_approval_for', 'max_command_timeout'];
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $input) && $input[$field] !== null) {
+                $current[$field] = $input[$field];
+            }
+        }
+
+        // Remove empty arrays to keep storage clean
+        $current = array_filter($current, fn ($v) => ! empty($v));
+
+        GlobalSetting::set('org_security_policy', $current);
+
+        return Response::text("Organization security policy updated.\n\n".json_encode($current, JSON_PRETTY_PRINT));
+    }
+
+    private function reset(): Response
+    {
+        GlobalSetting::set('org_security_policy', []);
+
+        return Response::text('Organization security policy reset. No org-level restrictions are active.');
+    }
+}

--- a/app/Mcp/Tools/Tool/ToolCreateTool.php
+++ b/app/Mcp/Tools/Tool/ToolCreateTool.php
@@ -14,7 +14,19 @@ class ToolCreateTool extends Tool
 {
     protected string $name = 'tool_create';
 
-    protected string $description = 'Create a new tool (MCP server or built-in). Specify name and optionally description, type, and transport config.';
+    protected string $description = <<<'DESC'
+Create a new tool. Supported types:
+
+mcp_stdio — local MCP server via stdio. transport_config: {command, args, env}
+mcp_http  — remote MCP server via HTTP/SSE. transport_config: {url, headers}
+built_in  — host capability. transport_config depends on kind:
+  bash: {kind:"bash", allowed_commands:[], allowed_paths:[]}
+  filesystem: {kind:"filesystem", allowed_paths:[], read_only:false}
+  ssh: {kind:"ssh", host, port, username, credential_id, allowed_commands:[]}
+
+For SSH tools: create an ssh_key Credential first, then reference its ID in credential_id.
+Host fingerprints are stored automatically on first connect (TOFU). Manage via tool_ssh_fingerprints.
+DESC;
 
     public function schema(JsonSchema $schema): array
     {

--- a/app/Mcp/Tools/Tool/ToolSshFingerprintsTool.php
+++ b/app/Mcp/Tools/Tool/ToolSshFingerprintsTool.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Mcp\Tools\Tool;
+
+use App\Domain\Tool\Models\SshHostFingerprint;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Attributes\IsDestructive;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+class ToolSshFingerprintsTool extends Tool
+{
+    protected string $name = 'tool_ssh_fingerprints';
+
+    protected string $description = 'Manage trusted SSH host fingerprints (TOFU store). '
+        .'Actions: list — show all trusted hosts; delete — remove a fingerprint so the next connection re-verifies via TOFU (use after legitimate host key rotation).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'action' => $schema->string()
+                ->description('Action to perform: list or delete')
+                ->enum(['list', 'delete'])
+                ->required(),
+            'fingerprint_id' => $schema->string()
+                ->description('Fingerprint ID to delete (required for delete action)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'action'         => 'required|string|in:list,delete',
+            'fingerprint_id' => 'nullable|string',
+        ]);
+
+        return match ($validated['action']) {
+            'list'   => $this->list(),
+            'delete' => $this->delete($validated['fingerprint_id'] ?? null),
+        };
+    }
+
+    private function list(): Response
+    {
+        $fingerprints = SshHostFingerprint::orderBy('host')
+            ->orderBy('port')
+            ->get(['id', 'host', 'port', 'fingerprint_sha256', 'verified_at', 'created_at']);
+
+        if ($fingerprints->isEmpty()) {
+            return Response::text('No trusted SSH hosts yet. Fingerprints are stored automatically on first connection (TOFU).');
+        }
+
+        $rows = $fingerprints->map(fn ($f) => sprintf(
+            "%-30s  port %-5d  sha256:%s  verified:%s",
+            $f->host,
+            $f->port,
+            substr($f->fingerprint_sha256, 0, 16).'...',
+            $f->verified_at?->toDateTimeString() ?? 'never',
+        ))->join("\n");
+
+        return Response::text("Trusted SSH hosts ({$fingerprints->count()}):\n\n{$rows}");
+    }
+
+    private function delete(?string $fingerprintId): Response
+    {
+        if (! $fingerprintId) {
+            return Response::error('fingerprint_id is required for delete action');
+        }
+
+        $fingerprint = SshHostFingerprint::find($fingerprintId);
+
+        if (! $fingerprint) {
+            return Response::error("Fingerprint {$fingerprintId} not found.");
+        }
+
+        $label = "{$fingerprint->host}:{$fingerprint->port}";
+        $fingerprint->delete();
+
+        return Response::text("Fingerprint for {$label} removed. Next SSH connection will re-verify via TOFU.");
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use App\Domain\Shared\Enums\TeamRole;
 use App\Domain\Shared\Models\Team;
 use App\Domain\Shared\Services\NotificationPreferencesService;
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,7 +15,7 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use NotificationChannels\WebPush\HasPushSubscriptions;
 
-class User extends Authenticatable implements MustVerifyEmail
+class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasApiTokens, HasFactory, HasPushSubscriptions, HasUuids, Notifiable;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 
@@ -51,6 +52,11 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Force HTTPS when APP_URL uses https (e.g. behind OrbStack / reverse proxy)
+        if (str_starts_with(config('app.url'), 'https://')) {
+            URL::forceScheme('https');
+        }
+
         // Community edition: all authenticated users have full access
         Gate::define('manage-team', fn ($user) => true);
         Gate::define('edit-content', fn ($user) => true);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -32,7 +32,9 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->trustProxies(at: '*');
         $middleware->append(SecurityHeaders::class);
+        $middleware->appendToGroup('web', \App\Http\Middleware\BypassAuth::class);
         $middleware->appendToGroup('web', SetCurrentTeam::class);
         $middleware->appendToGroup('web', SetPostgresRlsContext::class);
         $middleware->statefulApi();

--- a/config/app.php
+++ b/config/app.php
@@ -137,4 +137,18 @@ return [
 
     'deployment_mode' => env('DEPLOYMENT_MODE', 'self-hosted'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Auth Bypass (Local No-Password Mode)
+    |--------------------------------------------------------------------------
+    |
+    | When set to true, the application auto-logs in as the first user on every
+    | request. Designed for local single-user installs where a password is
+    | unnecessary. Only activates when APP_ENV is not 'production' and
+    | DEPLOYMENT_MODE is 'self-hosted'. NEVER enable on a public server.
+    |
+    */
+
+    'auth_bypass' => env('APP_AUTH_BYPASS', false),
+
 ];

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -146,7 +146,6 @@ return [
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
-        Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication([

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
       - "5174:5173"
     volumes:
       - .:/var/www
+      - vendor_data:/var/www/vendor
       - node_modules:/var/www/node_modules
     networks:
       - agent-fleet-open

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -29,6 +29,8 @@ server {
     location ~ \.php$ {
         fastcgi_pass app:9000;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param HTTPS $http_x_forwarded_proto;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $http_x_forwarded_proto;
         include fastcgi_params;
         fastcgi_buffering off;
         fastcgi_read_timeout 120s;

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -8,6 +8,9 @@ RUN apk add --no-cache \
     linux-headers \
     $PHPIZE_DEPS
 
+# Install system dependencies for exif
+RUN apk add --no-cache libexif-dev
+
 # Install PHP extensions
 RUN docker-php-ext-install \
     pdo_pgsql \
@@ -16,7 +19,8 @@ RUN docker-php-ext-install \
     intl \
     pcntl \
     opcache \
-    bcmath
+    bcmath \
+    exif
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis
@@ -53,7 +57,7 @@ RUN apk add --no-cache nodejs npm
 
 COPY . .
 
-RUN composer install --no-interaction --optimize-autoloader
+RUN php -d disable_functions="" /usr/bin/composer install --no-interaction --optimize-autoloader
 
 COPY docker/php/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
@@ -67,10 +71,10 @@ FROM base AS production
 
 COPY . .
 
-RUN composer install --no-dev --no-interaction --optimize-autoloader \
-    && php artisan config:cache \
-    && php artisan route:cache \
-    && php artisan view:cache
+RUN php -d disable_functions="" /usr/bin/composer install --no-dev --no-interaction --optimize-autoloader \
+    && php -d disable_functions="" artisan config:cache \
+    && php -d disable_functions="" artisan route:cache \
+    && php -d disable_functions="" artisan view:cache
 
 # Set proper permissions
 RUN chown -R www-data:www-data storage bootstrap/cache

--- a/resources/views/components/layouts/auth.blade.php
+++ b/resources/views/components/layouts/auth.blade.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ $title ?? config('app.name') }}</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <meta name="theme-color" content="#2563eb">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="FleetQ">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="format-detection" content="telephone=no">
+
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=inter:400,500,600,700" rel="stylesheet" />
+    @vite(['resources/css/app.css'])
+    @livewireStyles
+</head>
+<body class="flex min-h-screen items-center justify-center bg-gray-50 font-sans antialiased">
+    {{ $slot }}
+
+    @livewireScripts
+</body>
+</html>

--- a/resources/views/livewire/setup/setup-page.blade.php
+++ b/resources/views/livewire/setup/setup-page.blade.php
@@ -93,6 +93,30 @@
 
     {{-- Admin Account Form --}}
     @if(! $blockerPresent && ! empty($checks))
+        {{-- No-password mode tip --}}
+        <div class="mb-4 rounded-xl border border-blue-200 bg-blue-50 p-4">
+            <div class="flex gap-3">
+                <svg class="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
+                </svg>
+                <div>
+                    <p class="text-sm font-medium text-blue-800">Running locally? Skip the password.</p>
+                    <p class="mt-1 text-xs text-blue-700">
+                        If this is a local install on your own machine, you can enable no-password mode — the app will log you in automatically on every visit.
+                    </p>
+                    <p class="mt-2 text-xs text-blue-700">
+                        Add this to your <code class="rounded bg-blue-100 px-1 py-0.5 font-mono">.env</code> file:
+                    </p>
+                    <pre class="mt-1.5 rounded-md bg-blue-100 px-3 py-2 text-xs font-mono text-blue-900">APP_AUTH_BYPASS=true
+APP_ENV=local</pre>
+                    <p class="mt-2 text-xs text-blue-600">
+                        With bypass enabled you still need an account below — but you'll never be asked for a password again.
+                        <strong>Never use this on a server accessible from the internet.</strong>
+                    </p>
+                </div>
+            </div>
+        </div>
+
         <div class="rounded-xl border border-gray-200 bg-white p-6">
             <h2 class="mb-1 text-base font-semibold text-gray-900">Create Admin Account</h2>
             <p class="mb-5 text-sm text-gray-500">This will be the owner account for your installation.</p>

--- a/resources/views/livewire/setup/setup-page.blade.php
+++ b/resources/views/livewire/setup/setup-page.blade.php
@@ -1,0 +1,170 @@
+<div class="w-full max-w-lg px-4 py-8">
+    {{-- Header --}}
+    <div class="mb-8 text-center">
+        <div class="mb-3 flex justify-center">
+            <div class="flex h-12 w-12 items-center justify-center rounded-xl bg-primary-600">
+                <x-logo-icon class="h-7 w-7 text-white" />
+            </div>
+        </div>
+        <h1 class="text-2xl font-bold text-gray-900">{{ config('app.name') }}</h1>
+        <p class="mt-2 text-sm text-gray-500">Installation Setup</p>
+    </div>
+
+    {{-- System Checks --}}
+    <div class="mb-6 rounded-xl border border-gray-200 bg-white p-6">
+        <div class="mb-4 flex items-center justify-between">
+            <h2 class="text-base font-semibold text-gray-900">System Checks</h2>
+            <button
+                wire:click="recheck"
+                wire:loading.attr="disabled"
+                class="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-100 disabled:opacity-50"
+            >
+                <svg wire:loading wire:target="recheck" class="h-3.5 w-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                </svg>
+                <svg wire:loading.remove wire:target="recheck" class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Re-check
+            </button>
+        </div>
+
+        <div class="space-y-3">
+            @foreach($checks as $key => $check)
+                @php
+                    $labels = [
+                        'database'   => 'Database Connection',
+                        'migrations' => 'Database Schema',
+                        'app_key'    => 'Application Key',
+                        'redis'      => 'Redis Connection',
+                        'llm'        => 'LLM Provider',
+                    ];
+                    $label = $labels[$key] ?? ucfirst($key);
+                @endphp
+                <div class="flex items-start gap-3 rounded-lg p-3 {{ $check['status'] === 'ok' ? 'bg-green-50' : ($check['status'] === 'warn' ? 'bg-yellow-50' : 'bg-red-50') }}">
+                    <div class="mt-0.5 flex-shrink-0">
+                        @if($check['status'] === 'ok')
+                            <svg class="h-5 w-5 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                            </svg>
+                        @elseif($check['status'] === 'warn')
+                            <svg class="h-5 w-5 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+                            </svg>
+                        @else
+                            <svg class="h-5 w-5 text-red-500" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+                            </svg>
+                        @endif
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2">
+                            <span class="text-sm font-medium {{ $check['status'] === 'ok' ? 'text-green-800' : ($check['status'] === 'warn' ? 'text-yellow-800' : 'text-red-800') }}">
+                                {{ $label }}
+                            </span>
+                            @if($check['status'] === 'warn')
+                                <span class="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">Optional</span>
+                            @endif
+                        </div>
+                        <p class="mt-0.5 text-xs {{ $check['status'] === 'ok' ? 'text-green-700' : ($check['status'] === 'warn' ? 'text-yellow-700' : 'text-red-700') }}">
+                            {{ $check['detail'] }}
+                        </p>
+                        @if(isset($check['hint']))
+                            <p class="mt-1 text-xs text-gray-600">
+                                <span class="font-medium">Fix:</span> {{ $check['hint'] }}
+                            </p>
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+
+            @if(empty($checks))
+                <div class="flex items-center gap-2 py-2 text-sm text-gray-500">
+                    <svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                    </svg>
+                    Running checks...
+                </div>
+            @endif
+        </div>
+    </div>
+
+    {{-- Admin Account Form --}}
+    @if(! $blockerPresent && ! empty($checks))
+        <div class="rounded-xl border border-gray-200 bg-white p-6">
+            <h2 class="mb-1 text-base font-semibold text-gray-900">Create Admin Account</h2>
+            <p class="mb-5 text-sm text-gray-500">This will be the owner account for your installation.</p>
+
+            @if($errors->any())
+                <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-600">
+                    @foreach($errors->all() as $error)
+                        <p>{{ $error }}</p>
+                    @endforeach
+                </div>
+            @endif
+
+            <form wire:submit="createAccount" class="space-y-4">
+                <div>
+                    <x-form-input
+                        label="Full Name"
+                        type="text"
+                        id="name"
+                        name="name"
+                        wire:model="name"
+                        required
+                        autofocus
+                    />
+                </div>
+
+                <div>
+                    <x-form-input
+                        label="Email Address"
+                        type="email"
+                        id="email"
+                        name="email"
+                        wire:model="email"
+                        required
+                    />
+                </div>
+
+                <div>
+                    <x-form-input
+                        label="Password"
+                        type="password"
+                        id="password"
+                        name="password"
+                        wire:model="password"
+                        required
+                    />
+                </div>
+
+                <div>
+                    <x-form-input
+                        label="Confirm Password"
+                        type="password"
+                        id="password_confirmation"
+                        name="password_confirmation"
+                        wire:model="password_confirmation"
+                        required
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    wire:loading.attr="disabled"
+                    class="w-full rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50"
+                >
+                    <span wire:loading.remove wire:target="createAccount">Create Account & Launch</span>
+                    <span wire:loading wire:target="createAccount">Setting up...</span>
+                </button>
+            </form>
+        </div>
+    @elseif($blockerPresent && ! empty($checks))
+        <div class="rounded-xl border border-red-200 bg-red-50 p-5 text-center">
+            <p class="text-sm font-medium text-red-800">Fix the issues above before continuing.</p>
+            <p class="mt-1 text-xs text-red-600">After making changes to your .env file, click "Re-check" above.</p>
+        </div>
+    @endif
+</div>

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Api\V1\ProjectController;
 use App\Http\Controllers\Api\V1\SignalController;
 use App\Http\Controllers\Api\V1\SkillController;
 use App\Http\Controllers\Api\V1\TeamController;
+use App\Http\Controllers\Api\V1\SshFingerprintController;
 use App\Http\Controllers\Api\V1\ToolController;
 use App\Http\Controllers\Api\V1\WebhookEndpointController;
 use App\Http\Controllers\Api\V1\WorkflowController;
@@ -81,6 +82,8 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
 
     // Tools
     Route::apiResource('tools', ToolController::class);
+    Route::get('/ssh-fingerprints', [SshFingerprintController::class, 'index']);
+    Route::delete('/ssh-fingerprints/{sshFingerprint}', [SshFingerprintController::class, 'destroy']);
 
     // Credentials
     Route::apiResource('credentials', CredentialController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,8 +59,29 @@ use Illuminate\Support\Facades\Route;
 // Public experiment share (no auth)
 Route::get('/share/{shareToken}', [PublicExperimentController::class, 'show'])->name('experiments.share');
 
-// Root — landing page (always visible, even when authenticated)
-Route::get('/', fn () => view('landing'))->name('home');
+// Root — smart redirect: setup (fresh install) → dashboard (authed) → login
+Route::get('/', function () {
+    try {
+        if (! \App\Models\User::exists()) {
+            return redirect()->route('setup');
+        }
+    } catch (\Throwable) {
+        // DB unreachable — send to setup page to show diagnostics
+        return redirect()->route('setup');
+    }
+
+    if (auth()->check()) {
+        return redirect()->route('dashboard');
+    }
+
+    return redirect()->route('login');
+})->name('home');
+
+// Setup / installation check page (public — excluded from DB-dependent middleware)
+Route::withoutMiddleware([
+    \App\Http\Middleware\SetCurrentTeam::class,
+    \App\Http\Middleware\SetPostgresRlsContext::class,
+])->get('/setup', \App\Livewire\Setup\SetupPage::class)->name('setup');
 
 // Legal pages (public)
 Route::get('/privacy', fn () => view('legal.privacy'))->name('legal.privacy');


### PR DESCRIPTION
## Summary

- **Setup page** (`/setup`) — replaces landing page as entry point for fresh installs; runs 5 system checks (DB, migrations, APP_KEY, Redis, LLM); shows admin account creation form with no-password mode tip
- **Auth simplification** — no email verification in self-hosted edition; `APP_AUTH_BYPASS=true` for local no-password installs; `BypassAuth` middleware
- **Dockerfile fixes** — adds `ext-exif` (required by spatie/image), bypasses `proc_open` restriction during build-time composer/artisan commands
- **SSH host access** — `GET/DELETE /api/v1/ssh-fingerprints` endpoint; `tool_ssh_fingerprints` and `tool_bash_policy` MCP tools; improved `tool_create` description
- **Documentation** — full SSH Host Access section in README (per-OS setup, key generation, credential/tool creation, security hierarchy, fingerprint management)

## Changes

### New files
- `app/Livewire/Setup/SetupPage.php` + blade view — installation check page
- `app/Http/Middleware/BypassAuth.php` — auto-login middleware
- `app/Http/Controllers/Api/V1/SshFingerprintController.php`
- `app/Http/Resources/Api/V1/SshFingerprintResource.php`
- `app/Mcp/Tools/Tool/ToolSshFingerprintsTool.php`
- `app/Mcp/Tools/Tool/ToolBashPolicyTool.php`

### Modified files
- `routes/web.php` — root redirect logic, `/setup` route
- `routes/api_v1.php` — SSH fingerprints routes
- `bootstrap/app.php` — BypassAuth middleware registration
- `config/fortify.php` — removed emailVerification feature
- `app/Models/User.php` — removed MustVerifyEmail
- `docker/php/Dockerfile` — ext-exif, proc_open bypass
- `app/Mcp/Servers/AgentFleetServer.php` — register 2 new MCP tools
- `README.md` — SSH Host Access section + auth docs

## Testing

- Fresh DB (`migrate:fresh`) → redirects to `/setup` ✓
- Setup checks pass green ✓
- Admin account creation works ✓
- SSH connection from container to host via `host.docker.internal` ✓ (526ms, exit 0)
- TOFU fingerprint stored on first connect ✓
- API routes respond correctly ✓
- New MCP tools instantiate without errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)