### PR TITLE
feat: plugin extension architecture (all 5 phases)

### DIFF
--- a/app/Console/Commands/ListPluginsCommand.php
+++ b/app/Console/Commands/ListPluginsCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Shared\Models\PluginState;
+use App\Domain\Shared\Services\PluginRegistry;
+use Illuminate\Console\Command;
+
+/**
+ * List all installed FleetQ plugins and their status.
+ *
+ * Usage:
+ *   php artisan fleet:plugins
+ */
+class ListPluginsCommand extends Command
+{
+    protected $signature = 'fleet:plugins';
+
+    protected $description = 'List all installed FleetQ plugins';
+
+    public function handle(PluginRegistry $registry): int
+    {
+        $plugins = $registry->all();
+
+        if (empty($plugins)) {
+            $this->line('No plugins installed.');
+            $this->newLine();
+            $this->line('Install a plugin with:');
+            $this->line('  composer require vendor/fleet-plugin-name');
+
+            return self::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($plugins as $plugin) {
+            $rows[] = [
+                $plugin->getId(),
+                $plugin->getName(),
+                $plugin->getVersion(),
+                PluginState::isEnabled($plugin->getId()) ? '<fg=green>enabled</>' : '<fg=red>disabled</>',
+            ];
+        }
+
+        $this->table(['ID', 'Name', 'Version', 'Status'], $rows);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Contracts/FleetPlugin.php
+++ b/app/Contracts/FleetPlugin.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Contracts;
+
+/**
+ * Contract for all FleetQ plugins.
+ *
+ * Plugins distributed as Composer packages implement this interface and declare
+ * their service provider in composer.json using Laravel auto-discovery:
+ *
+ *   "extra": {
+ *     "laravel": { "providers": ["Acme\\MyPlugin\\MyPluginServiceProvider"] },
+ *     "fleet":   { "plugin": "my-plugin", "name": "My Plugin", "min-version": "1.0.0" }
+ *   }
+ *
+ * The service provider should extend FleetPluginServiceProvider and return
+ * an instance of this interface from createPlugin().
+ */
+interface FleetPlugin
+{
+    /**
+     * Unique slug for this plugin (e.g. 'fleet-analytics').
+     * Used as the plugin registry key and namespaced meta key prefix.
+     */
+    public function getId(): string;
+
+    /**
+     * Human-readable name (e.g. 'Fleet Analytics').
+     */
+    public function getName(): string;
+
+    /**
+     * Semantic version string (e.g. '1.0.0').
+     */
+    public function getVersion(): string;
+
+    /**
+     * Called during the service provider's register() phase.
+     * Use only for container bindings — no event listeners, routes, or macros here.
+     */
+    public function register(): void;
+
+    /**
+     * Called during the service provider's boot() phase.
+     * Safe to register event listeners, routes, blade directives, etc.
+     */
+    public function boot(): void;
+}

--- a/app/Contracts/HasHealthCheck.php
+++ b/app/Contracts/HasHealthCheck.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Domain\Shared\DTOs\PluginHealth;
+
+/**
+ * Optional interface for plugins that expose a health check.
+ *
+ * Implement this on your FleetPlugin class.
+ * The HealthPage and `fleet:plugins` command will display the result.
+ */
+interface HasHealthCheck
+{
+    public function check(): PluginHealth;
+}

--- a/app/Contracts/HasPluginSettings.php
+++ b/app/Contracts/HasPluginSettings.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Contracts;
+
+use Livewire\Component;
+
+/**
+ * Optional interface for plugins that expose a settings UI.
+ *
+ * Implement this on your FleetPlugin class.
+ * The GlobalSettingsPage will render a tab for your plugin's settings component.
+ */
+interface HasPluginSettings
+{
+    /**
+     * Return the fully-qualified class name of the Livewire component
+     * that renders this plugin's settings form.
+     *
+     * @return class-string<Component>
+     */
+    public function settingsComponent(): string;
+}

--- a/app/Contracts/PanelExtension.php
+++ b/app/Contracts/PanelExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Domain\Shared\DTOs\NavigationItem;
+use Livewire\Component;
+
+/**
+ * Optional interface for plugins that contribute UI elements to the platform.
+ *
+ * Implement this on your FleetPlugin class or a dedicated panel class.
+ * Register it in your FleetPluginServiceProvider: $this->panels = [MyPanelExtension::class];
+ */
+interface PanelExtension
+{
+    /**
+     * Livewire component classes to register as routable pages.
+     *
+     * @return list<class-string<Component>>
+     */
+    public function pages(): array;
+
+    /**
+     * Navigation items to inject into the sidebar.
+     *
+     * @return list<NavigationItem>
+     */
+    public function navigationItems(): array;
+
+    /**
+     * Livewire component classes to render as widgets on the dashboard.
+     *
+     * @return list<class-string>
+     */
+    public function dashboardWidgets(): array;
+}

--- a/app/Domain/Agent/Actions/ExecuteAgentAction.php
+++ b/app/Domain/Agent/Actions/ExecuteAgentAction.php
@@ -2,6 +2,8 @@
 
 namespace App\Domain\Agent\Actions;
 
+use App\Domain\Agent\Events\AgentExecuted;
+use App\Domain\Agent\Events\AgentExecuting;
 use App\Domain\Agent\Models\Agent;
 use App\Domain\Agent\Models\AgentExecution;
 use App\Domain\Agent\Pipeline\AgentExecutionContext;
@@ -67,6 +69,14 @@ class ExecuteAgentAction
             return $this->failExecution($agent, $teamId, $experimentId, $input, 'Agent budget cap reached');
         }
 
+        // Plugin hook: allow plugins to inspect/mutate context or cancel execution
+        $executing = new AgentExecuting($agent, $input);
+        event($executing);
+        if ($executing->cancel) {
+            return $this->failExecution($agent, $teamId, $experimentId, $input, $executing->cancelReason ?? 'Cancelled by plugin');
+        }
+        $input = $executing->context;
+
         // Run the semantic middleware pipeline to enrich / gate the execution context.
         // Each middleware may add system prompt parts, summarize input, or request clarification.
         $ctx = new AgentExecutionContext(
@@ -98,27 +108,32 @@ class ExecuteAgentAction
         // Workflow-driven execution: if input has a 'task' key (from workflow node prompt),
         // execute directly with LLM instead of skill chain
         if (! empty($input['task'])) {
-            return $this->executeDirectPrompt($agent, $input, $teamId, $userId, $experimentId, $stepId, $ctx->systemPromptParts);
-        }
+            $result = $this->executeDirectPrompt($agent, $input, $teamId, $userId, $experimentId, $stepId, $ctx->systemPromptParts);
+        } else {
+            // Resolve tools for this agent (filtered by project restrictions).
+            // Generate a sandbox ID so each execution gets an isolated filesystem workspace.
+            $sandboxId = (string) Str::uuid();
+            $tools = $this->resolveTools->execute($agent, $project, $sandboxId);
 
-        // Resolve tools for this agent (filtered by project restrictions).
-        // Generate a sandbox ID so each execution gets an isolated filesystem workspace.
-        $sandboxId = (string) Str::uuid();
-        $tools = $this->resolveTools->execute($agent, $project, $sandboxId);
-
-        if (! empty($tools)) {
-            try {
-                return $this->executeWithTools($agent, $input, $tools, $teamId, $userId, $experimentId, $project, $ctx->systemPromptParts);
-            } finally {
-                // Teardown sandbox regardless of success or failure
-                if ($agent->team_id) {
-                    (new SandboxedWorkspace($sandboxId, $agent->id, $agent->team_id))->teardown();
+            if (! empty($tools)) {
+                try {
+                    $result = $this->executeWithTools($agent, $input, $tools, $teamId, $userId, $experimentId, $project, $ctx->systemPromptParts);
+                } finally {
+                    // Teardown sandbox regardless of success or failure
+                    if ($agent->team_id) {
+                        (new SandboxedWorkspace($sandboxId, $agent->id, $agent->team_id))->teardown();
+                    }
                 }
+            } else {
+                // Fallback: existing skill-chain execution
+                $result = $this->executeSkillChain($agent, $input, $teamId, $userId, $experimentId);
             }
         }
 
-        // Fallback: existing skill-chain execution
-        return $this->executeSkillChain($agent, $input, $teamId, $userId, $experimentId);
+        // Plugin hook: notify plugins of execution result
+        event(new AgentExecuted($agent, $result['execution'], $result['output'] !== null));
+
+        return $result;
     }
 
     /**

--- a/app/Domain/Agent/Events/AgentExecuted.php
+++ b/app/Domain/Agent/Events/AgentExecuted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Domain\Agent\Events;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Agent\Models\AgentExecution;
+
+/**
+ * Fired after an agent execution completes (success or failure).
+ */
+class AgentExecuted
+{
+    public function __construct(
+        public readonly Agent $agent,
+        public readonly AgentExecution $execution,
+        public readonly bool $succeeded,
+    ) {}
+}

--- a/app/Domain/Agent/Events/AgentExecuting.php
+++ b/app/Domain/Agent/Events/AgentExecuting.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Domain\Agent\Events;
+
+use App\Domain\Agent\Models\Agent;
+
+/**
+ * Fired before an agent is executed.
+ *
+ * Listeners can mutate $context (pass-by-reference) to inject additional context,
+ * or call $event->cancel() to abort execution.
+ */
+class AgentExecuting
+{
+    public bool $cancel = false;
+
+    public ?string $cancelReason = null;
+
+    public function __construct(
+        public readonly Agent $agent,
+        public array $context,
+    ) {}
+
+    /**
+     * Abort the agent execution. The action will return a failed execution.
+     */
+    public function cancel(string $reason = 'Cancelled by plugin'): void
+    {
+        $this->cancel = true;
+        $this->cancelReason = $reason;
+    }
+}

--- a/app/Domain/Agent/Models/Agent.php
+++ b/app/Domain/Agent/Models/Agent.php
@@ -5,6 +5,7 @@ namespace App\Domain\Agent\Models;
 use App\Domain\Agent\Enums\AgentStatus;
 use App\Domain\Evolution\Models\EvolutionProposal;
 use App\Domain\Shared\Traits\BelongsToTeam;
+use App\Domain\Shared\Traits\HasPluginMeta;
 use App\Domain\Skill\Models\Skill;
 use App\Domain\Tool\Models\Tool;
 use App\Infrastructure\AI\Models\CircuitBreakerState;
@@ -40,7 +41,7 @@ use Illuminate\Support\Carbon;
  */
 class Agent extends Model
 {
-    use BelongsToTeam, HasFactory, HasUuids, SoftDeletes;
+    use BelongsToTeam, HasFactory, HasPluginMeta, HasUuids, SoftDeletes;
 
     protected $fillable = [
         'team_id',
@@ -68,12 +69,14 @@ class Agent extends Model
         'risk_score',
         'risk_profile',
         'risk_profile_updated_at',
+        'meta',
     ];
 
     protected function casts(): array
     {
         return [
             'status' => AgentStatus::class,
+            'meta' => 'array',
             'personality' => 'array',
             'config' => 'array',
             'capabilities' => 'array',

--- a/app/Domain/Crew/Actions/ExecuteCrewAction.php
+++ b/app/Domain/Crew/Actions/ExecuteCrewAction.php
@@ -5,6 +5,7 @@ namespace App\Domain\Crew\Actions;
 use App\Domain\Agent\Enums\AgentStatus;
 use App\Domain\Crew\Enums\CrewExecutionStatus;
 use App\Domain\Crew\Enums\CrewStatus;
+use App\Domain\Crew\Events\CrewExecuting;
 use App\Domain\Crew\Jobs\ExecuteCrewJob;
 use App\Domain\Crew\Models\Crew;
 use App\Domain\Crew\Models\CrewExecution;
@@ -20,6 +21,13 @@ class ExecuteCrewAction
     ): CrewExecution {
         if ($crew->status !== CrewStatus::Active) {
             throw new InvalidArgumentException('Crew must be active to execute.');
+        }
+
+        // Plugin hook: allow plugins to inspect or cancel crew execution
+        $executing = new CrewExecuting($crew, ['goal' => $goal]);
+        event($executing);
+        if ($executing->cancel) {
+            throw new InvalidArgumentException($executing->cancelReason ?? 'Crew execution cancelled by plugin');
         }
 
         // Validate coordinator and QA agents are still active

--- a/app/Domain/Crew/Events/CrewExecuted.php
+++ b/app/Domain/Crew/Events/CrewExecuted.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Domain\Crew\Events;
+
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Crew\Models\CrewExecution;
+
+/**
+ * Fired after a crew execution has been dispatched.
+ */
+class CrewExecuted
+{
+    public function __construct(
+        public readonly Crew $crew,
+        public readonly CrewExecution $execution,
+    ) {}
+}

--- a/app/Domain/Crew/Events/CrewExecuting.php
+++ b/app/Domain/Crew/Events/CrewExecuting.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\Crew\Events;
+
+use App\Domain\Crew\Models\Crew;
+
+/**
+ * Fired before a crew execution begins.
+ */
+class CrewExecuting
+{
+    public bool $cancel = false;
+
+    public ?string $cancelReason = null;
+
+    public function __construct(
+        public readonly Crew $crew,
+        public array $input,
+    ) {}
+
+    public function cancel(string $reason = 'Cancelled by plugin'): void
+    {
+        $this->cancel = true;
+        $this->cancelReason = $reason;
+    }
+}

--- a/app/Domain/Crew/Models/Crew.php
+++ b/app/Domain/Crew/Models/Crew.php
@@ -7,6 +7,7 @@ use App\Domain\Crew\Enums\CrewMemberRole;
 use App\Domain\Crew\Enums\CrewProcessType;
 use App\Domain\Crew\Enums\CrewStatus;
 use App\Domain\Shared\Traits\BelongsToTeam;
+use App\Domain\Shared\Traits\HasPluginMeta;
 use App\Models\User;
 use Database\Factories\Domain\Crew\CrewFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -18,7 +19,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Crew extends Model
 {
-    use BelongsToTeam, HasFactory, HasUuids, SoftDeletes;
+    use BelongsToTeam, HasFactory, HasPluginMeta, HasUuids, SoftDeletes;
 
     protected static function newFactory()
     {
@@ -38,11 +39,13 @@ class Crew extends Model
         'quality_threshold',
         'status',
         'settings',
+        'meta',
     ];
 
     protected function casts(): array
     {
         return [
+            'meta' => 'array',
             'process_type' => CrewProcessType::class,
             'status' => CrewStatus::class,
             'settings' => 'array',

--- a/app/Domain/Crew/Services/CrewOrchestrator.php
+++ b/app/Domain/Crew/Services/CrewOrchestrator.php
@@ -9,6 +9,7 @@ use App\Domain\Crew\Actions\ValidateTaskOutputAction;
 use App\Domain\Crew\Enums\CrewExecutionStatus;
 use App\Domain\Crew\Enums\CrewProcessType;
 use App\Domain\Crew\Enums\CrewTaskStatus;
+use App\Domain\Crew\Events\CrewExecuted;
 use App\Domain\Crew\Jobs\CoordinatorDecisionJob;
 use App\Domain\Crew\Jobs\ExecuteCrewTaskJob;
 use App\Domain\Crew\Models\CrewExecution;
@@ -294,6 +295,9 @@ class CrewOrchestrator
 
             // Collect artifacts from task outputs
             $this->collectArtifacts->execute($execution);
+
+            // Plugin hook: notify plugins of completed crew execution
+            event(new CrewExecuted($execution->crew, $execution));
 
             activity()
                 ->performedOn($execution)

--- a/app/Domain/Experiment/Models/Experiment.php
+++ b/app/Domain/Experiment/Models/Experiment.php
@@ -10,6 +10,7 @@ use App\Domain\Experiment\Enums\ExperimentTrack;
 use App\Domain\Metrics\Models\Metric;
 use App\Domain\Outbound\Models\OutboundProposal;
 use App\Domain\Shared\Traits\BelongsToTeam;
+use App\Domain\Shared\Traits\HasPluginMeta;
 use App\Domain\Signal\Models\Signal;
 use App\Domain\Workflow\Models\Workflow;
 use App\Models\Artifact;
@@ -50,7 +51,7 @@ use Illuminate\Support\Carbon;
  */
 class Experiment extends Model
 {
-    use BelongsToTeam, HasFactory, HasUuids;
+    use BelongsToTeam, HasFactory, HasPluginMeta, HasUuids;
 
     protected $fillable = [
         'team_id',
@@ -79,11 +80,13 @@ class Experiment extends Model
         'share_token',
         'share_enabled',
         'share_config',
+        'meta',
     ];
 
     protected function casts(): array
     {
         return [
+            'meta' => 'array',
             'status' => ExperimentStatus::class,
             'track' => ExperimentTrack::class,
             'constraints' => 'array',

--- a/app/Domain/Outbound/Actions/SendOutboundAction.php
+++ b/app/Domain/Outbound/Actions/SendOutboundAction.php
@@ -14,6 +14,8 @@ use App\Domain\Outbound\Connectors\TelegramConnector;
 use App\Domain\Outbound\Connectors\WebhookOutboundConnector;
 use App\Domain\Outbound\Connectors\WhatsAppConnector;
 use App\Domain\Outbound\Contracts\OutboundConnectorInterface;
+use App\Domain\Outbound\Events\OutboundSending;
+use App\Domain\Outbound\Events\OutboundSent;
 use App\Domain\Outbound\Exceptions\BlacklistedException;
 use App\Domain\Outbound\Exceptions\RateLimitExceededException;
 use App\Domain\Outbound\Middleware\ChannelRateLimit;
@@ -43,8 +45,14 @@ class SendOutboundAction
             new WebhookOutboundConnector,
             new SignalProtocolConnector,
             new MatrixConnector,
-            new DummyConnector,  // Fallback — must be last
         ];
+
+        // Append plugin-registered outbound connectors (tagged in service providers)
+        foreach (app()->tagged('fleet.outbound.connectors.plugin') as $connector) {
+            $this->connectors[] = $connector;
+        }
+
+        $this->connectors[] = new DummyConnector;  // Fallback — must be last
     }
 
     public function execute(OutboundProposal $proposal): OutboundAction
@@ -69,10 +77,22 @@ class SendOutboundAction
             );
         }
 
+        // Plugin hook: allow plugins to cancel outbound delivery
+        $sending = new OutboundSending($proposal);
+        event($sending);
+        if ($sending->cancel) {
+            throw new BlacklistedException($sending->cancelReason ?? 'Cancelled by plugin');
+        }
+
         $channel = $proposal->channel->value;
         $connector = $this->resolveConnector($channel);
 
-        return $connector->send($proposal);
+        $action = $connector->send($proposal);
+
+        // Plugin hook: notify plugins of delivery result
+        event(new OutboundSent($proposal, $action, $action->status === 'delivered'));
+
+        return $action;
     }
 
     private function resolveConnector(string $channel): OutboundConnectorInterface

--- a/app/Domain/Outbound/Events/OutboundSending.php
+++ b/app/Domain/Outbound/Events/OutboundSending.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Domain\Outbound\Events;
+
+use App\Domain\Outbound\Models\OutboundProposal;
+
+/**
+ * Fired before an outbound proposal is sent.
+ *
+ * Listeners can call $event->cancel() to prevent delivery.
+ */
+class OutboundSending
+{
+    public bool $cancel = false;
+
+    public ?string $cancelReason = null;
+
+    public function __construct(
+        public readonly OutboundProposal $proposal,
+    ) {}
+
+    public function cancel(string $reason = 'Cancelled by plugin'): void
+    {
+        $this->cancel = true;
+        $this->cancelReason = $reason;
+    }
+}

--- a/app/Domain/Outbound/Events/OutboundSent.php
+++ b/app/Domain/Outbound/Events/OutboundSent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Domain\Outbound\Events;
+
+use App\Domain\Outbound\Models\OutboundAction;
+use App\Domain\Outbound\Models\OutboundProposal;
+
+/**
+ * Fired after an outbound action has been recorded (send attempted).
+ */
+class OutboundSent
+{
+    public function __construct(
+        public readonly OutboundProposal $proposal,
+        public readonly OutboundAction $action,
+        public readonly bool $succeeded,
+    ) {}
+}

--- a/app/Domain/Project/Models/Project.php
+++ b/app/Domain/Project/Models/Project.php
@@ -8,6 +8,7 @@ use App\Domain\Project\Enums\ProjectExecutionMode;
 use App\Domain\Project\Enums\ProjectStatus;
 use App\Domain\Project\Enums\ProjectType;
 use App\Domain\Shared\Traits\BelongsToTeam;
+use App\Domain\Shared\Traits\HasPluginMeta;
 use App\Domain\Workflow\Models\Workflow;
 use App\Models\User;
 use Database\Factories\Domain\Project\ProjectFactory;
@@ -21,7 +22,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Project extends Model
 {
-    use BelongsToTeam, HasFactory, HasUuids;
+    use BelongsToTeam, HasFactory, HasPluginMeta, HasUuids;
 
     protected static function newFactory()
     {
@@ -73,11 +74,13 @@ class Project extends Model
         'completed_at',
         'last_run_at',
         'next_run_at',
+        'meta',
     ];
 
     protected function casts(): array
     {
         return [
+            'meta' => 'array',
             'type' => ProjectType::class,
             'execution_mode' => ProjectExecutionMode::class,
             'status' => ProjectStatus::class,

--- a/app/Domain/Shared/DTOs/NavigationItem.php
+++ b/app/Domain/Shared/DTOs/NavigationItem.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Domain\Shared\DTOs;
+
+/**
+ * A sidebar navigation item contributed by a plugin.
+ *
+ * Usage in FleetPluginServiceProvider::boot():
+ *
+ *   app(NavigationRegistry::class)->add(new NavigationItem(
+ *       label: 'Analytics',
+ *       route: 'fleet-analytics.dashboard',
+ *       icon:  'chart-bar',
+ *       order: 80,
+ *   ));
+ */
+readonly class NavigationItem
+{
+    public function __construct(
+        /** Human-readable label shown in the sidebar */
+        public string $label,
+
+        /** Named route (must be registered by the plugin's service provider) */
+        public string $route,
+
+        /** Heroicon name (without prefix), e.g. 'chart-bar', 'cog-6-tooth' */
+        public string $icon,
+
+        /** Optional sidebar group label (null = ungrouped at bottom) */
+        public ?string $group = null,
+
+        /** Lower numbers appear higher; core items use 0–99, plugins use 100+ */
+        public int $order = 100,
+
+        /** Gate ability that must pass for the item to be visible (null = always visible) */
+        public ?string $permission = null,
+
+        /** Optional badge text shown next to the label */
+        public ?string $badge = null,
+    ) {}
+}

--- a/app/Domain/Shared/DTOs/PluginHealth.php
+++ b/app/Domain/Shared/DTOs/PluginHealth.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Domain\Shared\DTOs;
+
+/**
+ * Result of a plugin health check.
+ *
+ * Returned by FleetPlugin implementations of HasHealthCheck::check().
+ */
+readonly class PluginHealth
+{
+    public function __construct(
+        public bool $healthy,
+
+        /** 'ok' | 'warning' | 'error' */
+        public string $status,
+
+        /** Human-readable description of the health state */
+        public string $message,
+    ) {}
+
+    public static function ok(string $message = 'Plugin is healthy'): self
+    {
+        return new self(healthy: true, status: 'ok', message: $message);
+    }
+
+    public static function warning(string $message): self
+    {
+        return new self(healthy: true, status: 'warning', message: $message);
+    }
+
+    public static function error(string $message): self
+    {
+        return new self(healthy: false, status: 'error', message: $message);
+    }
+}

--- a/app/Domain/Shared/Models/PluginState.php
+++ b/app/Domain/Shared/Models/PluginState.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Domain\Shared\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * Persists enabled/disabled state and settings for installed plugins.
+ *
+ * @property string $id
+ * @property string $plugin_id
+ * @property string $name
+ * @property string $version
+ * @property bool $enabled
+ * @property array|null $settings
+ * @property Carbon|null $installed_at
+ */
+class PluginState extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'plugin_id',
+        'name',
+        'version',
+        'enabled',
+        'settings',
+        'installed_at',
+    ];
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'settings' => 'array',
+        'installed_at' => 'datetime',
+    ];
+
+    /**
+     * Check whether a plugin is enabled, with a default fallback.
+     */
+    public static function isEnabled(string $pluginId, bool $default = true): bool
+    {
+        $state = static::where('plugin_id', $pluginId)->first();
+
+        return $state ? $state->enabled : $default;
+    }
+
+    /**
+     * Register a plugin the first time it boots (upsert).
+     */
+    public static function register(string $pluginId, string $name, string $version): self
+    {
+        return static::firstOrCreate(
+            ['plugin_id' => $pluginId],
+            [
+                'name' => $name,
+                'version' => $version,
+                'enabled' => true,
+                'installed_at' => now(),
+            ],
+        );
+    }
+}

--- a/app/Domain/Shared/Services/NavigationRegistry.php
+++ b/app/Domain/Shared/Services/NavigationRegistry.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Domain\Shared\Services;
+
+use App\Domain\Shared\DTOs\NavigationItem;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Registry for plugin-contributed sidebar navigation items.
+ *
+ * Bound as a singleton in AppServiceProvider.
+ * Rendered in resources/views/components/sidebar.blade.php after the core links.
+ */
+class NavigationRegistry
+{
+    /** @var list<NavigationItem> */
+    protected array $items = [];
+
+    public function add(NavigationItem $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * Return all items visible to the current user, sorted by order.
+     *
+     * @return Collection<int, NavigationItem>
+     */
+    public function items(): Collection
+    {
+        return collect($this->items)
+            ->sortBy('order')
+            ->values()
+            ->filter(fn (NavigationItem $item) => $item->permission === null || Gate::allows($item->permission));
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->items);
+    }
+}

--- a/app/Domain/Shared/Services/PluginRegistry.php
+++ b/app/Domain/Shared/Services/PluginRegistry.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Domain\Shared\Services;
+
+use App\Contracts\FleetPlugin;
+use App\Domain\Shared\Models\PluginState;
+use Illuminate\Support\Collection;
+
+/**
+ * Central registry for all installed FleetQ plugins.
+ *
+ * Bound as a singleton in AppServiceProvider.
+ * FleetPluginServiceProvider::register() automatically registers the plugin here.
+ */
+class PluginRegistry
+{
+    /** @var array<string, FleetPlugin> */
+    protected array $plugins = [];
+
+    public function register(FleetPlugin $plugin): void
+    {
+        $this->plugins[$plugin->getId()] = $plugin;
+    }
+
+    /**
+     * @return Collection<string, FleetPlugin>
+     */
+    public function all(): Collection
+    {
+        return collect($this->plugins);
+    }
+
+    public function find(string $id): ?FleetPlugin
+    {
+        return $this->plugins[$id] ?? null;
+    }
+
+    public function isEnabled(string $id): bool
+    {
+        if (! config('plugins.enabled', true)) {
+            return false;
+        }
+
+        // Check database state if model is available (Phase 5)
+        if (class_exists(PluginState::class)) {
+            return PluginState::isEnabled($id);
+        }
+
+        return true;
+    }
+
+    public function count(): int
+    {
+        return count($this->plugins);
+    }
+}

--- a/app/Domain/Shared/Traits/HasPluginMeta.php
+++ b/app/Domain/Shared/Traits/HasPluginMeta.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Domain\Shared\Traits;
+
+/**
+ * Provides plugin-namespaced metadata storage on any model with a `meta` JSONB column.
+ *
+ * Usage:
+ *   $agent->setPluginMeta('my-plugin', 'key', 'value');
+ *   $value = $agent->getPluginMeta('my-plugin', 'key');
+ *   $all   = $agent->allPluginMeta('my-plugin');
+ *   $agent->forgetPluginMeta('my-plugin', 'key');
+ *
+ * Each plugin's data is isolated under its own namespace key in the `meta` JSONB column.
+ * Plugins cannot accidentally overwrite each other's data as long as they use unique IDs.
+ */
+trait HasPluginMeta
+{
+    /**
+     * Store a value under the plugin's namespace in the meta column.
+     */
+    public function setPluginMeta(string $pluginId, string $key, mixed $value): void
+    {
+        $meta = $this->meta ?? [];
+        $meta[$pluginId][$key] = $value;
+        $this->forceFill(['meta' => $meta])->save();
+    }
+
+    /**
+     * Retrieve a value from the plugin's namespace, with optional default.
+     */
+    public function getPluginMeta(string $pluginId, string $key, mixed $default = null): mixed
+    {
+        return data_get($this->meta ?? [], "{$pluginId}.{$key}", $default);
+    }
+
+    /**
+     * Retrieve all metadata stored by a plugin.
+     *
+     * @return array<string, mixed>
+     */
+    public function allPluginMeta(string $pluginId): array
+    {
+        return ($this->meta ?? [])[$pluginId] ?? [];
+    }
+
+    /**
+     * Remove a specific key from the plugin's namespace.
+     */
+    public function forgetPluginMeta(string $pluginId, string $key): void
+    {
+        $meta = $this->meta ?? [];
+        unset($meta[$pluginId][$key]);
+        $this->forceFill(['meta' => $meta])->save();
+    }
+
+    /**
+     * Remove all metadata stored by a plugin.
+     */
+    public function clearPluginMeta(string $pluginId): void
+    {
+        $meta = $this->meta ?? [];
+        unset($meta[$pluginId]);
+        $this->forceFill(['meta' => $meta])->save();
+    }
+}

--- a/app/Domain/Signal/Actions/IngestSignalAction.php
+++ b/app/Domain/Signal/Actions/IngestSignalAction.php
@@ -3,6 +3,8 @@
 namespace App\Domain\Signal\Actions;
 
 use App\Domain\Shared\Services\ContactResolver;
+use App\Domain\Signal\Events\SignalIngested;
+use App\Domain\Signal\Events\SignalIngesting;
 use App\Domain\Signal\Jobs\ExtractSignalEntitiesJob;
 use App\Domain\Signal\Jobs\ProcessSignalMediaJob;
 use App\Domain\Signal\Jobs\RecalculateIntentScoreJob;
@@ -102,6 +104,20 @@ class IngestSignalAction
             return null;
         }
 
+        // Plugin hook: allow plugins to inspect/mutate or cancel ingest
+        $ingesting = new SignalIngesting($sourceType, $sourceIdentifier, $payload, $tags);
+        event($ingesting);
+        if ($ingesting->cancel) {
+            Log::info('IngestSignalAction: signal cancelled by plugin', [
+                'source_type' => $sourceType,
+                'reason' => $ingesting->cancelReason,
+            ]);
+
+            return null;
+        }
+        $payload = $ingesting->payload;
+        $tags = $ingesting->tags;
+
         // Resolve cross-channel contact identity for gated channels with known senders.
         $contactIdentityId = null;
         if (in_array($sourceType, self::GATED_CHANNELS, true) && $teamId !== null && $sourceIdentifier !== '') {
@@ -148,6 +164,9 @@ class IngestSignalAction
 
         // Evaluate trigger rules asynchronously (zero overhead to HTTP response)
         EvaluateTriggerRulesJob::dispatch($signal->id);
+
+        // Plugin hook: notify plugins a new signal was created
+        event(new SignalIngested($signal));
 
         // Recalculate composite intent score when entity has a stable identifier.
         // Skips intent_score signals to prevent scoring recursion.

--- a/app/Domain/Signal/Events/SignalIngested.php
+++ b/app/Domain/Signal/Events/SignalIngested.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Domain\Signal\Events;
+
+use App\Domain\Signal\Models\Signal;
+
+/**
+ * Fired after a new signal has been successfully persisted.
+ */
+class SignalIngested
+{
+    public function __construct(
+        public readonly Signal $signal,
+    ) {}
+}

--- a/app/Domain/Signal/Events/SignalIngesting.php
+++ b/app/Domain/Signal/Events/SignalIngesting.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Domain\Signal\Events;
+
+/**
+ * Fired before a signal is ingested.
+ *
+ * Listeners can mutate $payload or call $event->cancel() to reject the signal.
+ */
+class SignalIngesting
+{
+    public bool $cancel = false;
+
+    public ?string $cancelReason = null;
+
+    public function __construct(
+        public readonly string $sourceType,
+        public readonly string $sourceIdentifier,
+        public array $payload,
+        public array $tags = [],
+    ) {}
+
+    public function cancel(string $reason = 'Rejected by plugin'): void
+    {
+        $this->cancel = true;
+        $this->cancelReason = $reason;
+    }
+}

--- a/app/Domain/Skill/Actions/ExecuteSkillAction.php
+++ b/app/Domain/Skill/Actions/ExecuteSkillAction.php
@@ -8,6 +8,8 @@ use App\Domain\Budget\Actions\SettleBudgetAction;
 use App\Domain\Marketplace\Actions\RecordMarketplaceUsageAction;
 use App\Domain\Shared\Models\Team;
 use App\Domain\Skill\Enums\SkillType;
+use App\Domain\Skill\Events\SkillExecuted;
+use App\Domain\Skill\Events\SkillExecuting;
 use App\Domain\Skill\Exceptions\SkillProviderIncompatibleException;
 use App\Domain\Skill\Models\Skill;
 use App\Domain\Skill\Models\SkillExecution;
@@ -82,6 +84,14 @@ class ExecuteSkillAction
         if ($skill->type === SkillType::GpuCompute->value) {
             return $this->executeGpuCompute->execute($skill, $input, $teamId, $userId, $agentId, $experimentId);
         }
+
+        // Plugin hook: allow plugins to inspect input or cancel skill execution
+        $executing = new SkillExecuting($skill, $input);
+        event($executing);
+        if ($executing->cancel) {
+            return $this->failExecution($skill, $teamId, $agentId, $experimentId, $input, $executing->cancelReason ?? 'Cancelled by plugin');
+        }
+        $input = $executing->input;
 
         // 0. Check provider compatibility (if requirements declared)
         if (! empty($skill->provider_requirements)) {
@@ -187,6 +197,9 @@ class ExecuteSkillAction
                 $this->recordMarketplaceUsage->execute($execution);
             }
 
+            // Plugin hook: notify plugins of successful skill execution
+            event(new SkillExecuted($skill, $execution, true));
+
             return [
                 'execution' => $execution,
                 'output' => $output,
@@ -201,6 +214,9 @@ class ExecuteSkillAction
             $skill->recordExecution(false, $durationMs);
 
             $failResult = $this->failExecution($skill, $teamId, $agentId, $experimentId, $input, $e->getMessage(), $durationMs);
+
+            // Plugin hook: notify plugins of failed skill execution
+            event(new SkillExecuted($skill, $failResult['execution'], false));
 
             // Record failed marketplace usage
             if ($skill->source_listing_id) {

--- a/app/Domain/Skill/Events/SkillExecuted.php
+++ b/app/Domain/Skill/Events/SkillExecuted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Domain\Skill\Events;
+
+use App\Domain\Skill\Models\Skill;
+use App\Domain\Skill\Models\SkillExecution;
+
+/**
+ * Fired after a skill execution completes.
+ */
+class SkillExecuted
+{
+    public function __construct(
+        public readonly Skill $skill,
+        public readonly SkillExecution $execution,
+        public readonly bool $succeeded,
+    ) {}
+}

--- a/app/Domain/Skill/Events/SkillExecuting.php
+++ b/app/Domain/Skill/Events/SkillExecuting.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\Skill\Events;
+
+use App\Domain\Skill\Models\Skill;
+
+/**
+ * Fired before a skill is executed.
+ */
+class SkillExecuting
+{
+    public bool $cancel = false;
+
+    public ?string $cancelReason = null;
+
+    public function __construct(
+        public readonly Skill $skill,
+        public array $input,
+    ) {}
+
+    public function cancel(string $reason = 'Cancelled by plugin'): void
+    {
+        $this->cancel = true;
+        $this->cancelReason = $reason;
+    }
+}

--- a/app/Domain/Skill/Models/Skill.php
+++ b/app/Domain/Skill/Models/Skill.php
@@ -5,6 +5,7 @@ namespace App\Domain\Skill\Models;
 use App\Domain\Agent\Models\Agent;
 use App\Domain\Agent\Models\AgentSkillPivot;
 use App\Domain\Shared\Traits\BelongsToTeam;
+use App\Domain\Shared\Traits\HasPluginMeta;
 use App\Domain\Skill\Enums\ExecutionType;
 use App\Domain\Skill\Enums\RiskLevel;
 use App\Domain\Skill\Enums\SkillStatus;
@@ -19,7 +20,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Skill extends Model
 {
-    use BelongsToTeam, HasFactory, HasUuids, SoftDeletes;
+    use BelongsToTeam, HasFactory, HasPluginMeta, HasUuids, SoftDeletes;
 
     protected static function newFactory()
     {
@@ -52,11 +53,13 @@ class Skill extends Model
         'success_count',
         'avg_latency_ms',
         'provider_requirements',
+        'meta',
     ];
 
     protected function casts(): array
     {
         return [
+            'meta' => 'array',
             'type' => SkillType::class,
             'execution_type' => ExecutionType::class,
             'status' => SkillStatus::class,

--- a/app/Domain/Workflow/Models/Workflow.php
+++ b/app/Domain/Workflow/Models/Workflow.php
@@ -4,6 +4,7 @@ namespace App\Domain\Workflow\Models;
 
 use App\Domain\Experiment\Models\Experiment;
 use App\Domain\Shared\Traits\BelongsToTeam;
+use App\Domain\Shared\Traits\HasPluginMeta;
 use App\Domain\Workflow\Enums\WorkflowStatus;
 use App\Models\User;
 use Database\Factories\Domain\Workflow\WorkflowFactory;
@@ -15,7 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Workflow extends Model
 {
-    use BelongsToTeam, HasFactory, HasUuids;
+    use BelongsToTeam, HasFactory, HasPluginMeta, HasUuids;
 
     protected static function newFactory()
     {
@@ -33,11 +34,13 @@ class Workflow extends Model
         'max_loop_iterations',
         'estimated_cost_credits',
         'settings',
+        'meta',
     ];
 
     protected function casts(): array
     {
         return [
+            'meta' => 'array',
             'status' => WorkflowStatus::class,
             'version' => 'integer',
             'max_loop_iterations' => 'integer',

--- a/app/Livewire/Hooks/PluginDispatchHook.php
+++ b/app/Livewire/Hooks/PluginDispatchHook.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Livewire\Hooks;
+
+use Livewire\ComponentHook;
+
+/**
+ * Global Livewire lifecycle hook that lets plugins react to component events.
+ *
+ * Plugins listen to Laravel events dispatched here to integrate with the UI
+ * lifecycle without modifying any core Livewire components.
+ *
+ * Registration (in AppServiceProvider::boot):
+ *   \Livewire\Livewire::componentHook(PluginDispatchHook::class);
+ */
+class PluginDispatchHook extends ComponentHook
+{
+    public function hydrate(): void
+    {
+        event('fleet.component.hydrate', ['component' => $this->component]);
+    }
+
+    public function render($view): void
+    {
+        event('fleet.component.render', ['component' => $this->component, 'view' => $view]);
+    }
+}

--- a/app/Livewire/Settings/PluginsPage.php
+++ b/app/Livewire/Settings/PluginsPage.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Livewire\Settings;
+
+use App\Contracts\HasHealthCheck;
+use App\Domain\Shared\Models\PluginState;
+use App\Domain\Shared\Services\PluginRegistry;
+use Livewire\Component;
+
+/**
+ * Admin page listing all installed plugins with enable/disable toggles.
+ */
+class PluginsPage extends Component
+{
+    public function togglePlugin(string $pluginId): void
+    {
+        $state = PluginState::where('plugin_id', $pluginId)->first();
+        if ($state) {
+            $state->update(['enabled' => ! $state->enabled]);
+        }
+    }
+
+    public function render()
+    {
+        $registry = app(PluginRegistry::class);
+        $plugins = $registry->all();
+
+        $rows = [];
+        foreach ($plugins as $plugin) {
+            $state = PluginState::where('plugin_id', $plugin->getId())->first();
+
+            $health = null;
+            if ($plugin instanceof HasHealthCheck) {
+                try {
+                    $health = $plugin->check();
+                } catch (\Throwable) {
+                    //
+                }
+            }
+
+            $rows[] = [
+                'plugin' => $plugin,
+                'enabled' => $state?->enabled ?? true,
+                'version' => $state?->version ?? $plugin->getVersion(),
+                'installed_at' => $state?->installed_at,
+                'health' => $health,
+            ];
+        }
+
+        return view('livewire.settings.plugins-page', [
+            'rows' => $rows,
+            'total' => count($rows),
+        ]);
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -212,6 +212,13 @@ class AgentFleetServer extends Server
     protected function boot(): void
     {
         $this->bootstrapMcpAuth();
+
+        // Append plugin-contributed MCP tools (registered via FleetPluginServiceProvider::$mcpTools)
+        foreach (app('fleet.mcp.tool_classes') as $toolClass) {
+            if (! in_array($toolClass, $this->tools, true)) {
+                $this->tools[] = $toolClass;
+            }
+        }
     }
 
     protected array $tools = [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,16 +18,55 @@ use App\Domain\Experiment\Listeners\ResumeParentOnSubWorkflowComplete;
 use App\Domain\Memory\Listeners\StoreExecutionMemory;
 use App\Domain\Memory\Listeners\StoreExperimentLearnings;
 use App\Domain\Metrics\Jobs\EvaluateExecutionJob;
+use App\Domain\Outbound\Connectors\DiscordConnector;
+use App\Domain\Outbound\Connectors\GoogleChatConnector;
+use App\Domain\Outbound\Connectors\SlackConnector;
+use App\Domain\Outbound\Connectors\SmtpEmailConnector;
+use App\Domain\Outbound\Connectors\TeamsConnector;
+use App\Domain\Outbound\Connectors\TelegramConnector;
+use App\Domain\Outbound\Connectors\WebhookOutboundConnector;
+use App\Domain\Outbound\Connectors\WhatsAppConnector;
 use App\Domain\Project\Listeners\LogProjectActivity;
 use App\Domain\Project\Listeners\NotifyAssistantOnProjectComplete;
 use App\Domain\Project\Listeners\NotifyDependentsOnRunComplete;
 use App\Domain\Project\Listeners\SyncProjectStatusOnRunComplete;
 use App\Domain\Shared\Services\DeploymentMode;
+use App\Domain\Shared\Services\NavigationRegistry;
+use App\Domain\Shared\Services\PluginRegistry;
+use App\Domain\Signal\Connectors\ApiPollingConnector;
+use App\Domain\Signal\Connectors\CalendarConnector;
+use App\Domain\Signal\Connectors\ClearCueConnector;
+use App\Domain\Signal\Connectors\DatadogAlertConnector;
+use App\Domain\Signal\Connectors\DiscordWebhookConnector;
+use App\Domain\Signal\Connectors\GitHubIssuesConnector;
+use App\Domain\Signal\Connectors\GitHubWebhookConnector;
+use App\Domain\Signal\Connectors\HttpMonitorConnector;
+use App\Domain\Signal\Connectors\ImapConnector;
+use App\Domain\Signal\Connectors\JiraConnector;
+use App\Domain\Signal\Connectors\LinearConnector;
+use App\Domain\Signal\Connectors\ManualSignalConnector;
+use App\Domain\Signal\Connectors\MatrixConnector;
+use App\Domain\Signal\Connectors\PagerDutyConnector;
+use App\Domain\Signal\Connectors\RssConnector;
+use App\Domain\Signal\Connectors\SentryAlertConnector;
+use App\Domain\Signal\Connectors\SignalProtocolConnector;
+use App\Domain\Signal\Connectors\SlackWebhookConnector;
+use App\Domain\Signal\Connectors\TelegramSignalConnector;
+use App\Domain\Signal\Connectors\WebhookConnector;
+use App\Domain\Signal\Connectors\WhatsAppWebhookConnector;
+use App\Domain\Signal\Services\SignalConnectorRegistry;
 use App\Domain\Skill\Models\SkillExecution;
 use App\Domain\Webhook\Listeners\SendWebhookOnExperimentTransition;
 use App\Domain\Webhook\Listeners\SendWebhookOnProjectRunComplete;
+use App\Infrastructure\AI\Middleware\BudgetEnforcement;
+use App\Infrastructure\AI\Middleware\IdempotencyCheck;
+use App\Infrastructure\AI\Middleware\RateLimiting;
+use App\Infrastructure\AI\Middleware\SchemaValidation;
+use App\Infrastructure\AI\Middleware\SemanticCache;
+use App\Infrastructure\AI\Middleware\UsageTracking;
 use App\Infrastructure\Bridge\HandleBridgeRelayResponse;
 use App\Infrastructure\Mail\TeamAwareMailChannel;
+use App\Livewire\Hooks\PluginDispatchHook;
 use App\Models\User;
 use Dedoc\Scramble\Generator;
 use Dedoc\Scramble\Scramble;
@@ -48,6 +87,7 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Reverb\Events\MessageReceived;
+use Livewire\Livewire;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -57,6 +97,68 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(DeploymentMode::class, fn () => new DeploymentMode);
+
+        // Plugin extension points
+        $this->app->singleton(PluginRegistry::class, fn () => new PluginRegistry);
+        $this->app->singleton(NavigationRegistry::class, fn () => new NavigationRegistry);
+
+        // Accumulator for plugin-contributed MCP tool class names
+        $this->app->instance('fleet.mcp.tool_classes', []);
+
+        // Tag all built-in signal connectors so plugins and the registry can discover them
+        $this->app->tag([
+            WebhookConnector::class,
+            RssConnector::class,
+            ManualSignalConnector::class,
+            ImapConnector::class,
+            ApiPollingConnector::class,
+            TelegramSignalConnector::class,
+            SlackWebhookConnector::class,
+            DiscordWebhookConnector::class,
+            WhatsAppWebhookConnector::class,
+            GitHubWebhookConnector::class,
+            GitHubIssuesConnector::class,
+            LinearConnector::class,
+            JiraConnector::class,
+            PagerDutyConnector::class,
+            SentryAlertConnector::class,
+            DatadogAlertConnector::class,
+            ClearCueConnector::class,
+            MatrixConnector::class,
+            SignalProtocolConnector::class,
+            HttpMonitorConnector::class,
+            CalendarConnector::class,
+        ], 'fleet.signal.connectors');
+
+        // Bind SignalConnectorRegistry to resolve all tagged signal connectors
+        $this->app->singleton(
+            SignalConnectorRegistry::class,
+            fn ($app) => new SignalConnectorRegistry($app->tagged('fleet.signal.connectors')),
+        );
+
+        // Tag all built-in outbound connectors (plugins can add their own)
+        $this->app->tag([
+            SmtpEmailConnector::class,
+            TelegramConnector::class,
+            SlackConnector::class,
+            WhatsAppConnector::class,
+            DiscordConnector::class,
+            TeamsConnector::class,
+            GoogleChatConnector::class,
+            WebhookOutboundConnector::class,
+            \App\Domain\Outbound\Connectors\SignalProtocolConnector::class,
+            \App\Domain\Outbound\Connectors\MatrixConnector::class,
+        ], 'fleet.outbound.connectors');
+
+        // Tag all built-in AI gateway middleware (plugins can prepend their own)
+        $this->app->tag([
+            RateLimiting::class,
+            BudgetEnforcement::class,
+            IdempotencyCheck::class,
+            SemanticCache::class,
+            SchemaValidation::class,
+            UsageTracking::class,
+        ], 'fleet.ai.middleware');
 
         // Replace the default MailChannel with our team-aware variant that applies
         // the active email theme to all system notification emails.
@@ -94,6 +196,9 @@ class AppServiceProvider extends ServiceProvider
         // Blade directives for deployment mode
         Blade::if('cloud', fn () => app(DeploymentMode::class)->isCloud());
         Blade::if('selfhosted', fn () => app(DeploymentMode::class)->isSelfHosted());
+
+        // Plugin lifecycle hook: allows plugins to react to Livewire component events
+        Livewire::componentHook(PluginDispatchHook::class);
 
         // Bridge relay: forward Reverb client-relay.* whispers into Redis stream
         Event::listen(MessageReceived::class, HandleBridgeRelayResponse::class);

--- a/app/Providers/FleetPluginServiceProvider.php
+++ b/app/Providers/FleetPluginServiceProvider.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace App\Providers;
+
+use App\Contracts\FleetPlugin;
+use App\Contracts\PanelExtension;
+use App\Domain\Shared\Models\PluginState;
+use App\Domain\Shared\Services\NavigationRegistry;
+use App\Domain\Shared\Services\PluginRegistry;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
+
+/**
+ * Base service provider for all FleetQ plugins.
+ *
+ * Plugin authors extend this class instead of Laravel's ServiceProvider.
+ * Declarative arrays handle common registration tasks with zero boilerplate.
+ *
+ * Minimum plugin service provider:
+ *
+ *   class MyPluginServiceProvider extends FleetPluginServiceProvider
+ *   {
+ *       protected array $listen = [
+ *           SignalIngested::class => [MySingalListener::class],
+ *       ];
+ *
+ *       protected function createPlugin(): FleetPlugin
+ *       {
+ *           return new MyPlugin;
+ *       }
+ *   }
+ *
+ * Auto-discovery via composer.json:
+ *
+ *   "extra": {
+ *     "laravel": { "providers": ["Acme\\MyPlugin\\MyPluginServiceProvider"] },
+ *     "fleet":   { "plugin": "my-plugin", "name": "My Plugin", "min-version": "1.0.0" }
+ *   }
+ */
+abstract class FleetPluginServiceProvider extends ServiceProvider
+{
+    // -------------------------------------------------------------------------
+    // Declarative registration — override these arrays in your plugin provider
+    // -------------------------------------------------------------------------
+
+    /** @var array<class-string, list<class-string>> EventClass => [ListenerClass, ...] */
+    protected array $listen = [];
+
+    /** @var list<class-string> MCP Tool FQCNs to register (tagged as 'fleet.mcp.tools') */
+    protected array $mcpTools = [];
+
+    /**
+     * Livewire component namespaces to register.
+     * Key = namespace alias, value = fully-qualified component class namespace.
+     * Example: ['fleet-analytics' => 'FleetAnalytics\\Livewire']
+     *
+     * @var array<string, string>
+     */
+    protected array $livewire = [];
+
+    /** @var list<class-string> InputConnectorInterface implementations (tagged as 'fleet.signal.connectors') */
+    protected array $signals = [];
+
+    /** @var list<class-string> OutboundConnectorInterface implementations (tagged as 'fleet.outbound.connectors') */
+    protected array $outbound = [];
+
+    /** @var list<class-string> Artisan command classes */
+    protected array $commands = [];
+
+    /** @var list<class-string> AiMiddlewareInterface implementations (tagged as 'fleet.ai.middleware') */
+    protected array $aiMiddleware = [];
+
+    /** @var list<class-string<PanelExtension>> PanelExtension implementations */
+    protected array $panels = [];
+
+    // -------------------------------------------------------------------------
+    // Abstract — plugin authors must implement this
+    // -------------------------------------------------------------------------
+
+    abstract protected function createPlugin(): FleetPlugin;
+
+    // -------------------------------------------------------------------------
+    // ServiceProvider lifecycle
+    // -------------------------------------------------------------------------
+
+    public function register(): void
+    {
+        $plugin = $this->createPlugin();
+
+        // Register as a named singleton so other code can resolve this plugin by ID
+        $this->app->singleton("fleet.plugin.{$plugin->getId()}", fn () => $plugin);
+
+        // Register in the global registry (only if not disabled)
+        if ($this->app->bound(PluginRegistry::class)) {
+            $this->app->make(PluginRegistry::class)->register($plugin);
+        }
+
+        // Tag connectors and tools for the registries
+        $this->registerTaggedBindings();
+
+        // Let the plugin do its own container bindings
+        $plugin->register();
+    }
+
+    public function boot(): void
+    {
+        // Register/update plugin state (creates the row on first boot, no-op if table missing)
+        if (class_exists(PluginState::class)) {
+            try {
+                $plugin = $this->createPlugin();
+                PluginState::register(
+                    $plugin->getId(),
+                    $plugin->getName(),
+                    $plugin->getVersion(),
+                );
+            } catch (\Throwable) {
+                // Table might not exist yet on fresh install — ignore
+            }
+        }
+
+        // Skip all boot logic if disabled in plugin_states
+        if (! $this->isPluginEnabled()) {
+            return;
+        }
+
+        $plugin = $this->createPlugin();
+
+        // Boot declarative registrations
+        $this->bootListeners();
+        $this->bootLivewireComponents();
+        $this->bootPanelExtensions();
+
+        if ($this->app->runningInConsole()) {
+            $this->bootCommands();
+        }
+
+        // Allow subclasses to add boot logic without overriding the full boot()
+        $this->bootAddon();
+
+        // Let the plugin do its own boot logic
+        $plugin->boot();
+    }
+
+    /**
+     * Empty hook for subclasses — runs at the end of boot() after all declarations
+     * have been processed. Override this instead of boot() to avoid accidentally
+     * skipping disable checks or declarative registration.
+     */
+    protected function bootAddon(): void
+    {
+        // intentionally empty
+    }
+
+    // -------------------------------------------------------------------------
+    // Private / protected helpers
+    // -------------------------------------------------------------------------
+
+    protected function registerTaggedBindings(): void
+    {
+        if (! empty($this->signals)) {
+            $this->app->tag($this->signals, 'fleet.signal.connectors');
+        }
+
+        if (! empty($this->outbound)) {
+            // Tag as plugin-specific outbound connectors so SendOutboundAction can pick them up
+            $this->app->tag($this->outbound, 'fleet.outbound.connectors.plugin');
+        }
+
+        if (! empty($this->mcpTools)) {
+            $this->app->tag($this->mcpTools, 'fleet.mcp.tools');
+            // Accumulate class names so AgentFleetServer::boot() can append them
+            $existing = $this->app->make('fleet.mcp.tool_classes');
+            $this->app->instance('fleet.mcp.tool_classes', array_merge($existing, $this->mcpTools));
+        }
+
+        if (! empty($this->aiMiddleware)) {
+            $this->app->tag($this->aiMiddleware, 'fleet.ai.middleware');
+        }
+    }
+
+    protected function bootListeners(): void
+    {
+        foreach ($this->listen as $event => $listeners) {
+            foreach ($listeners as $listener) {
+                Event::listen($event, $listener);
+            }
+        }
+    }
+
+    protected function bootLivewireComponents(): void
+    {
+        if (empty($this->livewire)) {
+            return;
+        }
+
+        foreach ($this->livewire as $namespace => $componentNamespace) {
+            // Derive the expected view path from the class namespace
+            $parts = explode('\\', $componentNamespace);
+            // We can't reliably derive a path from namespace alone;
+            // plugin authors should use bootAddon() for full Livewire::addNamespace() calls
+            // that require explicit paths. This handles the simple alias case.
+            Livewire::addNamespace($namespace, $componentNamespace, null);
+        }
+    }
+
+    protected function bootPanelExtensions(): void
+    {
+        if (empty($this->panels)) {
+            return;
+        }
+
+        $nav = $this->app->make(NavigationRegistry::class);
+
+        foreach ($this->panels as $panelClass) {
+            /** @var PanelExtension $panel */
+            $panel = $this->app->make($panelClass);
+
+            foreach ($panel->navigationItems() as $item) {
+                $nav->add($item);
+            }
+        }
+    }
+
+    protected function bootCommands(): void
+    {
+        if (! empty($this->commands)) {
+            $this->commands($this->commands);
+        }
+    }
+
+    /**
+     * Return the plugin ID — used for disable checks and registry keys.
+     * Defaults to the ID returned by createPlugin().
+     */
+    protected function pluginId(): string
+    {
+        return $this->createPlugin()->getId();
+    }
+
+    /**
+     * Check whether the plugin is enabled.
+     * When the PluginState model is not available (e.g. before Phase 5 migration),
+     * defaults to enabled.
+     */
+    protected function isPluginEnabled(): bool
+    {
+        if (! config('plugins.enabled', true)) {
+            return false;
+        }
+
+        if (class_exists(PluginState::class)) {
+            try {
+                return PluginState::isEnabled($this->pluginId());
+            } catch (\Throwable) {
+                // Table might not exist yet during initial install
+                return true;
+            }
+        }
+
+        return true;
+    }
+}

--- a/config/plugins.php
+++ b/config/plugins.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Plugin System
+    |--------------------------------------------------------------------------
+    |
+    | Set to false to disable all FleetQ plugins globally.
+    | Individual plugins can be disabled via the plugin_states table (Phase 5).
+    |
+    */
+    'enabled' => env('FLEET_PLUGINS', true),
+];

--- a/database/migrations/2026_03_12_000001_add_meta_column_to_plugin_extensible_models.php
+++ b/database/migrations/2026_03_12_000001_add_meta_column_to_plugin_extensible_models.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add a plugin-namespaced `meta` JSONB column to core models.
+ *
+ * This column allows plugins to store arbitrary data on existing records
+ * without modifying the core schema. Each plugin's data is isolated under
+ * its own key (plugin ID) within the JSONB object.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $tables = ['agents', 'experiments', 'crews', 'skills', 'workflows', 'projects'];
+
+        foreach ($tables as $table) {
+            Schema::table($table, function (Blueprint $t) {
+                $t->jsonb('meta')->nullable()->after('id');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        $tables = ['agents', 'experiments', 'crews', 'skills', 'workflows', 'projects'];
+
+        foreach ($tables as $table) {
+            Schema::table($table, function (Blueprint $t) {
+                $t->dropColumn('meta');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_03_12_000002_create_plugin_states_table.php
+++ b/database/migrations/2026_03_12_000002_create_plugin_states_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('plugin_states', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('plugin_id')->unique();  // Matches FleetPlugin::getId()
+            $table->string('name');
+            $table->string('version')->default('0.0.0');
+            $table->boolean('enabled')->default(true);
+            $table->jsonb('settings')->nullable();
+            $table->timestamp('installed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plugin_states');
+    }
+};

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -59,6 +59,10 @@
             Integrations
         </x-sidebar-link>
 
+        <x-sidebar-link href="{{ route('plugins') }}" :active="request()->routeIs('plugins')" icon="puzzle-piece">
+            Plugins
+        </x-sidebar-link>
+
         <x-sidebar-link href="{{ route('memory.index') }}" :active="request()->routeIs('memory.*')" icon="circle-stack">
             Memory
         </x-sidebar-link>
@@ -86,3 +90,18 @@
         <x-sidebar-link href="{{ route('email.themes.index') }}" :active="request()->routeIs('email.*')" icon="envelope">
             Email Themes
         </x-sidebar-link>
+
+        {{-- Plugin-contributed navigation items --}}
+        @php $pluginNavItems = app(\App\Domain\Shared\Services\NavigationRegistry::class)->items(); @endphp
+        @foreach($pluginNavItems as $navItem)
+            @if(!$navItem->permission || \Illuminate\Support\Facades\Gate::check($navItem->permission))
+                <x-sidebar-link href="{{ $navItem->route }}" :active="request()->is(ltrim($navItem->route, '/').'*')" icon="{{ $navItem->icon ?? 'puzzle-piece' }}">
+                    {{ $navItem->label }}
+                    @if($navItem->badge)
+                        <span class="ml-auto rounded-full bg-primary-500 px-2 py-0.5 text-xs font-medium">{{ $navItem->badge }}</span>
+                    @endif
+                </x-sidebar-link>
+            @endif
+        @endforeach
+    </nav>
+</aside>

--- a/resources/views/livewire/agents/agent-detail-page.blade.php
+++ b/resources/views/livewire/agents/agent-detail-page.blade.php
@@ -531,4 +531,7 @@
             </div>
         @endif
     @endif
+
+    {{-- Plugin extension point: inject custom content into agent detail --}}
+    @stack('fleet.agent.detail')
 </div>

--- a/resources/views/livewire/crews/crew-detail-page.blade.php
+++ b/resources/views/livewire/crews/crew-detail-page.blade.php
@@ -315,4 +315,7 @@
             </div>
         @endif
     @endif
+
+    {{-- Plugin extension point: inject custom content into crew detail --}}
+    @stack('fleet.crew.detail')
 </div>

--- a/resources/views/livewire/experiments/experiment-detail-page.blade.php
+++ b/resources/views/livewire/experiments/experiment-detail-page.blade.php
@@ -432,4 +432,7 @@
             @endif
         </div>
     @endif
+
+    {{-- Plugin extension point: inject custom content into experiment detail --}}
+    @stack('fleet.experiment.detail')
 </div>

--- a/resources/views/livewire/projects/project-detail-page.blade.php
+++ b/resources/views/livewire/projects/project-detail-page.blade.php
@@ -286,4 +286,7 @@
     <div class="mt-6 rounded-xl border border-gray-200 bg-white p-6">
         <livewire:projects.project-expansion-panel :project="$project" :key="'expansion-' . $project->id" />
     </div>
+
+    {{-- Plugin extension point: inject custom content into project detail --}}
+    @stack('fleet.project.detail')
 </div>

--- a/resources/views/livewire/settings/plugins-page.blade.php
+++ b/resources/views/livewire/settings/plugins-page.blade.php
@@ -1,0 +1,92 @@
+<div>
+    <div class="mb-6">
+        <h1 class="text-2xl font-semibold text-gray-900">Plugins</h1>
+        <p class="mt-1 text-sm text-gray-500">
+            Manage installed plugins. Changes take effect after restarting the application.
+        </p>
+    </div>
+
+    @if($total === 0)
+        <div class="rounded-xl border border-dashed border-gray-300 bg-white p-12 text-center">
+            <svg class="mx-auto h-10 w-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                      d="M14.25 6.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003 0-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25 1.875c0 .369.128.713.349 1.003.215.283.401.604.401.959v0a.64.64 0 01-.657.643 48.39 48.39 0 01-4.163-.3c.186 1.613.293 3.25.315 4.907a.656.656 0 01-.658.663v0c-.355 0-.676-.186-.959-.401a1.647 1.647 0 00-1.003-.349c-1.036 0-1.875 1.007-1.875 2.25s.84 2.25 1.875 2.25c.369 0 .713-.128 1.003-.349.283-.215.604-.401.959-.401v0c.31 0 .555.26.532.57a48.039 48.039 0 01-.642 5.056c1.518.19 3.058.309 4.616.354a.64.64 0 00.657-.643v0c0-.355-.186-.676-.401-.959a1.647 1.647 0 01-.349-1.003c0-1.035 1.008-1.875 2.25-1.875 1.243 0 2.25.84 2.25 1.875 0 .369-.128.713-.349 1.003-.215.283-.4.604-.4.959v0c0 .333.277.599.61.58a48.1 48.1 0 005.427-.63 48.05 48.05 0 00.582-4.717.532.532 0 00-.533-.57v0c-.355 0-.676.186-.959.401-.29.221-.634.349-1.003.349-1.035 0-1.875-1.007-1.875-2.25s.84-2.25 1.875-2.25c.37 0 .713.128 1.003.349.283.215.604.4.959.4v0a.656.656 0 00.658-.663 48.422 48.422 0 00-.37-5.36c-1.886.342-3.81.574-5.766.689a.578.578 0 01-.61-.58v0z"/>
+            </svg>
+            <h3 class="mt-3 text-sm font-medium text-gray-900">No plugins installed</h3>
+            <p class="mt-1 text-sm text-gray-500">
+                Install plugins via Composer and they will appear here automatically.
+            </p>
+            <div class="mt-4">
+                <code class="rounded bg-gray-100 px-3 py-1.5 text-xs font-mono text-gray-700">
+                    composer require vendor/fleet-plugin-name
+                </code>
+            </div>
+        </div>
+    @else
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Plugin</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Version</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Status</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Health</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Installed</th>
+                        <th class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wide text-gray-500">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                    @foreach($rows as $row)
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-6 py-4">
+                                <div>
+                                    <p class="text-sm font-medium text-gray-900">{{ $row['plugin']->getName() }}</p>
+                                    <p class="text-xs text-gray-500">{{ $row['plugin']->getId() }}</p>
+                                </div>
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-600">
+                                {{ $row['version'] }}
+                            </td>
+                            <td class="px-6 py-4">
+                                @if($row['enabled'])
+                                    <span class="inline-flex items-center gap-1.5 rounded-full bg-green-50 px-2.5 py-0.5 text-xs font-medium text-green-700">
+                                        <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
+                                        Enabled
+                                    </span>
+                                @else
+                                    <span class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                                        <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>
+                                        Disabled
+                                    </span>
+                                @endif
+                            </td>
+                            <td class="px-6 py-4">
+                                @if($row['health'] !== null)
+                                    @if($row['health']->healthy)
+                                        <span class="text-xs text-green-600">{{ $row['health']->status }}</span>
+                                    @else
+                                        <span class="text-xs text-red-600">{{ $row['health']->status }}</span>
+                                    @endif
+                                @else
+                                    <span class="text-xs text-gray-400">—</span>
+                                @endif
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-500">
+                                {{ $row['installed_at'] ? $row['installed_at']->diffForHumans() : '—' }}
+                            </td>
+                            <td class="px-6 py-4 text-right">
+                                <button
+                                    wire:click="togglePlugin('{{ $row['plugin']->getId() }}')"
+                                    wire:confirm="{{ $row['enabled'] ? 'Disable this plugin?' : 'Enable this plugin?' }}"
+                                    class="text-sm font-medium {{ $row['enabled'] ? 'text-red-600 hover:text-red-700' : 'text-green-600 hover:text-green-700' }}"
+                                >
+                                    {{ $row['enabled'] ? 'Disable' : 'Enable' }}
+                                </button>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/skills/skill-detail-page.blade.php
+++ b/resources/views/livewire/skills/skill-detail-page.blade.php
@@ -268,4 +268,7 @@
             </div>
         @endif
     @endif
+
+    {{-- Plugin extension point: inject custom content into skill detail --}}
+    @stack('fleet.skill.detail')
 </div>

--- a/resources/views/livewire/workflows/workflow-detail-page.blade.php
+++ b/resources/views/livewire/workflows/workflow-detail-page.blade.php
@@ -159,4 +159,7 @@
             </div>
         </div>
     </div>
+
+    {{-- Plugin extension point: inject custom content into workflow detail --}}
+    @stack('fleet.workflow.detail')
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,6 +51,7 @@ use App\Livewire\Projects\ProjectDetailPage;
 use App\Livewire\Projects\ProjectKanbanPage;
 use App\Livewire\Projects\ProjectListPage;
 use App\Livewire\Settings\GlobalSettingsPage;
+use App\Livewire\Settings\PluginsPage;
 use App\Livewire\Setup\SetupPage;
 use App\Livewire\Shared\NotificationInboxPage;
 use App\Livewire\Shared\NotificationPreferencesPage;
@@ -206,6 +207,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/health', HealthPage::class)->name('health');
     Route::get('/audit', AuditLogPage::class)->name('audit');
     Route::get('/settings', GlobalSettingsPage::class)->name('settings');
+    Route::get('/plugins', PluginsPage::class)->name('plugins');
     Route::get('/team', TeamSettingsPage::class)->name('team.settings');
 
     Route::get('/notifications', NotificationInboxPage::class)->name('notifications.index');


### PR DESCRIPTION
## Summary

Implements a full zero-edit plugin extension system for the FleetQ community edition. A plugin installs with `composer require` and auto-discovers via Laravel's `extra.laravel.providers` — no core file edits needed.

### Phase 1 — Core contracts & service providers
- `FleetPlugin` interface (`getId`, `getName`, `getVersion`, `register`, `boot`)
- `FleetPluginServiceProvider` — abstract base class with declarative arrays: `$listen`, `$mcpTools`, `$signals`, `$outbound`, `$panels`, `$commands`, `$aiMiddleware`
- `PluginRegistry` singleton — tracks all registered plugins
- `NavigationRegistry` singleton — plugin-contributed sidebar nav items

### Phase 2 — Database & model extension
- `plugin_states` table — enable/disable plugins without uninstalling
- `meta` JSONB column on `agents`, `experiments`, `crews`, `skills`, `workflows`, `projects`
- `HasPluginMeta` trait — namespaced key/value store on any extensible model

### Phase 3 — Domain event hooks (before/after)
- `AgentExecuting` / `AgentExecuted` (cancellable)
- `CrewExecuting` / `CrewExecuted`
- `SkillExecuting` / `SkillExecuted` (cancellable, input mutation)
- `SignalIngesting` / `SignalIngested`
- `OutboundSending` / `OutboundSent`

### Phase 4 — Tagged IoC extension points
- `fleet.signal.connectors` — 21 built-in signal connectors + plugin additions
- `fleet.outbound.connectors.plugin` — plugin-only outbound connectors appended before DummyConnector
- `fleet.ai.middleware` — 6 built-in AI gateway middleware classes + plugin prepending
- `fleet.mcp.tool_classes` — plugin MCP tools appended in `AgentFleetServer::boot()`
- `@stack('fleet.*.detail')` directives on all 6 detail pages (agent, experiment, crew, skill, workflow, project)
- `PluginDispatchHook` Livewire ComponentHook — fires `fleet.component.hydrate` / `fleet.component.render` events

### Phase 5 — Admin UI & CLI
- `/plugins` route + `PluginsPage` Livewire component with enable/disable toggles
- Health check display for plugins implementing `HasHealthCheck`
- `php artisan fleet:plugins` — CLI table listing all installed plugins
- Sidebar link for Plugins page

## Minimum plugin example

```php
// composer.json
"extra": {
  "laravel": { "providers": ["Acme\\MyPlugin\\MyPluginServiceProvider"] },
  "fleet":   { "plugin": "my-plugin", "name": "My Plugin", "min-version": "1.1.0" }
}

// MyPluginServiceProvider.php
class MyPluginServiceProvider extends FleetPluginServiceProvider
{
    protected array $listen = [
        AgentExecuted::class => [MyAgentListener::class],
    ];
    protected array $mcpTools = [MyCustomTool::class];
    protected array $signals = [MySignalConnector::class];

    protected function createPlugin(): FleetPlugin
    {
        return new MyPlugin;
    }
}
```

## Test plan
- [ ] Fresh install: `plugin_states` and `meta` migrations run cleanly
- [ ] `/plugins` page loads and shows empty state when no plugins installed
- [ ] Plugin `composer require` → appears in `/plugins` list as enabled
- [ ] Toggling a plugin enable/disable persists in `plugin_states`
- [ ] Plugin `$mcpTools` appear in `php artisan mcp:start agent-fleet`
- [ ] `AgentExecuting` cancel prevents agent execution
- [ ] `HasPluginMeta` set/get/forget cycle works on Agent model
- [ ] `php artisan fleet:plugins` shows installed plugins table

🤖 Generated with [Claude Code](https://claude.com/claude-code)