### PR TITLE
feat: long-running agents — 5 borrowed patterns from Addy Osmani

### DIFF
--- a/app/Domain/Agent/DTOs/WorkspaceContractSnapshot.php
+++ b/app/Domain/Agent/DTOs/WorkspaceContractSnapshot.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Domain\Agent\DTOs;
+
+/**
+ * Materialized workspace contract for a single agent execution.
+ *
+ * Each field is the literal text content that gets written to the
+ * sandbox root as a file (AGENTS.md, feature-list.json, progress.md, init.sh).
+ *
+ * The snapshot is also persisted to AgentExecution.workspace_contract JSONB
+ * so it can be replayed on the next sandbox boot for the same execution.
+ */
+final readonly class WorkspaceContractSnapshot
+{
+    public function __construct(
+        public string $agentsMd,
+        public string $featureListJson,
+        public string $progressMd,
+        public string $initSh,
+    ) {}
+
+    /**
+     * @return array{agents_md: string, feature_list_json: string, progress_md: string, init_sh: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'agents_md' => $this->agentsMd,
+            'feature_list_json' => $this->featureListJson,
+            'progress_md' => $this->progressMd,
+            'init_sh' => $this->initSh,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            agentsMd: (string) ($payload['agents_md'] ?? ''),
+            featureListJson: (string) ($payload['feature_list_json'] ?? '{}'),
+            progressMd: (string) ($payload['progress_md'] ?? ''),
+            initSh: (string) ($payload['init_sh'] ?? "#!/usr/bin/env bash\nset -euo pipefail\n"),
+        );
+    }
+}

--- a/app/Domain/Agent/Models/AgentExecution.php
+++ b/app/Domain/Agent/Models/AgentExecution.php
@@ -51,6 +51,7 @@ class AgentExecution extends Model
         'judge_model',
         'error_message',
         'extracted_skill_id',
+        'workspace_contract',
     ];
 
     protected function casts(): array
@@ -66,6 +67,7 @@ class AgentExecution extends Model
             'cost_credits' => 'integer',
             'quality_score' => 'float',
             'quality_details' => 'array',
+            'workspace_contract' => 'array',
         ];
     }
 

--- a/app/Domain/Agent/Services/WorkspaceContractWriter.php
+++ b/app/Domain/Agent/Services/WorkspaceContractWriter.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace App\Domain\Agent\Services;
+
+use App\Domain\Agent\DTOs\WorkspaceContractSnapshot;
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Agent\Models\AgentExecution;
+use App\Domain\Project\Models\Project;
+use App\Domain\Project\Models\ProjectMilestone;
+use App\Domain\Workflow\Models\Workflow;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * Builds and persists the AGENTS.md / feature-list.json / progress.md / init.sh
+ * workspace contract that travels with every long-running agent invocation.
+ *
+ * Pattern borrowed from Anthropic's effective-harness post:
+ *   - feature-list.json is the externalized done condition.
+ *   - progress.md is the agent's rolling lab notebook.
+ *   - AGENTS.md is the "rules of the road" the agent reads on every wake.
+ *   - init.sh is the cold-boot script the sandbox runs once.
+ *
+ * The snapshot is written to disk if a SandboxedWorkspace is supplied, AND
+ * always persisted to AgentExecution.workspace_contract so a future wake
+ * can rehydrate the contract even after sandbox teardown.
+ */
+class WorkspaceContractWriter
+{
+    /**
+     * Build, materialize (if sandbox supplied), and persist the contract.
+     */
+    public function prepare(
+        AgentExecution $execution,
+        ?SandboxedWorkspace $sandbox = null,
+    ): WorkspaceContractSnapshot {
+        $agent = Agent::withoutGlobalScopes()->find($execution->agent_id);
+        $workflow = $this->resolveWorkflow($execution);
+        $project = $this->resolveProject($execution);
+
+        $snapshot = new WorkspaceContractSnapshot(
+            agentsMd: $this->buildAgentsMd($agent, $execution, $project),
+            featureListJson: $this->buildFeatureListJson($execution, $workflow, $project),
+            progressMd: $this->buildProgressMd($execution),
+            initSh: $this->buildInitSh($agent),
+        );
+
+        if ($sandbox !== null) {
+            $this->materialize($sandbox, $snapshot);
+        }
+
+        $execution->update(['workspace_contract' => $snapshot->toArray()]);
+
+        return $snapshot;
+    }
+
+    /**
+     * Read the snapshot back from AgentExecution.workspace_contract,
+     * defaulting to a freshly built one when absent.
+     */
+    public function restoreOrPrepare(AgentExecution $execution): WorkspaceContractSnapshot
+    {
+        $payload = $execution->workspace_contract;
+        if (is_array($payload) && $payload !== []) {
+            return WorkspaceContractSnapshot::fromArray($payload);
+        }
+
+        return $this->prepare($execution);
+    }
+
+    /**
+     * Append a single timestamped iteration line to progress.md and
+     * persist back to the snapshot. Idempotency is the caller's problem.
+     */
+    public function appendProgress(AgentExecution $execution, string $note, ?SandboxedWorkspace $sandbox = null): void
+    {
+        $snapshot = $this->restoreOrPrepare($execution);
+
+        $line = '- ['.Carbon::now()->toIso8601String().'] '.trim($note);
+        $newProgress = rtrim($snapshot->progressMd)."\n".$line."\n";
+
+        $next = new WorkspaceContractSnapshot(
+            agentsMd: $snapshot->agentsMd,
+            featureListJson: $snapshot->featureListJson,
+            progressMd: $newProgress,
+            initSh: $snapshot->initSh,
+        );
+
+        if ($sandbox !== null) {
+            $this->materialize($sandbox, $next);
+        }
+
+        $execution->update(['workspace_contract' => $next->toArray()]);
+    }
+
+    private function materialize(SandboxedWorkspace $sandbox, WorkspaceContractSnapshot $snapshot): void
+    {
+        // resolve() guards against path traversal; these literal names cannot escape.
+        file_put_contents($sandbox->resolve('AGENTS.md'), $snapshot->agentsMd);
+        file_put_contents($sandbox->resolve('feature-list.json'), $snapshot->featureListJson);
+        file_put_contents($sandbox->resolve('progress.md'), $snapshot->progressMd);
+        $initPath = $sandbox->resolve('init.sh');
+        file_put_contents($initPath, $snapshot->initSh);
+        @chmod($initPath, 0o755);
+    }
+
+    private function buildAgentsMd(?Agent $agent, AgentExecution $execution, ?Project $project): string
+    {
+        $name = $agent?->name ?? 'Agent';
+        $role = $agent?->role ?? 'Generalist';
+        $goal = $agent?->goal ?? '(no goal set)';
+
+        $rules = [
+            'Update progress.md after each meaningful step (a new tool call cluster, a test run, a deploy attempt).',
+            'Do not delete or weaken tests to make a build green. Restore removed assertions before claiming completion.',
+            'Re-read feature-list.json before declaring any feature done. Each feature has explicit done_criteria.',
+            'When uncertain about scope, ask via a clarification step rather than guessing.',
+        ];
+
+        if ($project) {
+            $rules[] = "This work belongs to project '{$project->title}' — favour solutions that compose with prior project runs.";
+        }
+
+        $rulesBlock = collect($rules)->map(fn ($r) => "- $r")->implode("\n");
+
+        return <<<MD
+        # AGENTS.md
+
+        Long-running workspace contract for **{$name}** ({$role}).
+
+        ## Goal
+
+        {$goal}
+
+        ## Rules
+
+        {$rulesBlock}
+
+        ## Files in this workspace
+
+        - `feature-list.json` — externalized features + done_criteria. The Done-Condition Judge reads this to verify completion.
+        - `progress.md` — rolling iteration log. Append using the `progress_append` built-in tool.
+        - `init.sh` — cold-boot script run once when a fresh sandbox is provisioned for this execution.
+
+        ## Execution
+
+        - id: {$execution->id}
+        - started_at: {$execution->created_at?->toIso8601String()}
+
+        MD;
+    }
+
+    private function buildFeatureListJson(AgentExecution $execution, ?Workflow $workflow, ?Project $project): string
+    {
+        $features = [];
+
+        if ($workflow) {
+            $nodes = $workflow->nodes()->orderBy('created_at')->get();
+            foreach ($nodes as $node) {
+                $config = is_array($node->config ?? null) ? $node->config : [];
+                $features[] = [
+                    'id' => (string) $node->id,
+                    'title' => (string) ($node->name ?? $node->node_type ?? 'node'),
+                    'done_criteria' => $config['done_criteria'] ?? null,
+                    'status' => 'pending',
+                ];
+            }
+        } elseif ($project) {
+            $milestones = ProjectMilestone::query()
+                ->where('project_id', $project->id)
+                ->orderBy('sort_order')
+                ->get();
+            foreach ($milestones as $m) {
+                $features[] = [
+                    'id' => (string) $m->id,
+                    'title' => (string) $m->title,
+                    'done_criteria' => $m->success_criteria ?? null,
+                    'status' => $m->status?->value ?? 'pending',
+                ];
+            }
+        }
+
+        if ($features === []) {
+            $features[] = [
+                'id' => Str::uuid7()->toString(),
+                'title' => 'Primary execution goal',
+                'done_criteria' => $execution->input ?? null,
+                'status' => 'pending',
+            ];
+        }
+
+        return json_encode([
+            'execution_id' => $execution->id,
+            'agent_id' => $execution->agent_id,
+            'features' => $features,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    private function buildProgressMd(AgentExecution $execution): string
+    {
+        return <<<MD
+        # progress.md
+
+        Rolling iteration log for execution `{$execution->id}`.
+
+        ## Iteration log
+
+        ## Blockers
+
+        ## Decisions
+
+        MD;
+    }
+
+    private function buildInitSh(?Agent $agent): string
+    {
+        $lines = [
+            '#!/usr/bin/env bash',
+            'set -euo pipefail',
+            '',
+            "echo \"[init] starting workspace for agent ".($agent?->id ?? 'unknown')."\"",
+            '',
+            'if [ -f composer.json ]; then',
+            '  composer install --no-interaction --prefer-dist 2>/dev/null || true',
+            'fi',
+            'if [ -f package.json ]; then',
+            '  npm ci --no-audit --no-fund 2>/dev/null || true',
+            'fi',
+            '',
+            "echo \"[init] complete\"",
+        ];
+
+        return implode("\n", $lines)."\n";
+    }
+
+    private function resolveWorkflow(AgentExecution $execution): ?Workflow
+    {
+        $experiment = $execution->experiment_id
+            ? \App\Domain\Experiment\Models\Experiment::withoutGlobalScopes()->find($execution->experiment_id)
+            : null;
+        $workflowId = $experiment?->workflow_id;
+        if (! is_string($workflowId) || $workflowId === '') {
+            return null;
+        }
+
+        return Workflow::withoutGlobalScopes()->find($workflowId);
+    }
+
+    private function resolveProject(AgentExecution $execution): ?Project
+    {
+        $experiment = $execution->experiment_id
+            ? \App\Domain\Experiment\Models\Experiment::withoutGlobalScopes()->find($execution->experiment_id)
+            : null;
+        $projectRunId = $experiment?->project_run_id ?? null;
+        if (! is_string($projectRunId) || $projectRunId === '') {
+            return null;
+        }
+        $projectRun = \App\Domain\Project\Models\ProjectRun::withoutGlobalScopes()->find($projectRunId);
+
+        return $projectRun ? Project::withoutGlobalScopes()->find($projectRun->project_id) : null;
+    }
+}

--- a/app/Domain/AgentSession/Actions/AppendSessionEventAction.php
+++ b/app/Domain/AgentSession/Actions/AppendSessionEventAction.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Domain\AgentSession\Actions;
+
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\AgentSession\Models\AgentSessionEvent;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Single write path for the AgentSession event log. Idempotent on
+ * (session_id, seq) — duplicate writes silently no-op so retries are
+ * safe. Returns the persisted event row.
+ */
+class AppendSessionEventAction
+{
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    public function execute(
+        AgentSession $session,
+        AgentSessionEventKind $kind,
+        ?array $payload = null,
+        ?int $seq = null,
+    ): AgentSessionEvent {
+        return DB::transaction(function () use ($session, $kind, $payload, $seq) {
+            $resolvedSeq = $seq ?? ($session->lastSeq() + 1);
+
+            try {
+                /** @var AgentSessionEvent $event */
+                $event = AgentSessionEvent::create([
+                    'team_id' => $session->team_id,
+                    'session_id' => $session->id,
+                    'seq' => $resolvedSeq,
+                    'kind' => $kind,
+                    'payload' => $payload,
+                    'created_at' => now(),
+                ]);
+
+                $session->update(['last_heartbeat_at' => now()]);
+
+                return $event;
+            } catch (QueryException $e) {
+                if ($this->isUniqueViolation($e)) {
+                    /** @var AgentSessionEvent $existing */
+                    $existing = AgentSessionEvent::query()
+                        ->where('session_id', $session->id)
+                        ->where('seq', $resolvedSeq)
+                        ->firstOrFail();
+
+                    return $existing;
+                }
+                throw $e;
+            }
+        });
+    }
+
+    private function isUniqueViolation(QueryException $e): bool
+    {
+        $code = (string) $e->getCode();
+
+        return $code === '23000' || $code === '23505';
+    }
+}

--- a/app/Domain/AgentSession/Actions/CancelAgentSessionAction.php
+++ b/app/Domain/AgentSession/Actions/CancelAgentSessionAction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Domain\AgentSession\Actions;
+
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+
+class CancelAgentSessionAction
+{
+    public function __construct(
+        private readonly AppendSessionEventAction $append,
+    ) {}
+
+    public function execute(AgentSession $session, ?string $reason = null): AgentSession
+    {
+        if ($session->status?->isTerminal()) {
+            return $session;
+        }
+
+        $session->update([
+            'status' => AgentSessionStatus::Cancelled,
+            'ended_at' => now(),
+        ]);
+
+        $this->append->execute(
+            session: $session->refresh(),
+            kind: AgentSessionEventKind::Note,
+            payload: ['cancelled' => true, 'reason' => $reason],
+        );
+
+        return $session->refresh();
+    }
+}

--- a/app/Domain/AgentSession/Actions/CreateAgentSessionAction.php
+++ b/app/Domain/AgentSession/Actions/CreateAgentSessionAction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Domain\AgentSession\Actions;
+
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+
+class CreateAgentSessionAction
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function execute(
+        string $teamId,
+        ?string $agentId = null,
+        ?string $experimentId = null,
+        ?string $crewExecutionId = null,
+        ?string $userId = null,
+        array $metadata = [],
+    ): AgentSession {
+        return AgentSession::create([
+            'team_id' => $teamId,
+            'agent_id' => $agentId,
+            'experiment_id' => $experimentId,
+            'crew_execution_id' => $crewExecutionId,
+            'user_id' => $userId,
+            'status' => AgentSessionStatus::Pending,
+            'metadata' => $metadata ?: null,
+        ]);
+    }
+}

--- a/app/Domain/AgentSession/Actions/SleepAgentSessionAction.php
+++ b/app/Domain/AgentSession/Actions/SleepAgentSessionAction.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Domain\AgentSession\Actions;
+
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+
+/**
+ * Detach an agent session from its current sandbox cleanly. Sandbox can
+ * die after this without losing run state — wake() will rehydrate later.
+ */
+class SleepAgentSessionAction
+{
+    public function __construct(
+        private readonly AppendSessionEventAction $append,
+    ) {}
+
+    public function execute(AgentSession $session, ?string $reason = null): AgentSession
+    {
+        if ($session->status?->isTerminal()) {
+            return $session;
+        }
+
+        $session->update([
+            'status' => AgentSessionStatus::Sleeping,
+            'last_heartbeat_at' => now(),
+        ]);
+
+        $this->append->execute(
+            session: $session->refresh(),
+            kind: AgentSessionEventKind::Sleep,
+            payload: ['reason' => $reason, 'at' => now()->toIso8601String()],
+        );
+
+        return $session->refresh();
+    }
+}

--- a/app/Domain/AgentSession/Actions/WakeAgentSessionAction.php
+++ b/app/Domain/AgentSession/Actions/WakeAgentSessionAction.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Domain\AgentSession\Actions;
+
+use App\Domain\AgentSession\DTOs\SessionContext;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+
+/**
+ * Reconstitute a SessionContext for a fresh sandbox/container without
+ * re-running any prior side effects. Records a Wake event in the log so
+ * audit can see when the session was rehydrated.
+ */
+class WakeAgentSessionAction
+{
+    public function __construct(
+        private readonly AppendSessionEventAction $append,
+    ) {}
+
+    public function execute(
+        AgentSession $session,
+        ?string $sandboxId = null,
+        int $recentEventLimit = 50,
+    ): SessionContext {
+        $now = now();
+        $session->update([
+            'status' => $session->status?->isTerminal()
+                ? $session->status
+                : AgentSessionStatus::Active,
+            'started_at' => $session->started_at ?? $now,
+            'last_heartbeat_at' => $now,
+            'last_known_sandbox_id' => $sandboxId ?? $session->last_known_sandbox_id,
+        ]);
+
+        $this->append->execute(
+            session: $session->refresh(),
+            kind: AgentSessionEventKind::Wake,
+            payload: ['sandbox_id' => $sandboxId, 'at' => $now->toIso8601String()],
+        );
+
+        $session->refresh();
+
+        $events = $session->events()
+            ->orderByDesc('seq')
+            ->take($recentEventLimit)
+            ->get(['seq', 'kind', 'payload', 'created_at'])
+            ->reverse()
+            ->values()
+            ->map(fn ($e) => [
+                'seq' => (int) $e->seq,
+                'kind' => $e->kind?->value,
+                'payload' => $e->payload,
+                'created_at' => $e->created_at?->toIso8601String(),
+            ])
+            ->all();
+
+        return new SessionContext(
+            session: $session,
+            recentEvents: $events,
+            workspaceContractSnapshot: $session->workspace_contract_snapshot,
+            totalEventCount: (int) $session->events()->count(),
+            lastSeq: $session->lastSeq(),
+        );
+    }
+}

--- a/app/Domain/AgentSession/DTOs/SessionContext.php
+++ b/app/Domain/AgentSession/DTOs/SessionContext.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Domain\AgentSession\DTOs;
+
+use App\Domain\AgentSession\Models\AgentSession;
+
+/**
+ * Reconstituted view of an AgentSession ready for a fresh sandbox to wake
+ * into. Returned by WakeAgentSessionAction.
+ */
+final readonly class SessionContext
+{
+    public function __construct(
+        public AgentSession $session,
+        /** @var array<int, array<string, mixed>> */
+        public array $recentEvents,
+        /** @var array<string, mixed>|null */
+        public ?array $workspaceContractSnapshot,
+        public int $totalEventCount,
+        public int $lastSeq,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'session_id' => $this->session->id,
+            'status' => $this->session->status?->value,
+            'team_id' => $this->session->team_id,
+            'agent_id' => $this->session->agent_id,
+            'experiment_id' => $this->session->experiment_id,
+            'crew_execution_id' => $this->session->crew_execution_id,
+            'last_seq' => $this->lastSeq,
+            'total_event_count' => $this->totalEventCount,
+            'workspace_contract_snapshot' => $this->workspaceContractSnapshot,
+            'recent_events' => $this->recentEvents,
+        ];
+    }
+}

--- a/app/Domain/AgentSession/Enums/AgentSessionEventKind.php
+++ b/app/Domain/AgentSession/Enums/AgentSessionEventKind.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Domain\AgentSession\Enums;
+
+enum AgentSessionEventKind: string
+{
+    case Wake = 'wake';
+    case Sleep = 'sleep';
+    case Transition = 'transition';
+    case StageStarted = 'stage_started';
+    case StageCompleted = 'stage_completed';
+    case ToolCall = 'tool_call';
+    case ToolResult = 'tool_result';
+    case LlmCall = 'llm_call';
+    case HumanInput = 'human_input';
+    case Artifact = 'artifact';
+    case Error = 'error';
+    case HandoffOut = 'handoff_out';
+    case HandoffIn = 'handoff_in';
+    case Note = 'note';
+}

--- a/app/Domain/AgentSession/Enums/AgentSessionStatus.php
+++ b/app/Domain/AgentSession/Enums/AgentSessionStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Domain\AgentSession\Enums;
+
+enum AgentSessionStatus: string
+{
+    case Pending = 'pending';
+    case Active = 'active';
+    case Sleeping = 'sleeping';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+    case Failed = 'failed';
+
+    public function isTerminal(): bool
+    {
+        return in_array($this, [self::Completed, self::Cancelled, self::Failed], true);
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Active => 'Active',
+            self::Sleeping => 'Sleeping',
+            self::Completed => 'Completed',
+            self::Cancelled => 'Cancelled',
+            self::Failed => 'Failed',
+        };
+    }
+}

--- a/app/Domain/AgentSession/Listeners/MirrorExperimentTransition.php
+++ b/app/Domain/AgentSession/Listeners/MirrorExperimentTransition.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Domain\AgentSession\Listeners;
+
+use App\Domain\AgentSession\Actions\AppendSessionEventAction;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\Experiment\Events\ExperimentTransitioned;
+
+/**
+ * Funnels existing ExperimentTransitioned events into the AgentSession
+ * event log without changing the Experiment domain. Zero-touch mirror.
+ *
+ * Skips silently when the experiment has no associated AgentSession yet
+ * — sessions are opt-in for v1, not retrofitted to every experiment.
+ */
+class MirrorExperimentTransition
+{
+    public function __construct(
+        private readonly AppendSessionEventAction $append,
+    ) {}
+
+    public function handle(ExperimentTransitioned $event): void
+    {
+        $session = AgentSession::query()
+            ->where('experiment_id', $event->experiment->id)
+            ->whereIn('status', ['pending', 'active', 'sleeping'])
+            ->latest('created_at')
+            ->first();
+
+        if (! $session) {
+            return;
+        }
+
+        $this->append->execute(
+            session: $session,
+            kind: AgentSessionEventKind::Transition,
+            payload: [
+                'experiment_id' => $event->experiment->id,
+                'from_state' => $event->fromState->value,
+                'to_state' => $event->toState->value,
+            ],
+        );
+    }
+}

--- a/app/Domain/AgentSession/Models/AgentSession.php
+++ b/app/Domain/AgentSession/Models/AgentSession.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Domain\AgentSession\Models;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\Crew\Models\CrewExecution;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Shared\Traits\BelongsToTeam;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Append-only session over an agent's long-running work. Decouples the
+ * agent's durable state from any single sandbox/container — wake() can
+ * reconstitute a SessionContext after a sandbox crash.
+ *
+ * Sourced from research_long_running_agents_2026-05-03 Gap E.
+ *
+ * @property string $id
+ * @property string $team_id
+ * @property string|null $agent_id
+ * @property string|null $experiment_id
+ * @property string|null $crew_execution_id
+ * @property string|null $user_id
+ * @property AgentSessionStatus $status
+ * @property \Carbon\Carbon|null $started_at
+ * @property \Carbon\Carbon|null $ended_at
+ * @property \Carbon\Carbon|null $last_heartbeat_at
+ * @property array<string, mixed>|null $workspace_contract_snapshot
+ * @property string|null $last_known_sandbox_id
+ * @property array<string, mixed>|null $metadata
+ */
+class AgentSession extends Model
+{
+    use BelongsToTeam, HasUuids;
+
+    protected $fillable = [
+        'team_id',
+        'agent_id',
+        'experiment_id',
+        'crew_execution_id',
+        'user_id',
+        'status',
+        'started_at',
+        'ended_at',
+        'last_heartbeat_at',
+        'workspace_contract_snapshot',
+        'last_known_sandbox_id',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => AgentSessionStatus::class,
+            'started_at' => 'datetime',
+            'ended_at' => 'datetime',
+            'last_heartbeat_at' => 'datetime',
+            'workspace_contract_snapshot' => 'array',
+            'metadata' => 'array',
+        ];
+    }
+
+    public function agent(): BelongsTo
+    {
+        return $this->belongsTo(Agent::class);
+    }
+
+    public function experiment(): BelongsTo
+    {
+        return $this->belongsTo(Experiment::class);
+    }
+
+    public function crewExecution(): BelongsTo
+    {
+        return $this->belongsTo(CrewExecution::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return HasMany<AgentSessionEvent, $this>
+     */
+    public function events(): HasMany
+    {
+        return $this->hasMany(AgentSessionEvent::class, 'session_id')->orderBy('seq');
+    }
+
+    /**
+     * Last sequence number written for this session, 0 when empty.
+     */
+    public function lastSeq(): int
+    {
+        return (int) $this->events()->max('seq');
+    }
+}

--- a/app/Domain/AgentSession/Models/AgentSessionEvent.php
+++ b/app/Domain/AgentSession/Models/AgentSessionEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Domain\AgentSession\Models;
+
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\Shared\Traits\BelongsToTeam;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Append-only event in an AgentSession's log. Composite uniqueness on
+ * (session_id, seq) lets writers be idempotent on retry.
+ *
+ * @property string $id
+ * @property string $team_id
+ * @property string $session_id
+ * @property int $seq
+ * @property AgentSessionEventKind $kind
+ * @property array<string, mixed>|null $payload
+ * @property \Carbon\Carbon $created_at
+ */
+class AgentSessionEvent extends Model
+{
+    use BelongsToTeam, HasUuids;
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'team_id',
+        'session_id',
+        'seq',
+        'kind',
+        'payload',
+        'created_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'kind' => AgentSessionEventKind::class,
+            'payload' => 'array',
+            'created_at' => 'datetime',
+            'seq' => 'integer',
+        ];
+    }
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(AgentSession::class, 'session_id');
+    }
+}

--- a/app/Domain/Crew/Actions/DecomposeGoalAction.php
+++ b/app/Domain/Crew/Actions/DecomposeGoalAction.php
@@ -45,7 +45,10 @@ class DecomposeGoalAction
             throw new \RuntimeException('Coordinator agent not found.');
         }
 
-        $resolved = $this->providerResolver->resolve(agent: $coordinator);
+        $coordinatorMember = \App\Domain\Crew\Models\CrewMember::forAgentInCrew($coordinator->id, $execution->crew_id);
+        $resolved = $coordinatorMember
+            ? $this->providerResolver->forCrewRole($coordinatorMember)
+            : $this->providerResolver->resolve(agent: $coordinator);
 
         $workerDescriptions = collect($config['workers'] ?? [])
             ->map(fn ($w) => "- {$w['name']} ({$w['role']}): {$w['goal']}. Skills: ".implode(', ', $w['skills'] ?? []))

--- a/app/Domain/Crew/Actions/SynthesizeResultAction.php
+++ b/app/Domain/Crew/Actions/SynthesizeResultAction.php
@@ -32,7 +32,10 @@ class SynthesizeResultAction
             throw new \RuntimeException('Coordinator agent not found.');
         }
 
-        $resolved = $this->providerResolver->resolve(agent: $coordinator);
+        $coordinatorMember = \App\Domain\Crew\Models\CrewMember::forAgentInCrew($coordinator->id, $execution->crew_id);
+        $resolved = $coordinatorMember
+            ? $this->providerResolver->forCrewRole($coordinatorMember)
+            : $this->providerResolver->resolve(agent: $coordinator);
 
         $processType = $config['process_type'] ?? 'parallel';
         $isAdversarial = $processType === 'adversarial';
@@ -112,7 +115,7 @@ class SynthesizeResultAction
             $reviewerAgent = Agent::withoutGlobalScopes()->find($outputReviewerMember->agent_id);
 
             if ($reviewerAgent) {
-                $reviewResolved = $this->providerResolver->resolve(agent: $reviewerAgent);
+                $reviewResolved = $this->providerResolver->forCrewRole($outputReviewerMember);
 
                 $reviewSystem = "You are {$reviewerAgent->role}. Your task is to review the synthesized result for quality, completeness, and accuracy. "
                     .'Output valid JSON with: "approved" (bool), "score" (0-1), "feedback" (string), '

--- a/app/Domain/Crew/Actions/ValidateTaskOutputAction.php
+++ b/app/Domain/Crew/Actions/ValidateTaskOutputAction.php
@@ -5,6 +5,7 @@ namespace App\Domain\Crew\Actions;
 use App\Domain\Agent\Models\Agent;
 use App\Domain\Crew\Enums\CrewTaskStatus;
 use App\Domain\Crew\Models\CrewExecution;
+use App\Domain\Crew\Models\CrewMember;
 use App\Domain\Crew\Models\CrewTaskExecution;
 use App\Infrastructure\AI\Contracts\AiGatewayInterface;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
@@ -31,7 +32,10 @@ class ValidateTaskOutputAction
             throw new \RuntimeException('QA agent not found.');
         }
 
-        $resolved = $this->providerResolver->resolve(agent: $qaAgent);
+        $qaMember = CrewMember::forAgentInCrew($qaAgent->id, $execution->crew_id);
+        $resolved = $qaMember
+            ? $this->providerResolver->forCrewRole($qaMember)
+            : $this->providerResolver->resolve(agent: $qaAgent);
 
         $rubric = $this->resolveRubric($taskExecution, $config);
         $qualityThreshold = $rubric['min_score'] ?? $config['quality_threshold'] ?? 0.70;

--- a/app/Domain/Crew/Enums/CrewMemberRole.php
+++ b/app/Domain/Crew/Enums/CrewMemberRole.php
@@ -9,6 +9,7 @@ enum CrewMemberRole: string
     case Worker = 'worker';
     case ProcessReviewer = 'process_reviewer';
     case OutputReviewer = 'output_reviewer';
+    case Judge = 'judge';
 
     public function label(): string
     {
@@ -18,6 +19,7 @@ enum CrewMemberRole: string
             self::Worker => 'Worker',
             self::ProcessReviewer => 'Process Reviewer',
             self::OutputReviewer => 'Output Reviewer',
+            self::Judge => 'Judge',
         };
     }
 
@@ -29,6 +31,7 @@ enum CrewMemberRole: string
             self::Worker => 'sky',
             self::ProcessReviewer => 'amber',
             self::OutputReviewer => 'rose',
+            self::Judge => 'emerald',
         };
     }
 }

--- a/app/Domain/Crew/Jobs/CoordinatorDecisionJob.php
+++ b/app/Domain/Crew/Jobs/CoordinatorDecisionJob.php
@@ -93,7 +93,10 @@ class CoordinatorDecisionJob implements ShouldQueue
             return;
         }
 
-        $resolved = $providerResolver->resolve(agent: $coordinator);
+        $coordinatorMember = \App\Domain\Crew\Models\CrewMember::forAgentInCrew($coordinator->id, $execution->crew_id);
+        $resolved = $coordinatorMember
+            ? $providerResolver->forCrewRole($coordinatorMember)
+            : $providerResolver->resolve(agent: $coordinator);
 
         // Build context: completed tasks and their outputs
         $completedTasks = $execution->taskExecutions()

--- a/app/Domain/Crew/Models/CrewMember.php
+++ b/app/Domain/Crew/Models/CrewMember.php
@@ -120,4 +120,43 @@ class CrewMember extends Model
 
         return $value !== null ? (int) $value : null;
     }
+
+    /**
+     * Look up the CrewMember row for a given agent within a specific crew,
+     * if one exists. Returns null when the agent is not enrolled in the crew
+     * (e.g., legacy executions whose qa_agent / coordinator predates the
+     * members table population).
+     */
+    public static function forAgentInCrew(?string $agentId, ?string $crewId): ?self
+    {
+        if ($agentId === null || $crewId === null) {
+            return null;
+        }
+
+        return static::query()
+            ->where('crew_id', $crewId)
+            ->where('agent_id', $agentId)
+            ->first();
+    }
+
+    /**
+     * Per-role model override resolved from config JSONB.
+     * Returns ['provider' => string, 'model' => string] or null when unset.
+     *
+     * @return array{provider: string, model: string}|null
+     */
+    public function getModelOverrideAttribute(): ?array
+    {
+        $override = $this->config['model_override'] ?? null;
+        if (! is_array($override)) {
+            return null;
+        }
+        $provider = $override['provider'] ?? null;
+        $model = $override['model'] ?? null;
+        if (! is_string($provider) || $provider === '' || ! is_string($model) || $model === '') {
+            return null;
+        }
+
+        return ['provider' => $provider, 'model' => $model];
+    }
 }

--- a/app/Domain/Experiment/Actions/TransitionExperimentAction.php
+++ b/app/Domain/Experiment/Actions/TransitionExperimentAction.php
@@ -52,6 +52,7 @@ class TransitionExperimentAction
                 'reason' => $reason,
                 'actor_id' => $actorId,
                 'metadata' => $metadata,
+                'judge_verdict' => $this->prerequisiteValidator->lastJudgeVerdict?->toArray(),
                 'created_at' => now(),
             ]);
 

--- a/app/Domain/Experiment/DTOs/DoneVerdict.php
+++ b/app/Domain/Experiment/DTOs/DoneVerdict.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Domain\Experiment\DTOs;
+
+/**
+ * Outcome of the Done-Condition Judge. `confirmed=true` means the agent's
+ * claim of completion was upheld against the externalized done_criteria.
+ *
+ * Stored on experiment_state_transitions.judge_verdict for audit.
+ */
+final readonly class DoneVerdict
+{
+    public function __construct(
+        public bool $confirmed,
+        public string $reasoning,
+        /** @var array<int, string> */
+        public array $missing,
+        /** @var array<int, string> */
+        public array $nextActions,
+        public ?string $judgeModel = null,
+    ) {}
+
+    public static function bypassed(string $reason = 'gate disabled'): self
+    {
+        return new self(true, $reason, [], []);
+    }
+
+    /**
+     * @return array{confirmed: bool, reasoning: string, missing: array<int, string>, next_actions: array<int, string>, judge_model: ?string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'confirmed' => $this->confirmed,
+            'reasoning' => $this->reasoning,
+            'missing' => $this->missing,
+            'next_actions' => $this->nextActions,
+            'judge_model' => $this->judgeModel,
+        ];
+    }
+}

--- a/app/Domain/Experiment/Models/ExperimentStateTransition.php
+++ b/app/Domain/Experiment/Models/ExperimentStateTransition.php
@@ -22,6 +22,7 @@ class ExperimentStateTransition extends Model
         'reason',
         'actor_id',
         'metadata',
+        'judge_verdict',
         'created_at',
     ];
 
@@ -29,6 +30,7 @@ class ExperimentStateTransition extends Model
     {
         return [
             'metadata' => 'array',
+            'judge_verdict' => 'array',
             'created_at' => 'datetime',
         ];
     }

--- a/app/Domain/Experiment/Services/DoneConditionJudge.php
+++ b/app/Domain/Experiment/Services/DoneConditionJudge.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Domain\Experiment\Services;
+
+use App\Domain\Experiment\DTOs\DoneVerdict;
+use App\Domain\Experiment\Models\Experiment;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Judge agent that re-evaluates an agent's "I'm done" claim against the
+ * externalized feature-list.json done_criteria. Borrowed from Anthropic's
+ * harness pattern: separating evaluator from generator stops the agent
+ * from grading its own work too generously.
+ *
+ * Default model is Haiku 4.5 (cheap, fast, isolated). Per-Project override
+ * lives in project.settings['done_gate_judge'] = {provider, model}.
+ */
+class DoneConditionJudge
+{
+    public function __construct(
+        private readonly AiGatewayInterface $gateway,
+    ) {}
+
+    /**
+     * @param  array<int, array<string, mixed>>  $features  feature-list.json features
+     * @param  array<string, mixed>|string  $evidence  what the agent claims as proof of completion
+     * @param  array{provider?: string, model?: string}|null  $override
+     */
+    public function evaluate(
+        Experiment $experiment,
+        array $features,
+        array|string $evidence,
+        ?array $override = null,
+    ): DoneVerdict {
+        $provider = $override['provider'] ?? 'anthropic';
+        $model = $override['model'] ?? 'claude-haiku-4-5';
+
+        $featuresJson = json_encode($features, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        $evidenceText = is_string($evidence)
+            ? $evidence
+            : json_encode($evidence, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+
+        $systemPrompt = <<<'TXT'
+        You are a strict completion judge. The worker agent claims this work is done.
+
+        Reply ONLY with JSON: {"confirmed": bool, "reasoning": string, "missing": [string], "next_actions": [string]}.
+
+        Be skeptical. If criteria mention tests, demand test output. If criteria mention deploy,
+        demand a deploy URL. Do not accept "I think it works" or vague handwaving as evidence.
+        Only confirm when EVERY done_criterion has concrete proof in the evidence.
+        TXT;
+
+        $userPrompt = "Done criteria (testable):\n{$featuresJson}\n\nEvidence the agent provided:\n{$evidenceText}";
+
+        $request = new AiRequestDTO(
+            provider: $provider,
+            model: $model,
+            systemPrompt: $systemPrompt,
+            userPrompt: $userPrompt,
+            maxTokens: 1024,
+            userId: $experiment->user_id,
+            teamId: $experiment->team_id,
+            purpose: 'judge.done',
+        );
+
+        try {
+            $response = $this->gateway->complete($request);
+        } catch (\Throwable $e) {
+            Log::warning('DoneConditionJudge: gateway failed, defaulting to confirmed=false', [
+                'experiment_id' => $experiment->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            return new DoneVerdict(
+                confirmed: false,
+                reasoning: 'Judge unreachable: '.$e->getMessage(),
+                missing: ['Judge gateway error — manual review required'],
+                nextActions: [],
+                judgeModel: $model,
+            );
+        }
+
+        $parsed = $response->parsedOutput;
+        if (! is_array($parsed)) {
+            $parsed = $this->extractJson($response->content);
+        }
+
+        if (! is_array($parsed)) {
+            return new DoneVerdict(
+                confirmed: false,
+                reasoning: 'Judge response was not valid JSON.',
+                missing: ['Judge output unparsable'],
+                nextActions: [],
+                judgeModel: $model,
+            );
+        }
+
+        return new DoneVerdict(
+            confirmed: (bool) ($parsed['confirmed'] ?? false),
+            reasoning: (string) ($parsed['reasoning'] ?? ''),
+            missing: array_values(array_map('strval', $parsed['missing'] ?? [])),
+            nextActions: array_values(array_map('strval', $parsed['next_actions'] ?? [])),
+            judgeModel: $model,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function extractJson(string $content): ?array
+    {
+        $stripped = preg_replace('/^```(?:json)?\s*|\s*```$/m', '', trim($content));
+        $decoded = json_decode((string) $stripped, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/app/Domain/Experiment/States/TransitionPrerequisiteValidator.php
+++ b/app/Domain/Experiment/States/TransitionPrerequisiteValidator.php
@@ -2,23 +2,34 @@
 
 namespace App\Domain\Experiment\States;
 
+use App\Domain\Agent\Models\AgentExecution;
+use App\Domain\Experiment\DTOs\DoneVerdict;
 use App\Domain\Experiment\Enums\ExperimentStatus;
 use App\Domain\Experiment\Enums\StageStatus;
 use App\Domain\Experiment\Enums\StageType;
 use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Services\DoneConditionJudge;
+use App\Domain\Project\Models\Project;
+use App\Domain\Project\Models\ProjectRun;
 
 class TransitionPrerequisiteValidator
 {
     /**
-     * Validate that prerequisites are met for a state transition.
-     * Returns null if valid, or an error message if invalid.
+     * Most-recent verdict from the Done-Condition Gate. The transition action
+     * persists this onto the resulting ExperimentStateTransition row so audit
+     * can review the judge's reasoning.
      */
+    public ?DoneVerdict $lastJudgeVerdict = null;
+
     public function validate(Experiment $experiment, ExperimentStatus $toState): ?string
     {
+        $this->lastJudgeVerdict = null;
+
         return match ($toState) {
             ExperimentStatus::Building => $this->validateBuildingPrereqs($experiment),
             ExperimentStatus::Executing => $this->validateExecutingPrereqs($experiment),
             ExperimentStatus::CollectingMetrics => $this->validateMetricsPrereqs($experiment),
+            ExperimentStatus::Completed => $this->validateDoneCondition($experiment),
             default => null,
         };
     }
@@ -41,8 +52,6 @@ class TransitionPrerequisiteValidator
 
     private function validateExecutingPrereqs(Experiment $experiment): ?string
     {
-        // Workflow experiments coming from Draft (project runs) skip planning.
-        // They need materialized playbook steps.
         $hasWorkflow = ! empty($experiment->constraints['workflow_graph']);
 
         if ($hasWorkflow && ! $experiment->playbookSteps()->exists()) {
@@ -54,7 +63,6 @@ class TransitionPrerequisiteValidator
 
     private function validateMetricsPrereqs(Experiment $experiment): ?string
     {
-        // If the experiment has playbook steps, at least one should be completed
         if ($experiment->playbookSteps()->exists()) {
             $completed = $experiment->playbookSteps()->where('status', 'completed')->count();
 
@@ -64,5 +72,148 @@ class TransitionPrerequisiteValidator
         }
 
         return null;
+    }
+
+    /**
+     * Done-Condition Gate (Anthropic-style anti-premature-stop judge).
+     *
+     * Off by default. Opt-in per Experiment via experiment.constraints:
+     *   - done_gate_enabled = true      → gate runs when transitioning to Completed
+     *   - done_gate_kill_switch = true  → bypass even when enabled
+     *   - done_gate_judge = {provider, model}  → optional model override
+     *
+     * If a Project owns this experiment (via project_run_id when the column
+     * exists), project.settings keys of the same names take precedence so
+     * teams can flip the gate at the project level without touching every
+     * experiment.
+     */
+    private function validateDoneCondition(Experiment $experiment): ?string
+    {
+        $settings = $this->resolveDoneGateSettings($experiment);
+        $enabled = (bool) ($settings['done_gate_enabled'] ?? false);
+        $killSwitch = (bool) ($settings['done_gate_kill_switch'] ?? false);
+
+        if (! $enabled || $killSwitch) {
+            return null;
+        }
+
+        $features = $this->resolveFeatures($experiment);
+        if ($features === []) {
+            // No externalized criteria → nothing to verify against; let it through.
+            return null;
+        }
+
+        $evidence = $this->collectEvidence($experiment);
+        $override = $settings['done_gate_judge'] ?? null;
+
+        $judge = app(DoneConditionJudge::class);
+        $verdict = $judge->evaluate(
+            experiment: $experiment,
+            features: $features,
+            evidence: $evidence,
+            override: is_array($override) ? $override : null,
+        );
+        $this->lastJudgeVerdict = $verdict;
+
+        if (! $verdict->confirmed) {
+            $missing = $verdict->missing !== []
+                ? ' Missing: '.implode('; ', array_slice($verdict->missing, 0, 5))
+                : '';
+
+            return 'Done-Condition Gate denied transition to Completed: '.$verdict->reasoning.$missing;
+        }
+
+        return null;
+    }
+
+    private function resolveProject(Experiment $experiment): ?Project
+    {
+        $projectRunId = $experiment->project_run_id ?? null;
+        if (! is_string($projectRunId) || $projectRunId === '') {
+            return null;
+        }
+        $run = ProjectRun::withoutGlobalScopes()->find($projectRunId);
+        if (! $run) {
+            return null;
+        }
+
+        return Project::withoutGlobalScopes()->find($run->project_id);
+    }
+
+    /**
+     * Merge experiment.constraints with the owning project.settings (when
+     * present), letting project-level flags override experiment-level ones.
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveDoneGateSettings(Experiment $experiment): array
+    {
+        $constraints = is_array($experiment->constraints ?? null) ? $experiment->constraints : [];
+        $settings = [
+            'done_gate_enabled' => $constraints['done_gate_enabled'] ?? false,
+            'done_gate_kill_switch' => $constraints['done_gate_kill_switch'] ?? false,
+            'done_gate_judge' => $constraints['done_gate_judge'] ?? null,
+        ];
+
+        $project = $this->resolveProject($experiment);
+        if ($project) {
+            $ps = is_array($project->settings ?? null) ? $project->settings : [];
+            foreach (['done_gate_enabled', 'done_gate_kill_switch', 'done_gate_judge'] as $key) {
+                if (array_key_exists($key, $ps)) {
+                    $settings[$key] = $ps[$key];
+                }
+            }
+        }
+
+        return $settings;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function resolveFeatures(Experiment $experiment): array
+    {
+        $latest = AgentExecution::query()
+            ->where('experiment_id', $experiment->id)
+            ->whereNotNull('workspace_contract')
+            ->latest('updated_at')
+            ->first();
+
+        if (! $latest) {
+            return [];
+        }
+
+        $contract = $latest->workspace_contract;
+        $jsonStr = is_array($contract) ? ($contract['feature_list_json'] ?? null) : null;
+        if (! is_string($jsonStr) || $jsonStr === '') {
+            return [];
+        }
+
+        $decoded = json_decode($jsonStr, true);
+
+        return is_array($decoded) && is_array($decoded['features'] ?? null) ? $decoded['features'] : [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collectEvidence(Experiment $experiment): array
+    {
+        $stages = $experiment->stages()
+            ->latest()
+            ->take(5)
+            ->get(['stage', 'status', 'output_snapshot'])
+            ->map(fn ($s) => [
+                'stage' => $s->stage instanceof \BackedEnum ? $s->stage->value : (string) $s->stage,
+                'status' => $s->status instanceof \BackedEnum ? $s->status->value : (string) $s->status,
+                'output_snapshot' => $s->output_snapshot,
+            ])
+            ->all();
+
+        return [
+            'experiment_id' => $experiment->id,
+            'recent_stages' => $stages,
+            'goal' => $experiment->goal ?? null,
+        ];
     }
 }

--- a/app/Domain/GitRepository/DTOs/TestRatchetVerdict.php
+++ b/app/Domain/GitRepository/DTOs/TestRatchetVerdict.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Domain\GitRepository\DTOs;
+
+/**
+ * Outcome of a TestRatchetGuard inspection. `violation` is true when the
+ * change set looks like an agent removed tests to make a build green.
+ *
+ * @property string[] $deletedTestFiles
+ * @property string[] $modifiedTestFiles
+ */
+final readonly class TestRatchetVerdict
+{
+    public function __construct(
+        public bool $violation,
+        public array $deletedTestFiles,
+        public array $modifiedTestFiles,
+        public int $removedAssertionCount,
+        public string $reason,
+    ) {}
+
+    public static function clean(): self
+    {
+        return new self(false, [], [], 0, 'no test files affected');
+    }
+
+    /**
+     * @return array{
+     *   violation: bool,
+     *   deleted_test_files: string[],
+     *   modified_test_files: string[],
+     *   removed_assertion_count: int,
+     *   reason: string
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'violation' => $this->violation,
+            'deleted_test_files' => $this->deletedTestFiles,
+            'modified_test_files' => $this->modifiedTestFiles,
+            'removed_assertion_count' => $this->removedAssertionCount,
+            'reason' => $this->reason,
+        ];
+    }
+}

--- a/app/Domain/GitRepository/Enums/TestRatchetMode.php
+++ b/app/Domain/GitRepository/Enums/TestRatchetMode.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Domain\GitRepository\Enums;
+
+enum TestRatchetMode: string
+{
+    case Off = 'off';
+    case Soft = 'soft';
+    case Hard = 'hard';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Off => 'Off',
+            self::Soft => 'Soft (nudge only)',
+            self::Hard => 'Hard (block via approval)',
+        };
+    }
+}

--- a/app/Domain/GitRepository/Exceptions/TestRatchetViolationException.php
+++ b/app/Domain/GitRepository/Exceptions/TestRatchetViolationException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Domain\GitRepository\Exceptions;
+
+use App\Domain\GitRepository\DTOs\TestRatchetVerdict;
+use RuntimeException;
+
+class TestRatchetViolationException extends RuntimeException
+{
+    public function __construct(public readonly TestRatchetVerdict $verdict)
+    {
+        parent::__construct(
+            'TestRatchetViolation: '.$verdict->reason
+            .' (deleted='.count($verdict->deletedTestFiles)
+            .' modified='.count($verdict->modifiedTestFiles)
+            .' removed_assertions='.$verdict->removedAssertionCount.')'
+        );
+    }
+}

--- a/app/Domain/GitRepository/Services/TestRatchetGuard.php
+++ b/app/Domain/GitRepository/Services/TestRatchetGuard.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Domain\GitRepository\Services;
+
+use App\Domain\GitRepository\DTOs\TestRatchetVerdict;
+
+/**
+ * Detects "agent deleted tests to make the build green" patterns.
+ *
+ * Inputs are normalized change sets:
+ *   - $changes: list of {path, mode, content?, content_before?} dicts
+ *     (mode = 'add'|'modify'|'delete')
+ *
+ * Heuristics:
+ *   - Any deletion of a test-file path → violation.
+ *   - Modification of a test file that net-removes ≥3 assertion lines → violation.
+ *
+ * Test-file patterns: *Test.php, *Spec.php, *.test.ts/.tsx/.js/.jsx, *.spec.ts/.tsx/.js/.jsx,
+ * *_spec.rb, paths under tests/ or __tests__/.
+ *
+ * Assertion-line regex matches lines starting with: expect, assert, ->assert,
+ * self.assert, $this->assert, @Test.
+ */
+class TestRatchetGuard
+{
+    private const TEST_PATH_PATTERNS = [
+        '#(?:^|/)tests/#i',
+        '#(?:^|/)__tests__/#i',
+        '#Test\.php$#',
+        '#Spec\.php$#',
+        '#\.test\.(?:ts|tsx|js|jsx|mjs|cjs)$#',
+        '#\.spec\.(?:ts|tsx|js|jsx|mjs|cjs)$#',
+        '#_spec\.rb$#',
+        '#_test\.go$#',
+        '#_test\.py$#',
+        '#test_.+\.py$#',
+    ];
+
+    private const ASSERTION_REGEX = '/^[+\-]?\s*(?:expect\b|assert\w*\b|->assert\w*\b|self\.assert\w*\b|\$this->assert\w*\b|@Test\b)/m';
+
+    private const ASSERTION_REMOVAL_THRESHOLD = 3;
+
+    /**
+     * @param  list<array{path: string, mode?: string, content?: string|null, content_before?: string|null}>  $changes
+     */
+    public function inspect(array $changes): TestRatchetVerdict
+    {
+        $deleted = [];
+        $modified = [];
+        $totalRemovedAssertions = 0;
+
+        foreach ($changes as $change) {
+            $path = (string) ($change['path'] ?? '');
+            if ($path === '' || ! $this->isTestPath($path)) {
+                continue;
+            }
+
+            $mode = (string) ($change['mode'] ?? 'modify');
+
+            if ($mode === 'delete') {
+                $deleted[] = $path;
+
+                continue;
+            }
+
+            $before = (string) ($change['content_before'] ?? '');
+            $after = (string) ($change['content'] ?? '');
+            $removed = $this->countRemovedAssertions($before, $after);
+            if ($removed >= 1) {
+                $modified[] = $path;
+                $totalRemovedAssertions += $removed;
+            }
+        }
+
+        if (count($deleted) === 0 && $totalRemovedAssertions < self::ASSERTION_REMOVAL_THRESHOLD) {
+            return TestRatchetVerdict::clean();
+        }
+
+        $reason = match (true) {
+            count($deleted) > 0 => count($deleted).' test file(s) deleted',
+            default => $totalRemovedAssertions.' assertion line(s) removed across '.count($modified).' test file(s)',
+        };
+
+        return new TestRatchetVerdict(
+            violation: true,
+            deletedTestFiles: $deleted,
+            modifiedTestFiles: $modified,
+            removedAssertionCount: $totalRemovedAssertions,
+            reason: $reason,
+        );
+    }
+
+    private function isTestPath(string $path): bool
+    {
+        foreach (self::TEST_PATH_PATTERNS as $pattern) {
+            if (preg_match($pattern, $path) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function countRemovedAssertions(string $before, string $after): int
+    {
+        $beforeCount = preg_match_all(self::ASSERTION_REGEX, $before) ?: 0;
+        $afterCount = preg_match_all(self::ASSERTION_REGEX, $after) ?: 0;
+
+        return max(0, $beforeCount - $afterCount);
+    }
+}

--- a/app/Domain/Tool/Enums/BuiltInToolKind.php
+++ b/app/Domain/Tool/Enums/BuiltInToolKind.php
@@ -13,6 +13,7 @@ enum BuiltInToolKind: string
     case BrowserUseCloud = 'browser_use_cloud';
     case ExecuteCode = 'execute_code';
     case BrowserHarness = 'browser_harness';
+    case ProgressAppend = 'progress_append';
 
     public function label(): string
     {
@@ -26,6 +27,7 @@ enum BuiltInToolKind: string
             self::BrowserUseCloud => 'Browser Use Cloud (cloud.browser-use.com)',
             self::ExecuteCode => 'Execute Code',
             self::BrowserHarness => 'Browser Harness (self-healing CDP)',
+            self::ProgressAppend => 'Progress Log (workspace contract)',
         };
     }
 }

--- a/app/Infrastructure/AI/Services/ProviderResolver.php
+++ b/app/Infrastructure/AI/Services/ProviderResolver.php
@@ -4,6 +4,7 @@ namespace App\Infrastructure\AI\Services;
 
 use App\Domain\Agent\Models\Agent;
 use App\Domain\Bridge\Models\BridgeConnection;
+use App\Domain\Crew\Models\CrewMember;
 use App\Domain\Shared\Enums\DataClassification;
 use App\Domain\Shared\Models\Team;
 use App\Domain\Shared\Models\TeamProviderCredential;
@@ -39,6 +40,30 @@ class ProviderResolver
         $resolved = $this->enforceAllowedModels($resolved, $team);
 
         return $this->enforceDataClassification($resolved, $agent, $team);
+    }
+
+    /**
+     * Resolve provider and model for a crew member, honoring the per-role
+     * model_override (config['model_override']) before falling through to
+     * the agent/team/platform hierarchy. Override is still subjected to the
+     * same allowed-models and data-classification enforcement that resolve()
+     * runs, so a stale override that became disallowed will not slip through.
+     *
+     * @return array{provider: string, model: string}
+     */
+    public function forCrewRole(CrewMember $member, string $purpose = 'run'): array
+    {
+        $override = $member->model_override;
+        $agent = $member->agent;
+        $team = $agent?->team;
+
+        if ($override !== null) {
+            $resolved = $this->enforceAllowedModels($override, $team);
+
+            return $this->enforceDataClassification($resolved, $agent, $team);
+        }
+
+        return $this->resolve(skill: null, agent: $agent, team: $team, purpose: $purpose);
     }
 
     /**

--- a/app/Infrastructure/Git/Clients/GatedGitClient.php
+++ b/app/Infrastructure/Git/Clients/GatedGitClient.php
@@ -3,8 +3,12 @@
 namespace App\Infrastructure\Git\Clients;
 
 use App\Domain\GitRepository\Contracts\GitClientInterface;
+use App\Domain\GitRepository\Enums\TestRatchetMode;
+use App\Domain\GitRepository\Exceptions\TestRatchetViolationException;
 use App\Domain\GitRepository\Models\GitRepository;
 use App\Domain\GitRepository\Services\GitOperationGate;
+use App\Domain\GitRepository\Services\TestRatchetGuard;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Decorator that gates GitClientInterface write methods through
@@ -65,6 +69,8 @@ class GatedGitClient implements GitClientInterface
             'branch' => $branch,
         ]);
 
+        $this->enforceTestRatchet([['path' => $path, 'mode' => 'modify', 'content' => $content]]);
+
         return $this->inner->writeFile($path, $content, $message, $branch);
     }
 
@@ -86,7 +92,39 @@ class GatedGitClient implements GitClientInterface
             'branch' => $branch,
         ]);
 
+        $this->enforceTestRatchet($changes);
+
         return $this->inner->commit($changes, $message, $branch);
+    }
+
+    /**
+     * Resolve the per-repo test_ratchet_mode (default Soft) and apply the guard.
+     * Off → no-op. Soft → log warning. Hard → throw TestRatchetViolationException.
+     *
+     * @param  array<int, array<string, mixed>>  $changes
+     */
+    private function enforceTestRatchet(array $changes): void
+    {
+        $rawMode = $this->repo->config['test_ratchet_mode'] ?? TestRatchetMode::Soft->value;
+        $mode = TestRatchetMode::tryFrom((string) $rawMode) ?? TestRatchetMode::Soft;
+
+        if ($mode === TestRatchetMode::Off) {
+            return;
+        }
+
+        $verdict = app(TestRatchetGuard::class)->inspect($changes);
+        if (! $verdict->violation) {
+            return;
+        }
+
+        if ($mode === TestRatchetMode::Hard) {
+            throw new TestRatchetViolationException($verdict);
+        }
+
+        Log::warning('TestRatchet (soft): test files affected', [
+            'repo_id' => $this->repo->id,
+            'verdict' => $verdict->toArray(),
+        ]);
     }
 
     public function push(string $branch): void

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -43,6 +43,7 @@ use App\Mcp\Tools\Agent\AgentListTool;
 use App\Mcp\Tools\Agent\AgentResetSessionTool;
 use App\Mcp\Tools\Agent\AgentRollbackConfigTool;
 use App\Mcp\Tools\Agent\AgentRuntimeStateTool;
+use App\Mcp\Tools\Agent\AgentWorkspaceContractGetTool;
 use App\Mcp\Tools\Agent\AgentSandboxTool;
 use App\Mcp\Tools\Agent\AgentSetReasoningStrategyTool;
 use App\Mcp\Tools\Agent\AgentSkillSyncTool;
@@ -69,6 +70,11 @@ use App\Mcp\Tools\AgentChatProtocol\ExternalAgentListTool;
 use App\Mcp\Tools\AgentChatProtocol\ExternalAgentPingTool;
 use App\Mcp\Tools\AgentChatProtocol\ExternalAgentRefreshManifestTool;
 use App\Mcp\Tools\AgentChatProtocol\ExternalAgentUpdateTool;
+use App\Mcp\Tools\AgentSession\AgentSessionEventsTool;
+use App\Mcp\Tools\AgentSession\AgentSessionGetTool;
+use App\Mcp\Tools\AgentSession\AgentSessionListTool;
+use App\Mcp\Tools\AgentSession\AgentSessionSleepTool;
+use App\Mcp\Tools\AgentSession\AgentSessionWakeTool;
 use App\Mcp\Tools\Approval\ActionProposalApproveTool;
 use App\Mcp\Tools\Approval\ActionProposalGetTool;
 use App\Mcp\Tools\Approval\ActionProposalListTool;
@@ -162,6 +168,7 @@ use App\Mcp\Tools\Crew\CrewGetMessagesTool;
 use App\Mcp\Tools\Crew\CrewGetTool;
 use App\Mcp\Tools\Crew\CrewListTool;
 use App\Mcp\Tools\Crew\CrewMemberRemoveTool;
+use App\Mcp\Tools\Crew\CrewMemberSetModelOverrideTool;
 use App\Mcp\Tools\Crew\CrewMemberUpdatePolicyTool;
 use App\Mcp\Tools\Crew\CrewProposeRestructuringTool;
 use App\Mcp\Tools\Crew\CrewSendMessageTool;
@@ -204,6 +211,7 @@ use App\Mcp\Tools\Experiment\ExperimentListTool;
 use App\Mcp\Tools\Experiment\ExperimentPauseTool;
 use App\Mcp\Tools\Experiment\ExperimentResumeFromCheckpointTool;
 use App\Mcp\Tools\Experiment\ExperimentResumeTool;
+use App\Mcp\Tools\Experiment\ExperimentDoneJudgeRunTool;
 use App\Mcp\Tools\Experiment\ExperimentRetryFromStepTool;
 use App\Mcp\Tools\Experiment\ExperimentRetryTool;
 use App\Mcp\Tools\Experiment\ExperimentSearchHistoryTool;
@@ -239,6 +247,7 @@ use App\Mcp\Tools\GitRepository\GitFileListTool;
 use App\Mcp\Tools\GitRepository\GitFileReadTool;
 use App\Mcp\Tools\GitRepository\GitFileWriteTool;
 use App\Mcp\Tools\GitRepository\GitPullRequestCreateTool;
+use App\Mcp\Tools\GitRepository\RepoTestRatchetCheckTool;
 use App\Mcp\Tools\GitRepository\GitPullRequestListTool;
 use App\Mcp\Tools\GitRepository\GitRepositoryCreateTool;
 use App\Mcp\Tools\GitRepository\GitRepositoryDeleteTool;
@@ -682,6 +691,7 @@ class AgentFleetServer extends Server
         AgentConfigHistoryTool::class,
         AgentRollbackConfigTool::class,
         AgentRuntimeStateTool::class,
+        AgentWorkspaceContractGetTool::class,
         AgentResetSessionTool::class,
         AgentSandboxTool::class,
         AgentHeartbeatUpdateTool::class,
@@ -723,6 +733,7 @@ class AgentFleetServer extends Server
         CrewSendMessageTool::class,
         CrewGetMessagesTool::class,
         CrewMemberUpdatePolicyTool::class,
+        CrewMemberSetModelOverrideTool::class,
         CrewGenerateFromPromptTool::class,
         CrewProposeRestructuringTool::class,
         CrewActivateTool::class,
@@ -753,6 +764,7 @@ class AgentFleetServer extends Server
         ExperimentSearchHistoryTool::class,
         ExperimentContextHealthTool::class,
         ExperimentSkipStageTool::class,
+        ExperimentDoneJudgeRunTool::class,
         ExperimentUpdateTool::class,
         ExperimentTrajectoryTool::class,
         WorkflowSnapshotListTool::class,
@@ -1103,6 +1115,13 @@ class AgentFleetServer extends Server
         ActivepiecesSyncTool::class,
         ActivepiecesListPiecesTool::class,
 
+        // Agent Session (5)
+        AgentSessionListTool::class,
+        AgentSessionGetTool::class,
+        AgentSessionEventsTool::class,
+        AgentSessionWakeTool::class,
+        AgentSessionSleepTool::class,
+
         // Compute (1)
         ComputeManageTool::class,
 
@@ -1193,6 +1212,7 @@ class AgentFleetServer extends Server
         CodeCallChainTool::class,
         CodeSkimFileTool::class,
         ExperimentRepoMapTool::class,
+        RepoTestRatchetCheckTool::class,
 
         // Auth / Social Login (2)
         SocialAccountListTool::class,

--- a/app/Mcp/Tools/Agent/AgentWorkspaceContractGetTool.php
+++ b/app/Mcp/Tools/Agent/AgentWorkspaceContractGetTool.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Mcp\Tools\Agent;
+
+use App\Domain\Agent\Models\AgentExecution;
+use App\Domain\Agent\Services\WorkspaceContractWriter;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class AgentWorkspaceContractGetTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_workspace_contract_get';
+
+    protected string $description = 'Fetch the AGENTS.md / feature-list.json / progress.md / init.sh workspace contract for an AgentExecution. Returns the persisted snapshot, building one on the fly if none exists yet. The contract is the durable handoff a long-running agent reads on each wake.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'execution_id' => $schema->string()
+                ->description('AgentExecution UUID')
+                ->required(),
+            'rebuild' => $schema->boolean()
+                ->description('Force a rebuild from current workflow/project state instead of reading the persisted snapshot.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'execution_id' => 'required|string',
+            'rebuild' => 'nullable|boolean',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $execution = AgentExecution::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['execution_id']);
+        if (! $execution) {
+            return $this->notFoundError('agent_execution');
+        }
+
+        $writer = app(WorkspaceContractWriter::class);
+        $snapshot = ! empty($validated['rebuild'])
+            ? $writer->prepare($execution)
+            : $writer->restoreOrPrepare($execution);
+
+        return Response::json([
+            'execution_id' => $execution->id,
+            'snapshot' => $snapshot->toArray(),
+        ]);
+    }
+}

--- a/app/Mcp/Tools/AgentSession/AgentSessionEventsTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionEventsTool.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class AgentSessionEventsTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_events';
+
+    protected string $description = 'Read the AgentSession event log. Supports cursor pagination via from_seq + limit (default 100, max 500). Events are ordered by seq ascending.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'session_id' => $schema->string()->description('AgentSession UUID')->required(),
+            'from_seq' => $schema->integer()->description('Return events with seq >= from_seq (default 1)'),
+            'limit' => $schema->integer()->description('Max events (default 100, max 500)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+            'from_seq' => 'nullable|integer|min:1',
+            'limit' => 'nullable|integer|min:1|max:500',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $session = AgentSession::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['session_id']);
+        if (! $session) {
+            return $this->notFoundError('agent_session');
+        }
+
+        $fromSeq = (int) ($validated['from_seq'] ?? 1);
+        $limit = (int) ($validated['limit'] ?? 100);
+
+        $events = $session->events()
+            ->where('seq', '>=', $fromSeq)
+            ->orderBy('seq')
+            ->take($limit)
+            ->get(['seq', 'kind', 'payload', 'created_at']);
+
+        return Response::json([
+            'session_id' => $session->id,
+            'from_seq' => $fromSeq,
+            'count' => $events->count(),
+            'next_seq' => $events->isNotEmpty() ? ((int) $events->last()->seq + 1) : $fromSeq,
+            'events' => $events->map(fn ($e) => [
+                'seq' => (int) $e->seq,
+                'kind' => $e->kind?->value,
+                'payload' => $e->payload,
+                'created_at' => $e->created_at?->toIso8601String(),
+            ])->all(),
+        ]);
+    }
+}

--- a/app/Mcp/Tools/AgentSession/AgentSessionGetTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionGetTool.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class AgentSessionGetTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_get';
+
+    protected string $description = 'Fetch a single AgentSession with metadata and counts. Returns workspace_contract_snapshot and event statistics.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'session_id' => $schema->string()->description('AgentSession UUID')->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate(['session_id' => 'required|string']);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $session = AgentSession::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['session_id']);
+        if (! $session) {
+            return $this->notFoundError('agent_session');
+        }
+
+        return Response::json([
+            'id' => $session->id,
+            'team_id' => $session->team_id,
+            'agent_id' => $session->agent_id,
+            'experiment_id' => $session->experiment_id,
+            'crew_execution_id' => $session->crew_execution_id,
+            'user_id' => $session->user_id,
+            'status' => $session->status?->value,
+            'started_at' => $session->started_at?->toIso8601String(),
+            'ended_at' => $session->ended_at?->toIso8601String(),
+            'last_heartbeat_at' => $session->last_heartbeat_at?->toIso8601String(),
+            'last_known_sandbox_id' => $session->last_known_sandbox_id,
+            'workspace_contract_snapshot' => $session->workspace_contract_snapshot,
+            'metadata' => $session->metadata,
+            'event_count' => $session->events()->count(),
+            'last_seq' => $session->lastSeq(),
+        ]);
+    }
+}

--- a/app/Mcp/Tools/AgentSession/AgentSessionListTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionListTool.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class AgentSessionListTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_list';
+
+    protected string $description = 'List AgentSessions for the current team. Optional filter by status (pending|active|sleeping|completed|cancelled|failed) and agent_id. Returns the most recent 50.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'status' => $schema->string()
+                ->description('Filter by AgentSessionStatus value')
+                ->enum(['pending', 'active', 'sleeping', 'completed', 'cancelled', 'failed']),
+            'agent_id' => $schema->string()
+                ->description('Filter by agent UUID'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'status' => 'nullable|string',
+            'agent_id' => 'nullable|string',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $query = AgentSession::withoutGlobalScopes()->where('team_id', $teamId);
+        if (! empty($validated['status'])) {
+            $query->where('status', $validated['status']);
+        }
+        if (! empty($validated['agent_id'])) {
+            $query->where('agent_id', $validated['agent_id']);
+        }
+
+        $rows = $query->latest('created_at')->take(50)->get([
+            'id', 'agent_id', 'experiment_id', 'crew_execution_id', 'status',
+            'started_at', 'ended_at', 'last_heartbeat_at', 'last_known_sandbox_id', 'created_at',
+        ]);
+
+        return Response::json([
+            'sessions' => $rows->map(fn ($s) => [
+                'id' => $s->id,
+                'agent_id' => $s->agent_id,
+                'experiment_id' => $s->experiment_id,
+                'crew_execution_id' => $s->crew_execution_id,
+                'status' => $s->status?->value,
+                'started_at' => $s->started_at?->toIso8601String(),
+                'ended_at' => $s->ended_at?->toIso8601String(),
+                'last_heartbeat_at' => $s->last_heartbeat_at?->toIso8601String(),
+                'last_known_sandbox_id' => $s->last_known_sandbox_id,
+                'created_at' => $s->created_at?->toIso8601String(),
+            ])->all(),
+        ]);
+    }
+}

--- a/app/Mcp/Tools/AgentSession/AgentSessionSleepTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionSleepTool.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Actions\SleepAgentSessionAction;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('write')]
+class AgentSessionSleepTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_sleep';
+
+    protected string $description = 'Detach a session from its current sandbox. Status moves to Sleeping. Sandbox can die after this without losing run state — wake() rehydrates later.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'session_id' => $schema->string()->description('AgentSession UUID')->required(),
+            'reason' => $schema->string()->description('Optional reason for detaching'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+            'reason' => 'nullable|string|max:255',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $session = AgentSession::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['session_id']);
+        if (! $session) {
+            return $this->notFoundError('agent_session');
+        }
+
+        $session = app(SleepAgentSessionAction::class)
+            ->execute($session, $validated['reason'] ?? null);
+
+        return Response::json([
+            'id' => $session->id,
+            'status' => $session->status?->value,
+            'last_heartbeat_at' => $session->last_heartbeat_at?->toIso8601String(),
+        ]);
+    }
+}

--- a/app/Mcp/Tools/AgentSession/AgentSessionWakeTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionWakeTool.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Actions\WakeAgentSessionAction;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('write')]
+class AgentSessionWakeTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_wake';
+
+    protected string $description = 'Wake an AgentSession from any prior state (Pending|Sleeping). Returns SessionContext (recent events + workspace_contract_snapshot) so a fresh sandbox can rehydrate without losing prior state. Records a Wake event in the log.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'session_id' => $schema->string()->description('AgentSession UUID')->required(),
+            'sandbox_id' => $schema->string()->description('Optional sandbox identifier waking the session'),
+            'recent_event_limit' => $schema->integer()->description('Recent events to return (default 50, max 500)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+            'sandbox_id' => 'nullable|string',
+            'recent_event_limit' => 'nullable|integer|min:1|max:500',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $session = AgentSession::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['session_id']);
+        if (! $session) {
+            return $this->notFoundError('agent_session');
+        }
+
+        $context = app(WakeAgentSessionAction::class)->execute(
+            session: $session,
+            sandboxId: $validated['sandbox_id'] ?? null,
+            recentEventLimit: (int) ($validated['recent_event_limit'] ?? 50),
+        );
+
+        return Response::json($context->toArray());
+    }
+}

--- a/app/Mcp/Tools/Crew/CrewMemberSetModelOverrideTool.php
+++ b/app/Mcp/Tools/Crew/CrewMemberSetModelOverrideTool.php
@@ -71,7 +71,7 @@ class CrewMemberSetModelOverrideTool extends Tool
 
         if ($provider !== null && $provider !== '') {
             if ($model === null || $model === '') {
-                return $this->validationError('model is required when provider is set');
+                return $this->invalidArgumentError('model is required when provider is set');
             }
             $config['model_override'] = ['provider' => $provider, 'model' => $model];
             $action = 'set';

--- a/app/Mcp/Tools/Crew/CrewMemberSetModelOverrideTool.php
+++ b/app/Mcp/Tools/Crew/CrewMemberSetModelOverrideTool.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Mcp\Tools\Crew;
+
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Crew\Models\CrewMember;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('write')]
+class CrewMemberSetModelOverrideTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'crew_member_set_model_override';
+
+    protected string $description = 'Set or clear the per-role model override for a crew member. The override applies only when the member is invoked through ProviderResolver::forCrewRole(), letting different roles (Planner, Worker, Judge) use different models. Pass provider+model to set, or omit both to clear.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'crew_id' => $schema->string()
+                ->description('Crew UUID owning the member')
+                ->required(),
+            'member_id' => $schema->string()
+                ->description('CrewMember UUID')
+                ->required(),
+            'provider' => $schema->string()
+                ->description('Provider name (anthropic, openai, google, claude-code, codex, etc). Omit to clear.'),
+            'model' => $schema->string()
+                ->description('Model identifier (e.g. claude-haiku-4-5, gpt-4o). Required when provider is set.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'crew_id' => 'required|string',
+            'member_id' => 'required|string',
+            'provider' => 'nullable|string|max:64',
+            'model' => 'nullable|string|max:128',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $crew = Crew::withoutGlobalScopes()->where('team_id', $teamId)->find($validated['crew_id']);
+        if (! $crew) {
+            return $this->notFoundError('crew');
+        }
+
+        $member = CrewMember::query()
+            ->where('crew_id', $crew->id)
+            ->where('id', $validated['member_id'])
+            ->first();
+        if (! $member) {
+            return $this->notFoundError('crew_member');
+        }
+
+        $config = $member->config ?? [];
+        $provider = $validated['provider'] ?? null;
+        $model = $validated['model'] ?? null;
+
+        if ($provider !== null && $provider !== '') {
+            if ($model === null || $model === '') {
+                return $this->validationError('model is required when provider is set');
+            }
+            $config['model_override'] = ['provider' => $provider, 'model' => $model];
+            $action = 'set';
+        } else {
+            unset($config['model_override']);
+            $action = 'cleared';
+        }
+
+        $member->update(['config' => $config]);
+
+        return Response::json([
+            'ok' => true,
+            'action' => $action,
+            'member_id' => $member->id,
+            'model_override' => $member->fresh()->model_override,
+        ]);
+    }
+}

--- a/app/Mcp/Tools/Experiment/ExperimentDoneJudgeRunTool.php
+++ b/app/Mcp/Tools/Experiment/ExperimentDoneJudgeRunTool.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Mcp\Tools\Experiment;
+
+use App\Domain\Agent\Models\AgentExecution;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Services\DoneConditionJudge;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+/**
+ * Run the Done-Condition Judge against an experiment ad-hoc, returning the
+ * verdict without applying any state transition. Useful for previewing what
+ * the gate would say before requesting a transition to Completed.
+ *
+ * Marked destructive because it incurs an LLM call (cost) and writes a
+ * verdict in the gateway's audit trail.
+ */
+#[IsDestructive]
+#[AssistantTool('write')]
+class ExperimentDoneJudgeRunTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'experiment_done_judge_run';
+
+    protected string $description = 'Run the Done-Condition Judge on an experiment without transitioning. Returns {confirmed, reasoning, missing[], next_actions[], judge_model}. Useful for previewing whether the Done-Condition Gate would accept the agent\'s "I am done" claim.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'experiment_id' => $schema->string()
+                ->description('Experiment UUID')
+                ->required(),
+            'evidence' => $schema->string()
+                ->description('Optional evidence text. When omitted, the recent stage outputs are used.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'experiment_id' => 'required|string',
+            'evidence' => 'nullable|string',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $experiment = Experiment::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['experiment_id']);
+        if (! $experiment) {
+            return $this->notFoundError('experiment');
+        }
+
+        $features = $this->resolveFeatures($experiment);
+        if ($features === []) {
+            return Response::json([
+                'experiment_id' => $experiment->id,
+                'skipped' => true,
+                'reason' => 'no workspace_contract feature-list found on any agent execution for this experiment',
+            ]);
+        }
+
+        $evidence = $validated['evidence'] ?? null;
+        $judge = app(DoneConditionJudge::class);
+        $verdict = $judge->evaluate($experiment, $features, $evidence ?? ['note' => 'evidence omitted from MCP call']);
+
+        return Response::json([
+            'experiment_id' => $experiment->id,
+            'verdict' => $verdict->toArray(),
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function resolveFeatures(Experiment $experiment): array
+    {
+        $latest = AgentExecution::query()
+            ->where('experiment_id', $experiment->id)
+            ->whereNotNull('workspace_contract')
+            ->latest('updated_at')
+            ->first();
+        if (! $latest) {
+            return [];
+        }
+        $jsonStr = $latest->workspace_contract['feature_list_json'] ?? null;
+        if (! is_string($jsonStr)) {
+            return [];
+        }
+        $decoded = json_decode($jsonStr, true);
+
+        return is_array($decoded) && is_array($decoded['features'] ?? null) ? $decoded['features'] : [];
+    }
+}

--- a/app/Mcp/Tools/GitRepository/RepoTestRatchetCheckTool.php
+++ b/app/Mcp/Tools/GitRepository/RepoTestRatchetCheckTool.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Mcp\Tools\GitRepository;
+
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\TestRatchetGuard;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class RepoTestRatchetCheckTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'repo_test_ratchet_check';
+
+    protected string $description = 'Inspect a proposed change set for test-deletion or assertion-removal patterns (anti-cheat). Returns a verdict { violation, deleted_test_files, modified_test_files, removed_assertion_count, reason } without applying the change. Pure read tool — useful for previewing what GatedGitClient would block.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'repo_id' => $schema->string()
+                ->description('GitRepository UUID')
+                ->required(),
+            'changes' => $schema->array()
+                ->description('Array of {path, mode, content?, content_before?} change descriptors')
+                ->items($schema->object()->properties([
+                    'path' => $schema->string()->required(),
+                    'mode' => $schema->string()->enum(['add', 'modify', 'delete']),
+                    'content' => $schema->string(),
+                    'content_before' => $schema->string(),
+                ]))
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'repo_id' => 'required|string',
+            'changes' => 'required|array',
+            'changes.*.path' => 'required|string',
+            'changes.*.mode' => 'nullable|string|in:add,modify,delete',
+            'changes.*.content' => 'nullable|string',
+            'changes.*.content_before' => 'nullable|string',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $repo = GitRepository::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['repo_id']);
+        if (! $repo) {
+            return $this->notFoundError('git_repository');
+        }
+
+        /** @var list<array{path: string, mode?: string, content?: string|null, content_before?: string|null}> $changes */
+        $changes = $validated['changes'];
+        $verdict = app(TestRatchetGuard::class)->inspect($changes);
+
+        return Response::json([
+            'repo_id' => $repo->id,
+            'mode' => $repo->config['test_ratchet_mode'] ?? 'soft',
+            'verdict' => $verdict->toArray(),
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -429,6 +429,12 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(AgentExecuted::class, BroadcastAgentExecuted::class);
         Event::listen(ExperimentTransitioned::class, BroadcastExperimentTransitioned::class);
 
+        // AgentSession event log — funnel existing experiment transitions into the session log
+        Event::listen(
+            ExperimentTransitioned::class,
+            \App\Domain\AgentSession\Listeners\MirrorExperimentTransition::class,
+        );
+
         // ActionProposal auto-execute on approval — dispatches a queued job
         Event::listen(ActionProposalApproved::class, DispatchActionProposalExecution::class);
 

--- a/database/factories/Domain/Crew/CrewMemberFactory.php
+++ b/database/factories/Domain/Crew/CrewMemberFactory.php
@@ -43,4 +43,9 @@ class CrewMemberFactory extends Factory
     {
         return $this->state(['role' => CrewMemberRole::OutputReviewer]);
     }
+
+    public function judge(): static
+    {
+        return $this->state(['role' => CrewMemberRole::Judge]);
+    }
 }

--- a/database/migrations/2026_05_03_180000_add_workspace_contract_to_agent_executions.php
+++ b/database/migrations/2026_05_03_180000_add_workspace_contract_to_agent_executions.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agent_executions', function (Blueprint $table) {
+            // Stores AGENTS.md / feature-list.json / progress.md / init.sh as a snapshot
+            // so we can rehydrate the workspace on the next sandbox boot.
+            $table->jsonb('workspace_contract')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agent_executions', function (Blueprint $table) {
+            $table->dropColumn('workspace_contract');
+        });
+    }
+};

--- a/database/migrations/2026_05_03_180001_add_judge_verdict_to_experiment_state_transitions.php
+++ b/database/migrations/2026_05_03_180001_add_judge_verdict_to_experiment_state_transitions.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('experiment_state_transitions', function (Blueprint $table) {
+            // Stores DoneVerdict from DoneConditionJudge when the gate runs.
+            // Null means the gate was disabled or not applicable to this transition.
+            $table->jsonb('judge_verdict')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('experiment_state_transitions', function (Blueprint $table) {
+            $table->dropColumn('judge_verdict');
+        });
+    }
+};

--- a/database/migrations/2026_05_03_180002_create_agent_sessions_table.php
+++ b/database/migrations/2026_05_03_180002_create_agent_sessions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_sessions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('team_id')->index();
+            $table->uuid('agent_id')->nullable()->index();
+            $table->uuid('experiment_id')->nullable()->index();
+            $table->uuid('crew_execution_id')->nullable()->index();
+            $table->uuid('user_id')->nullable();
+            $table->string('status', 32)->default('pending')->index();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('ended_at')->nullable();
+            $table->timestamp('last_heartbeat_at')->nullable();
+            $table->jsonb('workspace_contract_snapshot')->nullable();
+            $table->string('last_known_sandbox_id', 64)->nullable();
+            $table->jsonb('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['team_id', 'status']);
+            $table->index(['team_id', 'agent_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_sessions');
+    }
+};

--- a/database/migrations/2026_05_03_180003_create_agent_session_events_table.php
+++ b/database/migrations/2026_05_03_180003_create_agent_session_events_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_session_events', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('team_id')->index();
+            $table->uuid('session_id');
+            $table->bigInteger('seq');
+            $table->string('kind', 32);
+            $table->jsonb('payload')->nullable();
+            $table->timestamp('created_at');
+
+            $table->unique(['session_id', 'seq']);
+            $table->index(['session_id', 'created_at']);
+            $table->index(['team_id', 'kind']);
+
+            $table->foreign('session_id')
+                ->references('id')->on('agent_sessions')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_session_events');
+    }
+};

--- a/tests/Feature/Domain/Agent/WorkspaceContractTest.php
+++ b/tests/Feature/Domain/Agent/WorkspaceContractTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Domain\Agent;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Agent\Models\AgentExecution;
+use App\Domain\Agent\Services\SandboxedWorkspace;
+use App\Domain\Agent\Services\WorkspaceContractWriter;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class WorkspaceContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $sandboxBase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sandboxBase = sys_get_temp_dir().'/fleetq-test-sandboxes-'.Str::uuid7();
+        @mkdir($this->sandboxBase, 0o700, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->sandboxBase)) {
+            File::deleteDirectory($this->sandboxBase);
+        }
+        parent::tearDown();
+    }
+
+    public function test_prepare_writes_four_files_into_sandbox(): void
+    {
+        $execution = $this->makeExecution();
+        $sandbox = new SandboxedWorkspace($execution->id, $execution->agent_id, $execution->team_id, $this->sandboxBase);
+
+        $writer = app(WorkspaceContractWriter::class);
+        $snapshot = $writer->prepare($execution, $sandbox);
+
+        foreach (['AGENTS.md', 'feature-list.json', 'progress.md', 'init.sh'] as $file) {
+            $this->assertFileExists($sandbox->resolve($file));
+        }
+
+        $this->assertStringContainsString('AGENTS.md', $snapshot->agentsMd);
+        $this->assertStringContainsString('feature-list.json', $snapshot->agentsMd);
+
+        $features = json_decode($snapshot->featureListJson, true);
+        $this->assertIsArray($features);
+        $this->assertSame($execution->id, $features['execution_id']);
+        $this->assertNotEmpty($features['features']);
+    }
+
+    public function test_prepare_persists_snapshot_to_agent_execution(): void
+    {
+        $execution = $this->makeExecution();
+
+        app(WorkspaceContractWriter::class)->prepare($execution);
+
+        $reloaded = AgentExecution::find($execution->id);
+        $this->assertIsArray($reloaded->workspace_contract);
+        $this->assertArrayHasKey('agents_md', $reloaded->workspace_contract);
+        $this->assertArrayHasKey('feature_list_json', $reloaded->workspace_contract);
+    }
+
+    public function test_restore_or_prepare_uses_persisted_snapshot_when_present(): void
+    {
+        $execution = $this->makeExecution();
+        $execution->update(['workspace_contract' => [
+            'agents_md' => '# pinned\n',
+            'feature_list_json' => '{"pinned": true}',
+            'progress_md' => "# pinned\n",
+            'init_sh' => "#!/bin/sh\n",
+        ]]);
+
+        $snapshot = app(WorkspaceContractWriter::class)->restoreOrPrepare($execution);
+
+        $this->assertSame('# pinned\n', $snapshot->agentsMd);
+        $this->assertSame('{"pinned": true}', $snapshot->featureListJson);
+    }
+
+    public function test_append_progress_updates_persisted_snapshot(): void
+    {
+        $execution = $this->makeExecution();
+        $writer = app(WorkspaceContractWriter::class);
+        $writer->prepare($execution);
+
+        $writer->appendProgress($execution, 'ran the tests, 12 passed');
+        $writer->appendProgress($execution, 'committed and pushed');
+
+        $reloaded = AgentExecution::find($execution->id);
+        $progress = $reloaded->workspace_contract['progress_md'] ?? '';
+        $this->assertStringContainsString('ran the tests, 12 passed', $progress);
+        $this->assertStringContainsString('committed and pushed', $progress);
+    }
+
+    public function test_default_feature_uses_execution_input_as_done_criteria(): void
+    {
+        $execution = $this->makeExecution(['input' => ['goal' => 'make X work']]);
+
+        $snapshot = app(WorkspaceContractWriter::class)->prepare($execution);
+        $features = json_decode($snapshot->featureListJson, true);
+
+        $this->assertCount(1, $features['features']);
+        $this->assertSame('Primary execution goal', $features['features'][0]['title']);
+        $this->assertSame(['goal' => 'make X work'], $features['features'][0]['done_criteria']);
+    }
+
+    private function makeExecution(array $overrides = []): AgentExecution
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create();
+
+        $exec = new AgentExecution([
+            'agent_id' => $agent->id,
+            'team_id' => $team->id,
+            'status' => 'running',
+            'input' => $overrides['input'] ?? ['placeholder' => true],
+        ] + $overrides);
+        $exec->save();
+
+        return $exec;
+    }
+}

--- a/tests/Feature/Domain/AgentSession/AgentSessionLifecycleTest.php
+++ b/tests/Feature/Domain/AgentSession/AgentSessionLifecycleTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Domain\AgentSession;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentSession\Actions\AppendSessionEventAction;
+use App\Domain\AgentSession\Actions\CancelAgentSessionAction;
+use App\Domain\AgentSession\Actions\CreateAgentSessionAction;
+use App\Domain\AgentSession\Actions\SleepAgentSessionAction;
+use App\Domain\AgentSession\Actions\WakeAgentSessionAction;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Listeners\MirrorExperimentTransition;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Events\ExperimentTransitioned;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AgentSessionLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_then_wake_marks_session_active_and_records_wake_event(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create();
+
+        $session = app(CreateAgentSessionAction::class)->execute(
+            teamId: $team->id,
+            agentId: $agent->id,
+        );
+        $this->assertSame(AgentSessionStatus::Pending, $session->status);
+
+        $context = app(WakeAgentSessionAction::class)->execute($session, sandboxId: 'sb-1');
+
+        $session->refresh();
+        $this->assertSame(AgentSessionStatus::Active, $session->status);
+        $this->assertSame('sb-1', $session->last_known_sandbox_id);
+        $this->assertGreaterThan(0, $context->lastSeq);
+        $this->assertNotNull(collect($context->recentEvents)->firstWhere('kind', 'wake'));
+    }
+
+    public function test_append_event_idempotent_on_duplicate_seq(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+
+        $append = app(AppendSessionEventAction::class);
+        $first = $append->execute($session, AgentSessionEventKind::Note, ['msg' => 'hi'], seq: 1);
+        $dup = $append->execute($session, AgentSessionEventKind::Note, ['msg' => 'should-not-overwrite'], seq: 1);
+
+        $this->assertSame($first->id, $dup->id);
+        $this->assertSame(1, $session->refresh()->events()->count());
+    }
+
+    public function test_sleep_marks_sleeping_and_logs_event(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        app(WakeAgentSessionAction::class)->execute($session);
+
+        app(SleepAgentSessionAction::class)->execute($session->refresh(), reason: 'detached');
+        $session->refresh();
+
+        $this->assertSame(AgentSessionStatus::Sleeping, $session->status);
+        $sleepEvent = $session->events()->where('kind', 'sleep')->first();
+        $this->assertNotNull($sleepEvent);
+        $this->assertSame('detached', $sleepEvent->payload['reason'] ?? null);
+    }
+
+    public function test_cancel_is_terminal_and_subsequent_sleep_is_noop(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+
+        app(CancelAgentSessionAction::class)->execute($session);
+        $session->refresh();
+        $this->assertSame(AgentSessionStatus::Cancelled, $session->status);
+
+        app(SleepAgentSessionAction::class)->execute($session, reason: 'should-noop');
+        $this->assertSame(AgentSessionStatus::Cancelled, $session->refresh()->status);
+    }
+
+    public function test_mirror_experiment_transition_appends_transition_event(): void
+    {
+        $team = Team::factory()->create();
+        $experiment = Experiment::factory()->for($team)->create([
+            'status' => ExperimentStatus::Executing,
+        ]);
+        $session = app(CreateAgentSessionAction::class)->execute(
+            teamId: $team->id,
+            experimentId: $experiment->id,
+        );
+        app(WakeAgentSessionAction::class)->execute($session);
+
+        $event = new ExperimentTransitioned(
+            experiment: $experiment,
+            fromState: ExperimentStatus::Executing,
+            toState: ExperimentStatus::CollectingMetrics,
+        );
+        app(MirrorExperimentTransition::class)->handle($event);
+
+        $session->refresh();
+        $transitionEvent = $session->events()->where('kind', 'transition')->first();
+        $this->assertNotNull($transitionEvent);
+        $this->assertSame('executing', $transitionEvent->payload['from_state'] ?? null);
+        $this->assertSame('collecting_metrics', $transitionEvent->payload['to_state'] ?? null);
+    }
+
+    public function test_session_scoped_to_team(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        $sessionA = app(CreateAgentSessionAction::class)->execute(teamId: $teamA->id);
+        $sessionB = app(CreateAgentSessionAction::class)->execute(teamId: $teamB->id);
+
+        $countA = AgentSession::withoutGlobalScopes()->where('team_id', $teamA->id)->count();
+        $this->assertSame(1, $countA);
+        $this->assertNotSame($sessionA->id, $sessionB->id);
+    }
+}

--- a/tests/Feature/Domain/Crew/RoleModelRoutingTest.php
+++ b/tests/Feature/Domain/Crew/RoleModelRoutingTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature\Domain\Crew;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Crew\Enums\CrewMemberRole;
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Crew\Models\CrewMember;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\Services\ProviderResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+class RoleModelRoutingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ProviderResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Use the unconditional base resolver (avoid CloudProviderResolver overrides
+        // that strip local providers).
+        $this->resolver = new ProviderResolver;
+
+        Config::set('llm.default_provider', 'anthropic');
+        Config::set('llm.default_model', 'claude-sonnet-4-5');
+    }
+
+    public function test_for_crew_role_falls_through_to_resolve_when_no_override(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create([
+            'provider' => 'anthropic',
+            'model' => 'claude-sonnet-4-5',
+        ]);
+        $coordinator = Agent::factory()->for($team)->create();
+        $qa = Agent::factory()->for($team)->create();
+        $crew = Crew::factory()->for($team)->create([
+            'coordinator_agent_id' => $coordinator->id,
+            'qa_agent_id' => $qa->id,
+        ]);
+        $member = CrewMember::factory()->for($crew)->for($agent)->create([
+            'role' => CrewMemberRole::Worker,
+            'config' => [],
+        ]);
+
+        $resolved = $this->resolver->forCrewRole($member);
+
+        $this->assertSame('anthropic', $resolved['provider']);
+        $this->assertSame('claude-sonnet-4-5', $resolved['model']);
+    }
+
+    public function test_for_crew_role_honors_model_override(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create([
+            'provider' => 'anthropic',
+            'model' => 'claude-sonnet-4-5',
+        ]);
+        $coordinator = Agent::factory()->for($team)->create();
+        $qa = Agent::factory()->for($team)->create();
+        $crew = Crew::factory()->for($team)->create([
+            'coordinator_agent_id' => $coordinator->id,
+            'qa_agent_id' => $qa->id,
+        ]);
+        $member = CrewMember::factory()->for($crew)->for($agent)->create([
+            'role' => CrewMemberRole::Judge,
+            'config' => [
+                'model_override' => [
+                    'provider' => 'anthropic',
+                    'model' => 'claude-haiku-4-5',
+                ],
+            ],
+        ]);
+
+        $resolved = $this->resolver->forCrewRole($member);
+
+        $this->assertSame('anthropic', $resolved['provider']);
+        $this->assertSame('claude-haiku-4-5', $resolved['model']);
+    }
+
+    public function test_judge_role_enum_value_persists(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create();
+        $coordinator = Agent::factory()->for($team)->create();
+        $qa = Agent::factory()->for($team)->create();
+        $crew = Crew::factory()->for($team)->create([
+            'coordinator_agent_id' => $coordinator->id,
+            'qa_agent_id' => $qa->id,
+        ]);
+        $member = CrewMember::factory()->for($crew)->for($agent)->judge()->create();
+
+        $reloaded = CrewMember::find($member->id);
+
+        $this->assertSame(CrewMemberRole::Judge, $reloaded->role);
+        $this->assertSame('judge', $reloaded->role->value);
+        $this->assertSame('Judge', $reloaded->role->label());
+    }
+
+    public function test_for_agent_in_crew_lookup(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create();
+        $coordinator = Agent::factory()->for($team)->create();
+        $qa = Agent::factory()->for($team)->create();
+        $crew = Crew::factory()->for($team)->create([
+            'coordinator_agent_id' => $coordinator->id,
+            'qa_agent_id' => $qa->id,
+        ]);
+        $member = CrewMember::factory()->for($crew)->for($agent)->qa()->create();
+
+        $found = CrewMember::forAgentInCrew($agent->id, $crew->id);
+        $this->assertNotNull($found);
+        $this->assertSame($member->id, $found->id);
+
+        $missing = CrewMember::forAgentInCrew('00000000-0000-0000-0000-000000000000', $crew->id);
+        $this->assertNull($missing);
+
+        $nullArg = CrewMember::forAgentInCrew(null, $crew->id);
+        $this->assertNull($nullArg);
+    }
+}

--- a/tests/Feature/Domain/Experiment/DoneConditionGateTest.php
+++ b/tests/Feature/Domain/Experiment/DoneConditionGateTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature\Domain\Experiment;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Agent\Models\AgentExecution;
+use App\Domain\Experiment\DTOs\DoneVerdict;
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Services\DoneConditionJudge;
+use App\Domain\Experiment\States\TransitionPrerequisiteValidator;
+use App\Domain\Project\Models\Project;
+use App\Domain\Project\Models\ProjectRun;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class DoneConditionGateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_gate_disabled_passes_through(): void
+    {
+        $experiment = $this->makeExperiment(doneGateEnabled: false);
+
+        $error = app(TransitionPrerequisiteValidator::class)
+            ->validate($experiment, ExperimentStatus::Completed);
+
+        $this->assertNull($error);
+    }
+
+    public function test_no_features_means_no_judge_invocation(): void
+    {
+        $experiment = $this->makeExperiment(doneGateEnabled: true);
+
+        // No agent_execution → no feature list → gate is a no-op
+        $judgeMock = Mockery::mock(DoneConditionJudge::class);
+        $judgeMock->shouldNotReceive('evaluate');
+        $this->app->instance(DoneConditionJudge::class, $judgeMock);
+
+        $error = app(TransitionPrerequisiteValidator::class)
+            ->validate($experiment, ExperimentStatus::Completed);
+
+        $this->assertNull($error);
+    }
+
+    public function test_judge_confirms_passes(): void
+    {
+        $experiment = $this->makeExperiment(doneGateEnabled: true);
+        $this->seedFeatureList($experiment);
+
+        $judgeMock = Mockery::mock(DoneConditionJudge::class);
+        $judgeMock->shouldReceive('evaluate')
+            ->once()
+            ->andReturn(new DoneVerdict(
+                confirmed: true,
+                reasoning: 'all criteria met',
+                missing: [],
+                nextActions: [],
+                judgeModel: 'claude-haiku-4-5',
+            ));
+        $this->app->instance(DoneConditionJudge::class, $judgeMock);
+
+        $validator = app(TransitionPrerequisiteValidator::class);
+        $error = $validator->validate($experiment, ExperimentStatus::Completed);
+
+        $this->assertNull($error);
+        $this->assertNotNull($validator->lastJudgeVerdict);
+        $this->assertTrue($validator->lastJudgeVerdict->confirmed);
+    }
+
+    public function test_judge_denies_blocks(): void
+    {
+        $experiment = $this->makeExperiment(doneGateEnabled: true);
+        $this->seedFeatureList($experiment);
+
+        $judgeMock = Mockery::mock(DoneConditionJudge::class);
+        $judgeMock->shouldReceive('evaluate')->once()->andReturn(new DoneVerdict(
+            confirmed: false,
+            reasoning: 'tests not run',
+            missing: ['test output', 'deploy URL'],
+            nextActions: ['run phpunit', 'curl /health'],
+            judgeModel: 'claude-haiku-4-5',
+        ));
+        $this->app->instance(DoneConditionJudge::class, $judgeMock);
+
+        $validator = app(TransitionPrerequisiteValidator::class);
+        $error = $validator->validate($experiment, ExperimentStatus::Completed);
+
+        $this->assertNotNull($error);
+        $this->assertStringContainsString('Done-Condition Gate denied', $error);
+        $this->assertStringContainsString('tests not run', $error);
+        $this->assertNotNull($validator->lastJudgeVerdict);
+        $this->assertFalse($validator->lastJudgeVerdict->confirmed);
+    }
+
+    public function test_kill_switch_bypasses_gate(): void
+    {
+        $experiment = $this->makeExperiment(doneGateEnabled: true, killSwitch: true);
+        $this->seedFeatureList($experiment);
+
+        $judgeMock = Mockery::mock(DoneConditionJudge::class);
+        $judgeMock->shouldNotReceive('evaluate');
+        $this->app->instance(DoneConditionJudge::class, $judgeMock);
+
+        $error = app(TransitionPrerequisiteValidator::class)
+            ->validate($experiment, ExperimentStatus::Completed);
+
+        $this->assertNull($error);
+    }
+
+    private function makeExperiment(bool $doneGateEnabled, bool $killSwitch = false): Experiment
+    {
+        $team = Team::factory()->create();
+
+        return Experiment::factory()->for($team)->create([
+            'status' => ExperimentStatus::Executing,
+            'constraints' => [
+                'done_gate_enabled' => $doneGateEnabled,
+                'done_gate_kill_switch' => $killSwitch,
+            ],
+        ]);
+    }
+
+    private function seedFeatureList(Experiment $experiment): void
+    {
+        $agent = Agent::factory()->for($experiment->team)->create();
+        $exec = new AgentExecution([
+            'agent_id' => $agent->id,
+            'team_id' => $experiment->team_id,
+            'experiment_id' => $experiment->id,
+            'status' => 'completed',
+            'input' => ['placeholder' => true],
+            'workspace_contract' => [
+                'agents_md' => '',
+                'feature_list_json' => json_encode([
+                    'features' => [
+                        ['id' => '1', 'title' => 'X', 'done_criteria' => 'tests pass', 'status' => 'pending'],
+                    ],
+                ]),
+                'progress_md' => '',
+                'init_sh' => '',
+            ],
+        ]);
+        $exec->save();
+    }
+}

--- a/tests/Feature/Domain/GitRepository/TestRatchetGuardTest.php
+++ b/tests/Feature/Domain/GitRepository/TestRatchetGuardTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Domain\GitRepository;
+
+use App\Domain\GitRepository\Services\TestRatchetGuard;
+use Tests\TestCase;
+
+class TestRatchetGuardTest extends TestCase
+{
+    private TestRatchetGuard $guard;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->guard = new TestRatchetGuard;
+    }
+
+    public function test_clean_diff_against_non_test_files_passes(): void
+    {
+        $verdict = $this->guard->inspect([
+            ['path' => 'src/Foo.php', 'mode' => 'modify', 'content' => "<?php class Foo {}\n"],
+            ['path' => 'README.md', 'mode' => 'modify', 'content' => "# Foo\n"],
+        ]);
+
+        $this->assertFalse($verdict->violation);
+        $this->assertSame('no test files affected', $verdict->reason);
+    }
+
+    public function test_deleted_phpunit_test_file_is_violation(): void
+    {
+        $verdict = $this->guard->inspect([
+            ['path' => 'tests/Feature/Domain/Foo/FooTest.php', 'mode' => 'delete'],
+            ['path' => 'src/Foo.php', 'mode' => 'modify', 'content' => '<?php'],
+        ]);
+
+        $this->assertTrue($verdict->violation);
+        $this->assertSame(['tests/Feature/Domain/Foo/FooTest.php'], $verdict->deletedTestFiles);
+        $this->assertStringContainsString('1 test file(s) deleted', $verdict->reason);
+    }
+
+    public function test_modification_that_removes_three_assertions_is_violation(): void
+    {
+        $before = "    public function test_x() {\n        \$this->assertTrue(true);\n        \$this->assertSame(1, 1);\n        \$this->assertNull(null);\n        \$this->assertCount(0, []);\n    }\n";
+        $after = "    public function test_x() {\n        \$this->assertTrue(true);\n    }\n";
+
+        $verdict = $this->guard->inspect([
+            ['path' => 'tests/Unit/X/XTest.php', 'mode' => 'modify', 'content' => $after, 'content_before' => $before],
+        ]);
+
+        $this->assertTrue($verdict->violation);
+        $this->assertSame(['tests/Unit/X/XTest.php'], $verdict->modifiedTestFiles);
+        $this->assertGreaterThanOrEqual(3, $verdict->removedAssertionCount);
+    }
+
+    public function test_jest_spec_deletion_is_violation(): void
+    {
+        $verdict = $this->guard->inspect([
+            ['path' => 'src/__tests__/utils.spec.ts', 'mode' => 'delete'],
+        ]);
+
+        $this->assertTrue($verdict->violation);
+        $this->assertSame(['src/__tests__/utils.spec.ts'], $verdict->deletedTestFiles);
+    }
+
+    public function test_modifying_test_to_add_assertions_is_not_violation(): void
+    {
+        $before = "    public function test_x() { \$this->assertTrue(true); }\n";
+        $after = "    public function test_x() {\n        \$this->assertTrue(true);\n        \$this->assertSame(1, 1);\n    }\n";
+
+        $verdict = $this->guard->inspect([
+            ['path' => 'tests/Unit/X/XTest.php', 'mode' => 'modify', 'content' => $after, 'content_before' => $before],
+        ]);
+
+        $this->assertFalse($verdict->violation);
+    }
+}


### PR DESCRIPTION
## Summary

Five patterns borrowed from [Addy Osmani's *Long Running Agents*](https://addyosmani.com/blog/long-running-agents/) — anti-cheat, anti-premature-stop, role-specific model routing, workspace contract, and a session event log.

Source research and unified design live on the parent: `claudedocs/research_long_running_agents_2026-05-03.md`, `docs/plans/2026-05-03-001-long-running-agents-design.md`.

## What Shipped

| Gap | Pattern | New surface |
|---|---|---|
| **D** | Role-specific model routing | `CrewMemberRole::Judge`, `CrewMember.config.model_override`, `ProviderResolver::forCrewRole()` wired through 4 crew callsites. MCP `crew_member_set_model_override`. |
| **C** | Test Ratchet anti-cheat | `TestRatchetGuard` (test-file deletion + assertion-removal heuristics), modes `off`/`soft`/`hard` on `GitRepository.config.test_ratchet_mode`, hooked into `GatedGitClient`. MCP `repo_test_ratchet_check`. |
| **A** | Workspace contract | `WorkspaceContractWriter` materializes `AGENTS.md` + `feature-list.json` + `progress.md` + `init.sh` into the sandbox AND persists snapshot to `agent_executions.workspace_contract`. New `BuiltInToolKind::ProgressAppend`. MCP `agent_workspace_contract_get`. |
| **B** | Done-Condition Gate | `DoneConditionJudge` (Haiku 4.5 default) re-validates "I'm done" against externalized criteria. New transition prerequisite for `Completed`; verdict persisted on `experiment_state_transitions.judge_verdict`. Opt-in via `experiment.constraints.done_gate_enabled` or `project.settings`. MCP `experiment_done_judge_run`. |
| **E** | AgentSession domain (#39) | New `agent_sessions` + `agent_session_events` tables. Actions: Create / Append / Wake / Sleep / Cancel. `MirrorExperimentTransition` listener funnels existing `ExperimentTransitioned` events without touching the Experiment domain. 5 MCP tools: list / get / events / wake / sleep. |

## Files

- 4 migrations
- 1 new domain (AgentSession) — 8 PHP files
- 12 new MCP tools (12 registrations + use-statements added in `AgentFleetServer`)
- 1 enum extended (`CrewMemberRole::Judge`, `BuiltInToolKind::ProgressAppend`)
- 16 modified files (model casts, action wiring, listener registration, factory)
- 5 new test files — **25 tests, 70 assertions, all green**

## Defaults Applied

- Workspace file is `AGENTS.md` (Anthropic convention — interop with local Claude Code sessions)
- Done-Condition Judge defaults to Haiku 4.5 (override per-Crew or per-Project)
- AgentSession retention is plan-driven (uses existing `audit_retention_days` infra; cleanup command deferred)
- Replay/handoff/drift-monitor are **deferred** (Phase 4-5 in research's recommended sprint plan)

## Regression Status

| Suite | Result |
|---|---|
| Crew + Experiment + Agent | 171 passed |
| MCP | 178 passed |
| AgentSession + Approval + GitRepository | 84 passed |
| ToolAnnotationCoverage gate | 1 passed |
| Pint --dirty | clean |

## Test plan

- [x] Run new suites locally (25 / 25 green)
- [x] Run broader regression (Crew/Experiment/Agent/MCP/Approval/GitRepository — 433 / 433 green)
- [x] Confirm MCP annotation gate (`#[IsReadOnly]` / `#[IsDestructive]`) holds
- [x] `pint --dirty --format agent` clean
- [ ] CI: tests + quality + build (will run on push)
- [ ] Smoke-test on prod after merge: `agent_session_list` + `crew_member_set_model_override` via MCP

## Out of scope (deferred follow-ups)

- Agent Simulator (Replay engine)
- Local↔Cloud session handoff UX
- Memory Drift Monitor
- METR Time-Horizon Dashboard
- Per-agent capability ACLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)