### PR TITLE
feat(broadcasting): desktop client prerequisites — runtime config + team-activity auth + event_id

### DIFF
--- a/app/Domain/Shared/Events/TeamActivityBroadcast.php
+++ b/app/Domain/Shared/Events/TeamActivityBroadcast.php
@@ -7,6 +7,7 @@ use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
 
 /**
  * Lightweight unified event broadcast on the per-team activity channel,
@@ -20,6 +21,16 @@ class TeamActivityBroadcast implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * Stable per-event id assigned at construction. ULIDs are
+     * monotonically ordered per-process — ideal as a dedup key for
+     * subscribers that need at-most-once semantics across reconnects
+     * (the desktop app's per-entity_seq table). Distinct from the
+     * actor/entity id because two listeners reacting to the same domain
+     * event emit two distinct broadcasts.
+     */
+    public readonly string $eventId;
+
     public function __construct(
         public readonly string $teamId,
         public readonly string $kind,
@@ -29,7 +40,9 @@ class TeamActivityBroadcast implements ShouldBroadcastNow
         public readonly string $summary,
         public readonly string $at,
         public readonly array $extra = [],
-    ) {}
+    ) {
+        $this->eventId = (string) Str::ulid();
+    }
 
     public function broadcastOn(): array
     {
@@ -44,6 +57,7 @@ class TeamActivityBroadcast implements ShouldBroadcastNow
     public function broadcastWith(): array
     {
         return [
+            'event_id' => $this->eventId,
             'kind' => $this->kind,
             'actor_id' => $this->actorId,
             'actor_kind' => $this->actorKind,

--- a/app/Http/Controllers/Api/V1/BridgeController.php
+++ b/app/Http/Controllers/Api/V1/BridgeController.php
@@ -243,8 +243,16 @@ class BridgeController extends Controller
             return response()->json(['error' => 'Missing parameters'], 400);
         }
 
-        // Authorize: only allow daemon.{teamId} channels matching user's team
-        if (preg_match('/^private-daemon\.(.+)$/', $channelName, $m)) {
+        // Authorize. Two channel patterns are accepted on the API-side broadcast auth:
+        //   - private-daemon.{teamId}      — bridge daemon's reverse-tunnel control channel
+        //   - private-team.{teamId}.activity — unified per-team firehose consumed by the
+        //                                      desktop app and any future API-bearer client.
+        // In both cases the caller's team (resolved from Sanctum token abilities, falling
+        // back to current_team_id) must match the channel's teamId. The web frontend
+        // continues to use Laravel's standard /broadcasting/auth via session cookies and
+        // is unaffected by this method.
+        if (preg_match('/^private-daemon\.(.+)$/', $channelName, $m)
+            || preg_match('/^private-team\.(.+)\.activity$/', $channelName, $m)) {
             if ($this->resolveTeamId($request) !== $m[1]) {
                 return response()->json(['error' => 'Forbidden'], 403);
             }

--- a/app/Http/Controllers/Api/V1/BroadcastingConfigController.php
+++ b/app/Http/Controllers/Api/V1/BroadcastingConfigController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @tags Broadcasting
+ *
+ * Returns the public-facing Reverb (Pusher protocol) connection parameters
+ * for clients that don't go through `bridge/register` — primarily the
+ * desktop app. Mirrors what `BridgeController::register` already embeds in
+ * its registration response so both code paths converge on one config
+ * source.
+ *
+ * Resolution mirrors `BridgeController::buildReverbUrl()`: prefer
+ * `app.reverb_public_*` (set per public-facing deployment) and fall back to
+ * the package-level `reverb.apps.apps.0.options.*`. Internal-only Docker
+ * hosts in `REVERB_HOST` never leak.
+ */
+class BroadcastingConfigController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        $scheme = config('app.reverb_public_scheme')
+            ?: config('reverb.apps.apps.0.options.scheme', 'https');
+        $host = config('app.reverb_public_host')
+            ?: config('reverb.apps.apps.0.options.host');
+        $port = config('app.reverb_public_port')
+            ?: (int) config('reverb.apps.apps.0.options.port', 443);
+
+        return response()->json([
+            'data' => [
+                'app_key' => config('reverb.apps.apps.0.key'),
+                'host' => $host,
+                'port' => (int) $port,
+                'scheme' => $scheme,
+            ],
+        ]);
+    }
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -381,6 +381,10 @@ Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     // its private channel subscription (POST with socket_id + channel_name, returns auth token)
     Route::post('/broadcasting/auth', [BridgeController::class, 'broadcastingAuth']);
 
+    // Public-facing Reverb connection parameters — consumed by clients that
+    // connect over WSS without going through bridge/register (the desktop app).
+    Route::get('/broadcasting/config', \App\Http\Controllers\Api\V1\BroadcastingConfigController::class);
+
     // Websites
     Route::apiResource('websites', WebsiteController::class);
     Route::post('/websites/{website}/publish', [WebsiteController::class, 'publish']);

--- a/tests/Feature/Api/V1/BridgeControllerTest.php
+++ b/tests/Feature/Api/V1/BridgeControllerTest.php
@@ -212,4 +212,62 @@ class BridgeControllerTest extends ApiTestCase
         $connection->refresh();
         $this->assertEquals(BridgeConnectionStatus::Disconnected, $connection->status);
     }
+
+    // -----------------------------------------------------------------------
+    // POST /api/v1/broadcasting/auth — channel auth signature (HMAC-SHA256)
+    // -----------------------------------------------------------------------
+
+    public function test_broadcasting_auth_authorizes_team_activity_channel_for_matching_team(): void
+    {
+        config([
+            'reverb.apps.apps.0.key' => 'fleetq-key',
+            'reverb.apps.apps.0.secret' => 'fleetq-secret',
+        ]);
+
+        $this->actingAsApiUser();
+
+        $channel = "private-team.{$this->team->id}.activity";
+        $response = $this->postJson('/api/v1/broadcasting/auth', [
+            'socket_id' => '1.2',
+            'channel_name' => $channel,
+        ]);
+
+        $expectedSignature = hash_hmac('sha256', "1.2:{$channel}", 'fleetq-secret');
+        $response->assertOk()
+            ->assertJsonPath('auth', "fleetq-key:{$expectedSignature}");
+    }
+
+    public function test_broadcasting_auth_rejects_team_activity_channel_for_other_team(): void
+    {
+        $this->actingAsApiUser();
+
+        $response = $this->postJson('/api/v1/broadcasting/auth', [
+            'socket_id' => '1.2',
+            'channel_name' => 'private-team.some-other-team-id.activity',
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_broadcasting_auth_still_authorizes_daemon_channel_for_matching_team(): void
+    {
+        // Regression guard: extending the channel allow-list must not break the
+        // bridge daemon's existing `private-daemon.{teamId}` flow.
+        config([
+            'reverb.apps.apps.0.key' => 'fleetq-key',
+            'reverb.apps.apps.0.secret' => 'fleetq-secret',
+        ]);
+
+        $this->actingAsApiUser();
+
+        $channel = "private-daemon.{$this->team->id}";
+        $response = $this->postJson('/api/v1/broadcasting/auth', [
+            'socket_id' => '1.2',
+            'channel_name' => $channel,
+        ]);
+
+        $expectedSignature = hash_hmac('sha256', "1.2:{$channel}", 'fleetq-secret');
+        $response->assertOk()
+            ->assertJsonPath('auth', "fleetq-key:{$expectedSignature}");
+    }
 }

--- a/tests/Feature/Api/V1/BroadcastingConfigControllerTest.php
+++ b/tests/Feature/Api/V1/BroadcastingConfigControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Api\V1;
+
+class BroadcastingConfigControllerTest extends ApiTestCase
+{
+    public function test_returns_reverb_config_for_authenticated_caller(): void
+    {
+        config([
+            'reverb.apps.apps.0.key' => 'fleetq-key',
+            'reverb.apps.apps.0.options.host' => 'relay.fleetq.test',
+            'reverb.apps.apps.0.options.port' => 443,
+            'reverb.apps.apps.0.options.scheme' => 'https',
+            'app.reverb_public_scheme' => null,
+            'app.reverb_public_host' => null,
+            'app.reverb_public_port' => null,
+        ]);
+
+        $this->actingAsApiUser();
+
+        $response = $this->getJson('/api/v1/broadcasting/config');
+
+        $response->assertOk()
+            ->assertJsonPath('data.app_key', 'fleetq-key')
+            ->assertJsonPath('data.host', 'relay.fleetq.test')
+            ->assertJsonPath('data.port', 443)
+            ->assertJsonPath('data.scheme', 'https');
+    }
+
+    public function test_prefers_public_facing_overrides_when_set(): void
+    {
+        // app.reverb_public_* is the production-deployment override that
+        // hides internal Docker hosts in REVERB_HOST. When set, it wins.
+        config([
+            'reverb.apps.apps.0.key' => 'fleetq-key',
+            'reverb.apps.apps.0.options.host' => 'reverb.internal',
+            'reverb.apps.apps.0.options.port' => 8080,
+            'reverb.apps.apps.0.options.scheme' => 'http',
+            'app.reverb_public_scheme' => 'https',
+            'app.reverb_public_host' => 'relay.fleetq.test',
+            'app.reverb_public_port' => 443,
+        ]);
+
+        $this->actingAsApiUser();
+
+        $response = $this->getJson('/api/v1/broadcasting/config');
+
+        $response->assertOk()
+            ->assertJsonPath('data.host', 'relay.fleetq.test')
+            ->assertJsonPath('data.port', 443)
+            ->assertJsonPath('data.scheme', 'https');
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/broadcasting/config');
+
+        $response->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Domain/Shared/TeamActivityBroadcastTest.php
+++ b/tests/Feature/Domain/Shared/TeamActivityBroadcastTest.php
@@ -83,6 +83,36 @@ class TeamActivityBroadcastTest extends TestCase
         $this->assertSame("private-team.{$this->team->id}.activity", $channels[0]->name);
     }
 
+    public function test_event_id_is_assigned_per_construction_and_present_in_payload(): void
+    {
+        $a = new TeamActivityBroadcast(
+            teamId: $this->team->id,
+            kind: 'agent.executed',
+            actorId: 'abc',
+            actorKind: 'agent',
+            actorLabel: 'Bot',
+            summary: 'did stuff',
+            at: now()->toIso8601String(),
+        );
+        $b = new TeamActivityBroadcast(
+            teamId: $this->team->id,
+            kind: 'agent.executed',
+            actorId: 'abc',
+            actorKind: 'agent',
+            actorLabel: 'Bot',
+            summary: 'did stuff again',
+            at: now()->toIso8601String(),
+        );
+
+        // ULIDs are 26 Crockford-base32 chars (the cast is `(string) Str::ulid()`).
+        $this->assertMatchesRegularExpression('/^[0-9A-HJKMNP-TV-Z]{26}$/', $a->eventId);
+        $this->assertNotSame($a->eventId, $b->eventId);
+
+        $payload = $a->broadcastWith();
+        $this->assertArrayHasKey('event_id', $payload);
+        $this->assertSame($a->eventId, $payload['event_id']);
+    }
+
     public function test_channel_auth_allows_team_member(): void
     {
         Broadcast::routes();


### PR DESCRIPTION
## Summary

Three small cloud-side prerequisites that unblock the FleetQ Desktop app's Reverb (Pusher protocol) WebSocket integration. Each commit is independent and reviewable on its own; merging them together gives the desktop the full surface it needs.

| Commit | What | Why |
|---|---|---|
| `feat(api): GET /api/v1/broadcasting/config` | New invokable controller returning `{app_key, host, port, scheme}` for Sanctum-authenticated callers. | Desktop connects over WSS without going through `bridge/register`. Mirrors the same Reverb config block that `BridgeController::register` already returns. |
| `feat(broadcasting): authorize private-team.{teamId}.activity in API auth` | Extends `BridgeController::broadcastingAuth` to allow `private-team.{teamId}.activity` (was: only `private-daemon.{teamId}`). | Desktop subscribes to the unified team-activity firehose using its Sanctum bearer. Same teamId-must-match-caller authorization as the daemon path. |
| `feat(broadcasting): stable event_id (ULID) on TeamActivityBroadcast` | Adds `Str::ulid()` at construction; exposed as `event_id` in `broadcastWith()`. | Pusher protocol doesn't surface a server-assigned event id, and the existing `(kind, actor_id, at, summary)` tuple is not collision-safe across listener fan-out. The desktop's per-entity_seq dedup table needs a stable key for at-most-once semantics across reconnects. |

## Why one PR, three commits

Each commit is a focused, independently-reviewable unit. Together they're the minimum cloud-side surface that lets the desktop app subscribe to live events. Splitting them into three PRs would just add review overhead without making any one piece smaller.

## Compatibility

- **Web frontend (Laravel Echo via session cookies):** unaffected. Echo ignores unknown payload keys, so the new `event_id` is silently absorbed. Channel auth for the web side goes through Laravel's standard `/broadcasting/auth`, not the API-side handler we extended.
- **Bridge daemon (`private-daemon.{teamId}`):** unaffected; covered by a regression test in commit 2.
- **Existing TeamActivityBroadcast consumers:** the constructor signature is unchanged. `broadcastWith()` gains one extra key but never loses any existing keys.

## Test plan

Three new feature tests added (one per commit):

- `BroadcastingConfigControllerTest`
  - Returns the expected JSON shape for an authenticated caller
  - Prefers `app.reverb_public_*` overrides over package config
  - 401 without bearer
- `BridgeControllerTest`
  - Authorizes `private-team.{teamId}.activity` for the matching team with a verifiable HMAC signature
  - 403s when the channel's teamId doesn't match the caller
  - Regression: `private-daemon.{teamId}` still works for the bridge daemon
- `TeamActivityBroadcastTest`
  - `eventId` is a 26-char Crockford-base32 ULID
  - Two distinct constructions produce distinct ids
  - `broadcastWith()` includes `event_id`

**Run locally:** `docker compose exec app php artisan test --filter='BroadcastingConfig|broadcasting_auth|event_id'`

> Note: I added these tests but couldn't execute them in this session — the local docker stack wasn't up. Syntax is verified via `php -l`. Please run the test suite as part of review.

## Follow-up (not in this PR)

- Desktop client implementation in `fleetq-desktop` (separate repo) consumes all three changes.
- Once the desktop is verified live, the bridge daemon can be migrated to use the new `/api/v1/broadcasting/config` endpoint instead of receiving Reverb config inline in the `bridge/register` response (deduplicates the config exposure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)