### PR TITLE
feat: close 6 deferred gaps from long-running-agents sprint

### DIFF
--- a/app/Console/Commands/CleanupAgentSessionEvents.php
+++ b/app/Console/Commands/CleanupAgentSessionEvents.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\AgentSession\Models\AgentSessionEvent;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class CleanupAgentSessionEvents extends Command
+{
+    protected $signature = 'agent-session-events:cleanup
+        {--days=90 : Number of days to retain agent session events}
+        {--dry-run : Only count rows that would be deleted, do not delete}
+        {--chunk=1000 : Rows deleted per loop iteration}';
+
+    protected $description = 'Delete agent_session_events older than the retention period and remove orphaned terminal sessions whose events are all gone.';
+
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+        if ($days < 1) {
+            $this->error('--days must be >= 1');
+
+            return self::FAILURE;
+        }
+
+        $cutoff = now()->subDays($days);
+        $chunk = max(1, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $eventsDeleted = $this->cleanupEvents($cutoff, $chunk, $dryRun);
+        $this->info(($dryRun ? '[dry-run] ' : '')."Removed {$eventsDeleted} agent_session_events older than {$days} days.");
+
+        $sessionsDeleted = $this->cleanupOrphanTerminalSessions($cutoff, $dryRun);
+        $this->info(($dryRun ? '[dry-run] ' : '')."Removed {$sessionsDeleted} orphan terminal agent_sessions.");
+
+        return self::SUCCESS;
+    }
+
+    private function cleanupEvents(Carbon $cutoff, int $chunk, bool $dryRun): int
+    {
+        if ($dryRun) {
+            return AgentSessionEvent::withoutGlobalScopes()
+                ->where('created_at', '<', $cutoff)
+                ->count();
+        }
+
+        $totalDeleted = 0;
+        do {
+            $deleted = AgentSessionEvent::withoutGlobalScopes()
+                ->where('created_at', '<', $cutoff)
+                ->limit($chunk)
+                ->delete();
+            $totalDeleted += $deleted;
+        } while ($deleted > 0);
+
+        return $totalDeleted;
+    }
+
+    private function cleanupOrphanTerminalSessions(Carbon $cutoff, bool $dryRun): int
+    {
+        $terminalStatuses = [
+            AgentSessionStatus::Completed->value,
+            AgentSessionStatus::Cancelled->value,
+            AgentSessionStatus::Failed->value,
+        ];
+
+        $query = AgentSession::withoutGlobalScopes()
+            ->whereIn('status', $terminalStatuses)
+            ->where('ended_at', '<', $cutoff)
+            ->whereDoesntHave('events');
+
+        if ($dryRun) {
+            return $query->count();
+        }
+
+        return $query->delete();
+    }
+}

--- a/app/Domain/Agent/Actions/ExecuteAgentAction.php
+++ b/app/Domain/Agent/Actions/ExecuteAgentAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Agent\Actions;
 
+use App\Domain\Agent\DTOs\WorkspaceContractSnapshot;
 use App\Domain\Agent\Enums\AgentHookPosition;
 use App\Domain\Agent\Enums\AgentReasoningStrategy;
 use App\Domain\Agent\Enums\AgentStatus;
@@ -27,6 +28,7 @@ use App\Domain\Agent\Services\AgentPromptCompiler;
 use App\Domain\Agent\Services\AgentRuntimeStateService;
 use App\Domain\Agent\Services\SandboxedWorkspace;
 use App\Domain\Agent\Services\ToolRecoveryOrchestrator;
+use App\Domain\Agent\Services\WorkspaceContractWriter;
 use App\Domain\Approval\Enums\ApprovalStatus;
 use App\Domain\Approval\Models\ApprovalRequest;
 use App\Domain\Credential\Actions\ResolveProjectCredentialsAction;
@@ -76,7 +78,15 @@ class ExecuteAgentAction
         private readonly AgentPromptCompiler $promptCompiler,
         private readonly ToolRecoveryOrchestrator $toolRecovery,
         private readonly SchemaValidator $schemaValidator,
+        private readonly WorkspaceContractWriter $workspaceContractWriter,
     ) {}
+
+    /**
+     * Workspace contract built once per execute() call and reused by every
+     * AgentExecution::create() callsite plus the post-success progress append.
+     * Reset to null after execute() returns.
+     */
+    private ?WorkspaceContractSnapshot $currentWorkspaceContract = null;
 
     /**
      * Validate an agent's final output against its `output_schema` JSONB, if
@@ -234,12 +244,19 @@ class ExecuteAgentAction
             ])
             ->thenReturn();
 
+        // Use the (potentially summarized) input going forward
+        $input = $ctx->input;
+
+        // Build workspace contract once for this execute() call. Stored on the
+        // instance so every AgentExecution::create() callsite below — including
+        // requestClarification — can attach it without threading a parameter
+        // through method signatures.
+        $this->currentWorkspaceContract = $this->workspaceContractWriter
+            ->buildSnapshotForExecution($agent, $experimentId, $project, $input);
+
         if ($ctx->requiresClarification) {
             return $this->requestClarification($ctx, $stepId);
         }
-
-        // Use the (potentially summarized) input going forward
-        $input = $ctx->input;
 
         // Workflow-driven execution: if input has a 'task' key (from workflow node prompt),
         // execute directly with LLM instead of skill chain
@@ -266,6 +283,26 @@ class ExecuteAgentAction
             );
 
             $tools = $this->resolveTools->execute($agent, $project, $sandboxId, $sidecarSessionId, $currentDepth, $userId, $semanticQuery, $allowedToolIds);
+
+            // Materialize the workspace contract files into the sandbox before the
+            // LLM tool-loop starts so the agent can read AGENTS.md / feature-list.json /
+            // progress.md / init.sh from disk via filesystem tools. Best-effort —
+            // failure is logged, never raised. currentWorkspaceContract is always
+            // populated by this point (set right after pipeline middleware above).
+            if ($agent->team_id) {
+                try {
+                    $this->workspaceContractWriter->materializeSnapshot(
+                        new SandboxedWorkspace($sandboxId, $agent->id, $agent->team_id),
+                        $this->currentWorkspaceContract,
+                    );
+                } catch (\Throwable $e) {
+                    Log::warning('WorkspaceContract materialize failed', [
+                        'sandbox_id' => $sandboxId,
+                        'agent_id' => $agent->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
 
             if (! empty($tools)) {
                 try {
@@ -297,6 +334,25 @@ class ExecuteAgentAction
 
         // Plugin hook: notify plugins of execution result
         event(new AgentExecuted($agent, $result['execution'], $result['output'] !== null));
+
+        // Best-effort: log a single progress line summarising the run. Never
+        // raised — progress is observability, not a hard dependency.
+        if ($result['execution'] instanceof AgentExecution) {
+            try {
+                $status = $result['execution']->status;
+                $note = "Run {$result['execution']->id} ".(
+                    $result['output'] !== null ? "completed (status={$status})" : "ended without output (status={$status})"
+                );
+                $this->workspaceContractWriter->appendProgress($result['execution'], $note);
+            } catch (\Throwable $e) {
+                Log::warning('WorkspaceContract appendProgress failed', [
+                    'execution_id' => $result['execution']->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $this->currentWorkspaceContract = null;
 
         return $result;
     }
@@ -439,6 +495,7 @@ class ExecuteAgentAction
                     'tier' => $tierConfig['tier']->value,
                     'semantic_loop_max_repeat' => $semanticMaxRepeat >= $semanticWarn ? $semanticMaxRepeat : null,
                 ]),
+                'workspace_contract' => $this->currentWorkspaceContract?->toArray(),
             ]);
 
             $this->runtimeStateService->recordExecution($agent, $response->usage);
@@ -483,6 +540,7 @@ class ExecuteAgentAction
                 'duration_ms' => $durationMs,
                 'cost_credits' => $costCredits,
                 'quality_details' => ['result_as_answer' => true],
+                'workspace_contract' => $this->currentWorkspaceContract?->toArray(),
             ]);
 
             return [
@@ -651,6 +709,7 @@ class ExecuteAgentAction
                 'duration_ms' => $durationMs,
                 'cost_credits' => $costCredits,
                 'quality_details' => $qualityDetails,
+                'workspace_contract' => $this->currentWorkspaceContract?->toArray(),
             ]);
 
             $this->runtimeStateService->recordExecution($agent, $response->usage);
@@ -959,6 +1018,7 @@ class ExecuteAgentAction
                 'skills_executed' => $skillResults,
                 'duration_ms' => $durationMs,
                 'cost_credits' => $totalCost,
+                'workspace_contract' => $this->currentWorkspaceContract?->toArray(),
             ]);
 
             ExtractMemoryJob::dispatch($agent->id, $teamId, $execution->id)
@@ -1053,6 +1113,7 @@ class ExecuteAgentAction
             'output' => ['awaiting_clarification' => true, 'question' => $question],
             'duration_ms' => 0,
             'cost_credits' => 0,
+            'workspace_contract' => $this->currentWorkspaceContract?->toArray(),
         ]);
 
         return [
@@ -1086,6 +1147,7 @@ class ExecuteAgentAction
             'duration_ms' => $durationMs,
             'cost_credits' => $costCredits,
             'error_message' => $errorMessage,
+            'workspace_contract' => $this->currentWorkspaceContract?->toArray(),
         ]);
 
         return [

--- a/app/Domain/Agent/Services/WorkspaceContractWriter.php
+++ b/app/Domain/Agent/Services/WorkspaceContractWriter.php
@@ -40,20 +40,92 @@ class WorkspaceContractWriter
         $workflow = $this->resolveWorkflow($execution);
         $project = $this->resolveProject($execution);
 
-        $snapshot = new WorkspaceContractSnapshot(
-            agentsMd: $this->buildAgentsMd($agent, $execution, $project),
-            featureListJson: $this->buildFeatureListJson($execution, $workflow, $project),
-            progressMd: $this->buildProgressMd($execution),
-            initSh: $this->buildInitSh($agent),
+        $snapshot = $this->buildSnapshot(
+            agent: $agent,
+            workflow: $workflow,
+            project: $project,
+            executionContext: [
+                'execution_id' => $execution->id,
+                'agent_id' => $execution->agent_id,
+                'created_at' => $execution->created_at?->toIso8601String(),
+                'input' => $execution->input,
+            ],
         );
 
         if ($sandbox !== null) {
-            $this->materialize($sandbox, $snapshot);
+            $this->materializeSnapshot($sandbox, $snapshot);
         }
 
         $execution->update(['workspace_contract' => $snapshot->toArray()]);
 
         return $snapshot;
+    }
+
+    /**
+     * Build a snapshot without persisting or materializing.
+     *
+     * Used by call sites that want the contract built upfront — before an
+     * AgentExecution row exists — so it can be (a) materialized to a sandbox
+     * for the LLM tool-loop to read, and (b) stored on the eventual
+     * AgentExecution row when the run record is created.
+     *
+     * @param  array{execution_id?: string|null, agent_id?: string|null, created_at?: string|null, input?: mixed}  $executionContext
+     */
+    public function buildSnapshot(
+        ?Agent $agent,
+        ?Workflow $workflow,
+        ?Project $project,
+        array $executionContext = [],
+    ): WorkspaceContractSnapshot {
+        return new WorkspaceContractSnapshot(
+            agentsMd: $this->buildAgentsMdFromContext($agent, $executionContext, $project),
+            featureListJson: $this->buildFeatureListJsonFromContext($executionContext, $workflow, $project),
+            progressMd: $this->buildProgressMdFromContext($executionContext),
+            initSh: $this->buildInitSh($agent),
+        );
+    }
+
+    /**
+     * Write a snapshot's 4 files into a sandbox without touching the DB.
+     */
+    public function materializeSnapshot(SandboxedWorkspace $sandbox, WorkspaceContractSnapshot $snapshot): void
+    {
+        $this->materialize($sandbox, $snapshot);
+    }
+
+    /**
+     * Convenience for ExecuteAgentAction: resolves the optional Workflow from
+     * an experimentId and delegates to buildSnapshot(). Avoids leaking
+     * resolveWorkflow/resolveProject internals into action code.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function buildSnapshotForExecution(
+        Agent $agent,
+        ?string $experimentId,
+        ?Project $project,
+        array $input,
+    ): WorkspaceContractSnapshot {
+        $workflow = null;
+        if (is_string($experimentId) && $experimentId !== '') {
+            $experiment = Experiment::withoutGlobalScopes()->find($experimentId);
+            $workflowId = $experiment?->workflow_id;
+            if (is_string($workflowId) && $workflowId !== '') {
+                $workflow = Workflow::withoutGlobalScopes()->find($workflowId);
+            }
+        }
+
+        return $this->buildSnapshot(
+            agent: $agent,
+            workflow: $workflow,
+            project: $project,
+            executionContext: [
+                'execution_id' => null,
+                'agent_id' => $agent->id,
+                'created_at' => null,
+                'input' => $input,
+            ],
+        );
     }
 
     /**
@@ -106,7 +178,10 @@ class WorkspaceContractWriter
         @chmod($initPath, 0o755);
     }
 
-    private function buildAgentsMd(?Agent $agent, AgentExecution $execution, ?Project $project): string
+    /**
+     * @param  array{execution_id?: string|null, agent_id?: string|null, created_at?: string|null, input?: mixed}  $context
+     */
+    private function buildAgentsMdFromContext(?Agent $agent, array $context, ?Project $project): string
     {
         $name = $agent?->name ?? 'Agent';
         $role = $agent?->role ?? 'Generalist';
@@ -124,6 +199,8 @@ class WorkspaceContractWriter
         }
 
         $rulesBlock = collect($rules)->map(fn ($r) => "- $r")->implode("\n");
+        $executionId = (string) ($context['execution_id'] ?? '(pending)');
+        $startedAt = (string) ($context['created_at'] ?? Carbon::now()->toIso8601String());
 
         return <<<MD
         # AGENTS.md
@@ -146,13 +223,16 @@ class WorkspaceContractWriter
 
         ## Execution
 
-        - id: {$execution->id}
-        - started_at: {$execution->created_at?->toIso8601String()}
+        - id: {$executionId}
+        - started_at: {$startedAt}
 
         MD;
     }
 
-    private function buildFeatureListJson(AgentExecution $execution, ?Workflow $workflow, ?Project $project): string
+    /**
+     * @param  array{execution_id?: string|null, agent_id?: string|null, input?: mixed}  $context
+     */
+    private function buildFeatureListJsonFromContext(array $context, ?Workflow $workflow, ?Project $project): string
     {
         $features = [];
 
@@ -186,24 +266,29 @@ class WorkspaceContractWriter
             $features[] = [
                 'id' => Str::uuid7()->toString(),
                 'title' => 'Primary execution goal',
-                'done_criteria' => $execution->input ?? null,
+                'done_criteria' => $context['input'] ?? null,
                 'status' => 'pending',
             ];
         }
 
         return json_encode([
-            'execution_id' => $execution->id,
-            'agent_id' => $execution->agent_id,
+            'execution_id' => $context['execution_id'] ?? null,
+            'agent_id' => $context['agent_id'] ?? null,
             'features' => $features,
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     }
 
-    private function buildProgressMd(AgentExecution $execution): string
+    /**
+     * @param  array{execution_id?: string|null}  $context
+     */
+    private function buildProgressMdFromContext(array $context): string
     {
+        $executionId = (string) ($context['execution_id'] ?? '(pending)');
+
         return <<<MD
         # progress.md
 
-        Rolling iteration log for execution `{$execution->id}`.
+        Rolling iteration log for execution `{$executionId}`.
 
         ## Iteration log
 

--- a/app/Domain/AgentSession/Actions/HandoffAgentSessionAction.php
+++ b/app/Domain/AgentSession/Actions/HandoffAgentSessionAction.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Domain\AgentSession\Actions;
+
+use App\Domain\Agent\Enums\AgentStatus;
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Hand off an active or sleeping session from one agent to another within the
+ * same team. Source is paused (Sleeping); a new target session is created
+ * carrying the workspace contract snapshot forward. Both sides emit a single
+ * mirrored event so audit trails on either session reconstruct the move.
+ *
+ * Idempotent within a 60-second window: if the source's metadata already
+ * records a handoff to the same target agent newer than 60s ago, return the
+ * existing target session rather than creating a duplicate.
+ */
+class HandoffAgentSessionAction
+{
+    private const IDEMPOTENCY_WINDOW_SECONDS = 60;
+
+    public function __construct(
+        private readonly AppendSessionEventAction $append,
+    ) {}
+
+    /**
+     * @return array{source: AgentSession, target: AgentSession, reused: bool}
+     */
+    public function execute(
+        AgentSession $source,
+        string $targetAgentId,
+        ?string $note = null,
+    ): array {
+        if ($source->status === AgentSessionStatus::Pending) {
+            throw new RuntimeException('Cannot hand off a pending session — start it first.');
+        }
+        if ($source->status->isTerminal()) {
+            throw new RuntimeException("Source session is in terminal status '{$source->status->value}'.");
+        }
+
+        $targetAgent = Agent::withoutGlobalScopes()->find($targetAgentId);
+        if (! $targetAgent) {
+            throw new InvalidArgumentException('Target agent not found.');
+        }
+        if ($targetAgent->team_id !== $source->team_id) {
+            throw new InvalidArgumentException('Cross-team handoff is not allowed.');
+        }
+        if ($targetAgent->status === AgentStatus::Disabled) {
+            throw new InvalidArgumentException('Target agent is disabled.');
+        }
+        if ($targetAgent->id === $source->agent_id) {
+            throw new InvalidArgumentException('Target agent must differ from source agent.');
+        }
+
+        $existing = $this->findRecentIdempotentHandoff($source, $targetAgentId);
+        if ($existing !== null) {
+            return ['source' => $source, 'target' => $existing, 'reused' => true];
+        }
+
+        return DB::transaction(function () use ($source, $targetAgent, $note): array {
+            /** @var AgentSession $target */
+            $target = AgentSession::create([
+                'team_id' => $source->team_id,
+                'agent_id' => $targetAgent->id,
+                'experiment_id' => $source->experiment_id,
+                'crew_execution_id' => $source->crew_execution_id,
+                'user_id' => $source->user_id,
+                'status' => AgentSessionStatus::Pending,
+                'workspace_contract_snapshot' => $source->workspace_contract_snapshot,
+                'metadata' => [
+                    'handoff' => [
+                        'from_session_id' => $source->id,
+                        'from_agent_id' => $source->agent_id,
+                        'note' => $note,
+                        'received_at' => Carbon::now()->toIso8601String(),
+                    ],
+                ],
+            ]);
+
+            $this->append->execute(
+                session: $source,
+                kind: AgentSessionEventKind::HandoffOut,
+                payload: [
+                    'target_session_id' => $target->id,
+                    'target_agent_id' => $targetAgent->id,
+                    'note' => $note,
+                ],
+            );
+
+            $this->append->execute(
+                session: $target->refresh(),
+                kind: AgentSessionEventKind::HandoffIn,
+                payload: [
+                    'source_session_id' => $source->id,
+                    'source_agent_id' => $source->agent_id,
+                    'note' => $note,
+                ],
+            );
+
+            $sourceMeta = is_array($source->metadata) ? $source->metadata : [];
+            $sourceMeta['handoff'] = [
+                'target_session_id' => $target->id,
+                'target_agent_id' => $targetAgent->id,
+                'note' => $note,
+                'created_at' => Carbon::now()->toIso8601String(),
+            ];
+            $source->update([
+                'metadata' => $sourceMeta,
+                'status' => AgentSessionStatus::Sleeping,
+            ]);
+
+            return ['source' => $source->refresh(), 'target' => $target->refresh(), 'reused' => false];
+        });
+    }
+
+    private function findRecentIdempotentHandoff(AgentSession $source, string $targetAgentId): ?AgentSession
+    {
+        $metadata = is_array($source->metadata) ? $source->metadata : null;
+        $handoff = $metadata['handoff'] ?? null;
+        if (! is_array($handoff)) {
+            return null;
+        }
+        if (($handoff['target_agent_id'] ?? null) !== $targetAgentId) {
+            return null;
+        }
+        $createdAt = $handoff['created_at'] ?? null;
+        if (! is_string($createdAt) || $createdAt === '') {
+            return null;
+        }
+        try {
+            $created = Carbon::parse($createdAt);
+        } catch (\Throwable) {
+            return null;
+        }
+        if ($created->diffInSeconds(Carbon::now()) > self::IDEMPOTENCY_WINDOW_SECONDS) {
+            return null;
+        }
+        $targetSessionId = $handoff['target_session_id'] ?? null;
+        if (! is_string($targetSessionId) || $targetSessionId === '') {
+            return null;
+        }
+
+        return AgentSession::withoutGlobalScopes()
+            ->where('team_id', $source->team_id)
+            ->find($targetSessionId);
+    }
+}

--- a/app/Domain/AgentSession/Actions/ReplayAgentSessionAction.php
+++ b/app/Domain/AgentSession/Actions/ReplayAgentSessionAction.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Domain\AgentSession\Actions;
+
+use App\Domain\AgentSession\DTOs\ReplaySummary;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\AgentSession\Models\AgentSessionEvent;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Read-only reconstruction of a session's event timeline plus session-wide
+ * summary stats. Supports paginated streaming via since_seq + limit so a
+ * UI/audit consumer can pull the first 1000 events, then poll for newer
+ * ones without refetching.
+ *
+ * Stats are computed across ALL events (not the returned slice) so the
+ * caller gets correct totals on the very first call.
+ */
+class ReplayAgentSessionAction
+{
+    public const DEFAULT_LIMIT = 1000;
+
+    public const MAX_LIMIT = 5000;
+
+    /**
+     * @param  array<int, AgentSessionEventKind>|null  $kinds  filters the returned events slice; stats still cover all events
+     */
+    public function execute(
+        AgentSession $session,
+        int $sinceSeq = 0,
+        ?int $limit = null,
+        ?array $kinds = null,
+    ): ReplaySummary {
+        $resolvedLimit = $this->clampLimit($limit);
+
+        $totals = $this->computeSessionTotals($session);
+
+        $sliceQuery = AgentSessionEvent::query()
+            ->where('session_id', $session->id)
+            ->where('seq', '>', $sinceSeq)
+            ->orderBy('seq');
+        if ($kinds !== null && $kinds !== []) {
+            $sliceQuery->whereIn('kind', array_map(fn (AgentSessionEventKind $k) => $k->value, $kinds));
+        }
+        /** @var Collection<int, AgentSessionEvent> $sliceEvents */
+        $sliceEvents = $sliceQuery->limit($resolvedLimit + 1)->get();
+
+        $hasMore = $sliceEvents->count() > $resolvedLimit;
+        if ($hasMore) {
+            $sliceEvents = $sliceEvents->slice(0, $resolvedLimit)->values();
+        }
+
+        $eventsArr = $sliceEvents->map(fn (AgentSessionEvent $e) => [
+            'seq' => $e->seq,
+            'kind' => $e->kind->value,
+            'payload' => $e->payload,
+            'created_at' => $e->created_at->toIso8601String(),
+        ])->all();
+
+        $duration = null;
+        if ($session->started_at && $session->ended_at) {
+            $duration = (int) $session->started_at->diffInSeconds($session->ended_at);
+        }
+
+        return new ReplaySummary(
+            sessionId: $session->id,
+            status: $session->status,
+            startedAt: $session->started_at,
+            endedAt: $session->ended_at,
+            durationSeconds: $duration,
+            totalEvents: $totals['total_events'],
+            eventsByKind: $totals['events_by_kind'],
+            llmTotalTokens: $totals['llm_total_tokens'],
+            llmTotalCostUsd: $totals['llm_total_cost_usd'],
+            toolCallCount: $totals['tool_call_count'],
+            toolFailureCount: $totals['tool_failure_count'],
+            handoffCount: $totals['handoff_count'],
+            events: $eventsArr,
+            nextSinceSeq: $hasMore && $eventsArr !== [] ? (int) end($eventsArr)['seq'] : null,
+        );
+    }
+
+    /**
+     * @return array{
+     *   total_events: int,
+     *   events_by_kind: array<string, int>,
+     *   llm_total_tokens: int,
+     *   llm_total_cost_usd: float,
+     *   tool_call_count: int,
+     *   tool_failure_count: int,
+     *   handoff_count: int,
+     * }
+     */
+    private function computeSessionTotals(AgentSession $session): array
+    {
+        $eventsByKind = [];
+        $llmTokens = 0;
+        $llmCost = 0.0;
+        $toolCalls = 0;
+        $toolFailures = 0;
+        $handoffs = 0;
+        $total = 0;
+
+        AgentSessionEvent::query()
+            ->where('session_id', $session->id)
+            ->orderBy('seq')
+            ->chunk(500, function ($chunk) use (
+                &$total, &$eventsByKind, &$llmTokens, &$llmCost,
+                &$toolCalls, &$toolFailures, &$handoffs
+            ) {
+                foreach ($chunk as $event) {
+                    /** @var AgentSessionEvent $event */
+                    $total++;
+                    $kindValue = $event->kind->value;
+                    $eventsByKind[$kindValue] = ($eventsByKind[$kindValue] ?? 0) + 1;
+
+                    $payload = is_array($event->payload) ? $event->payload : [];
+
+                    if ($event->kind === AgentSessionEventKind::LlmCall) {
+                        $tokens = $payload['tokens_total'] ?? null;
+                        if (is_int($tokens) || (is_string($tokens) && ctype_digit($tokens))) {
+                            $llmTokens += (int) $tokens;
+                        } else {
+                            $this->logShapeMiss('LlmCall.tokens_total', $event->id, $tokens);
+                        }
+                        $cost = $payload['cost_usd'] ?? null;
+                        if (is_numeric($cost)) {
+                            $llmCost += (float) $cost;
+                        } else {
+                            $this->logShapeMiss('LlmCall.cost_usd', $event->id, $cost);
+                        }
+                    }
+
+                    if ($event->kind === AgentSessionEventKind::ToolCall) {
+                        $toolCalls++;
+                    }
+
+                    if ($event->kind === AgentSessionEventKind::ToolResult) {
+                        $errored = $payload['error'] ?? null;
+                        if ($errored !== null && $errored !== false && $errored !== '' && $errored !== 0) {
+                            $toolFailures++;
+                        }
+                    }
+
+                    if (
+                        $event->kind === AgentSessionEventKind::HandoffOut
+                        || $event->kind === AgentSessionEventKind::HandoffIn
+                    ) {
+                        $handoffs++;
+                    }
+                }
+            });
+
+        return [
+            'total_events' => $total,
+            'events_by_kind' => $eventsByKind,
+            'llm_total_tokens' => $llmTokens,
+            'llm_total_cost_usd' => $llmCost,
+            'tool_call_count' => $toolCalls,
+            'tool_failure_count' => $toolFailures,
+            'handoff_count' => $handoffs,
+        ];
+    }
+
+    private function clampLimit(?int $limit): int
+    {
+        $value = $limit ?? self::DEFAULT_LIMIT;
+        $value = max(1, $value);
+
+        return min($value, self::MAX_LIMIT);
+    }
+
+    private function logShapeMiss(string $field, string $eventId, mixed $value): void
+    {
+        Log::info('AgentSessionReplay: event payload shape mismatch — defaulting to 0', [
+            'field' => $field,
+            'event_id' => $eventId,
+            'received_type' => gettype($value),
+        ]);
+    }
+}

--- a/app/Domain/AgentSession/DTOs/ReplaySummary.php
+++ b/app/Domain/AgentSession/DTOs/ReplaySummary.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Domain\AgentSession\DTOs;
+
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use Carbon\Carbon;
+
+/**
+ * Result of replaying an AgentSession's event log. Carries the chronological
+ * event slice the caller asked for plus aggregated stats covering the WHOLE
+ * session (not just the slice) so streaming clients don't need to refetch
+ * to know totals.
+ *
+ * "Replay" here means reconstruction-grade event stream + summary, not
+ * deterministic re-execution against a fresh agent. Re-execution is a
+ * separate concern intentionally out of scope.
+ */
+final readonly class ReplaySummary
+{
+    /**
+     * @param  array<int, array{seq: int, kind: string, payload: array<string, mixed>|null, created_at: string|null}>  $events
+     * @param  array<string, int>  $eventsByKind
+     */
+    public function __construct(
+        public string $sessionId,
+        public ?AgentSessionStatus $status,
+        public ?Carbon $startedAt,
+        public ?Carbon $endedAt,
+        public ?int $durationSeconds,
+        public int $totalEvents,
+        public array $eventsByKind,
+        public int $llmTotalTokens,
+        public float $llmTotalCostUsd,
+        public int $toolCallCount,
+        public int $toolFailureCount,
+        public int $handoffCount,
+        public array $events,
+        public ?int $nextSinceSeq,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'session_id' => $this->sessionId,
+            'status' => $this->status?->value,
+            'started_at' => $this->startedAt?->toIso8601String(),
+            'ended_at' => $this->endedAt?->toIso8601String(),
+            'duration_seconds' => $this->durationSeconds,
+            'total_events' => $this->totalEvents,
+            'events_by_kind' => $this->eventsByKind,
+            'llm_total_tokens' => $this->llmTotalTokens,
+            'llm_total_cost_usd' => $this->llmTotalCostUsd,
+            'tool_call_count' => $this->toolCallCount,
+            'tool_failure_count' => $this->toolFailureCount,
+            'handoff_count' => $this->handoffCount,
+            'events' => $this->events,
+            'next_since_seq' => $this->nextSinceSeq,
+        ];
+    }
+}

--- a/app/Domain/Project/Models/Project.php
+++ b/app/Domain/Project/Models/Project.php
@@ -21,6 +21,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
+/**
+ * @property array<string, mixed>|null $settings
+ */
 class Project extends Model
 {
     use BelongsToTeam, HasFactory, HasPluginMeta, HasUuids;

--- a/app/Livewire/GitRepositories/GitRepositoryDetailPage.php
+++ b/app/Livewire/GitRepositories/GitRepositoryDetailPage.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\GitRepositories;
 
 use App\Domain\GitRepository\Actions\TestGitConnectionAction;
+use App\Domain\GitRepository\Enums\TestRatchetMode;
 use App\Domain\GitRepository\Models\GitRepository;
 use Livewire\Component;
 
@@ -16,6 +17,17 @@ class GitRepositoryDetailPage extends Component
 
     public bool $testSuccess = false;
 
+    public string $testRatchetMode = '';
+
+    public ?string $testRatchetSavedMessage = null;
+
+    public function mount(): void
+    {
+        $config = $this->gitRepository->config ?? [];
+        $raw = (string) ($config['test_ratchet_mode'] ?? TestRatchetMode::Soft->value);
+        $this->testRatchetMode = (TestRatchetMode::tryFrom($raw) ?? TestRatchetMode::Soft)->value;
+    }
+
     public function testConnection(): void
     {
         $this->testing = true;
@@ -28,6 +40,21 @@ class GitRepositoryDetailPage extends Component
         $this->testing = false;
 
         $this->gitRepository->refresh();
+    }
+
+    public function saveTestRatchetMode(): void
+    {
+        $this->validate([
+            'testRatchetMode' => 'required|in:'.implode(',', array_column(TestRatchetMode::cases(), 'value')),
+        ]);
+
+        $config = $this->gitRepository->config ?? [];
+        $config['test_ratchet_mode'] = $this->testRatchetMode;
+        $this->gitRepository->update(['config' => $config]);
+        $this->gitRepository->refresh();
+
+        $mode = TestRatchetMode::from($this->testRatchetMode);
+        $this->testRatchetSavedMessage = "Test ratchet mode set to {$mode->label()}.";
     }
 
     public function render()
@@ -46,6 +73,7 @@ class GitRepositoryDetailPage extends Component
         return view('livewire.git-repositories.git-repository-detail-page', [
             'operations' => $operations,
             'pullRequests' => $pullRequests,
+            'testRatchetModes' => TestRatchetMode::cases(),
         ])->layout('layouts.app', ['header' => $this->gitRepository->name]);
     }
 }

--- a/app/Livewire/Projects/EditProjectForm.php
+++ b/app/Livewire/Projects/EditProjectForm.php
@@ -81,6 +81,11 @@ class EditProjectForm extends Component
 
     public array $selectedCredentialIds = [];
 
+    // Quality Gates (live in project.settings JSONB)
+    public bool $doneGateEnabled = false;
+
+    public bool $doneGateKillSwitch = false;
+
     public function mount(Project $project): void
     {
         $this->project = $project;
@@ -129,6 +134,11 @@ class EditProjectForm extends Component
         // Tools & Credentials
         $this->selectedToolIds = $project->allowed_tool_ids ?? [];
         $this->selectedCredentialIds = $project->allowed_credential_ids ?? [];
+
+        // Quality Gates
+        $settings = $project->settings ?? [];
+        $this->doneGateEnabled = (bool) ($settings['done_gate_enabled'] ?? false);
+        $this->doneGateKillSwitch = (bool) ($settings['done_gate_kill_switch'] ?? false);
     }
 
     protected function rules(): array
@@ -162,6 +172,9 @@ class EditProjectForm extends Component
         $rules['heartbeatBudgetCap'] = 'nullable|integer|min:1';
         $rules['heartbeatContextSources'] = 'array';
         $rules['heartbeatContextSources.*'] = 'string|in:signals,metrics,audit,experiments';
+
+        $rules['doneGateEnabled'] = 'boolean';
+        $rules['doneGateKillSwitch'] = 'boolean';
 
         return $rules;
     }
@@ -214,11 +227,16 @@ class EditProjectForm extends Component
 
         app(UpdateProjectAction::class)->execute($this->project, $data);
 
-        // Update tools, credentials, email template
+        // Update tools, credentials, email template, quality gates
+        $existingSettings = $this->project->settings ?? [];
+        $existingSettings['done_gate_enabled'] = $this->doneGateEnabled;
+        $existingSettings['done_gate_kill_switch'] = $this->doneGateKillSwitch;
+
         $this->project->update([
             'allowed_tool_ids' => array_values($this->selectedToolIds),
             'allowed_credential_ids' => array_values($this->selectedCredentialIds),
             'email_template_id' => $this->emailTemplateId ?: null,
+            'settings' => $existingSettings,
         ]);
 
         session()->flash('message', 'Project updated successfully!');

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -70,9 +70,12 @@ use App\Mcp\Tools\AgentChatProtocol\ExternalAgentListTool;
 use App\Mcp\Tools\AgentChatProtocol\ExternalAgentPingTool;
 use App\Mcp\Tools\AgentChatProtocol\ExternalAgentRefreshManifestTool;
 use App\Mcp\Tools\AgentChatProtocol\ExternalAgentUpdateTool;
+use App\Mcp\Tools\AgentSession\AgentSessionCancelTool;
 use App\Mcp\Tools\AgentSession\AgentSessionEventsTool;
 use App\Mcp\Tools\AgentSession\AgentSessionGetTool;
+use App\Mcp\Tools\AgentSession\AgentSessionHandoffTool;
 use App\Mcp\Tools\AgentSession\AgentSessionListTool;
+use App\Mcp\Tools\AgentSession\AgentSessionReplayTool;
 use App\Mcp\Tools\AgentSession\AgentSessionSleepTool;
 use App\Mcp\Tools\AgentSession\AgentSessionWakeTool;
 use App\Mcp\Tools\Approval\ActionProposalApproveTool;
@@ -1115,12 +1118,15 @@ class AgentFleetServer extends Server
         ActivepiecesSyncTool::class,
         ActivepiecesListPiecesTool::class,
 
-        // Agent Session (5)
+        // Agent Session (8)
         AgentSessionListTool::class,
         AgentSessionGetTool::class,
         AgentSessionEventsTool::class,
         AgentSessionWakeTool::class,
         AgentSessionSleepTool::class,
+        AgentSessionCancelTool::class,
+        AgentSessionHandoffTool::class,
+        AgentSessionReplayTool::class,
 
         // Compute (1)
         ComputeManageTool::class,

--- a/app/Mcp/Tools/AgentSession/AgentSessionCancelTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionCancelTool.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Actions\CancelAgentSessionAction;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('write')]
+class AgentSessionCancelTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_cancel';
+
+    protected string $description = 'Cancel an agent session. Status moves to Cancelled and ended_at is stamped. Idempotent — calling on an already-terminal session returns the same row without emitting a duplicate event.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'session_id' => $schema->string()->description('AgentSession UUID')->required(),
+            'reason' => $schema->string()->description('Optional reason recorded on the cancel event'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+            'reason' => 'nullable|string|max:255',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $session = AgentSession::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['session_id']);
+        if (! $session) {
+            return $this->notFoundError('agent_session');
+        }
+
+        $session = app(CancelAgentSessionAction::class)
+            ->execute($session, $validated['reason'] ?? null);
+
+        return Response::json([
+            'id' => $session->id,
+            'status' => $session->status->value,
+            'ended_at' => $session->ended_at?->toIso8601String(),
+        ]);
+    }
+}

--- a/app/Mcp/Tools/AgentSession/AgentSessionHandoffTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionHandoffTool.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Actions\HandoffAgentSessionAction;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('write')]
+class AgentSessionHandoffTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_handoff';
+
+    protected string $description = 'Hand off an active or sleeping session to a different agent in the same team. Source moves to Sleeping; a new Pending target session inherits the workspace_contract_snapshot. HandoffOut + HandoffIn events are appended on both sides. Idempotent within 60 seconds of the same source→target_agent pair.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'session_id' => $schema->string()->description('Source AgentSession UUID')->required(),
+            'target_agent_id' => $schema->string()->description('Agent UUID that should pick up the work; must belong to the same team and not be disabled')->required(),
+            'note' => $schema->string()->description('Optional note recorded on both HandoffOut and HandoffIn events'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+            'target_agent_id' => "required|string|uuid|exists:agents,id,team_id,{$teamId}",
+            'note' => 'nullable|string|max:255',
+        ]);
+
+        $source = AgentSession::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['session_id']);
+        if (! $source) {
+            return $this->notFoundError('agent_session');
+        }
+
+        $result = app(HandoffAgentSessionAction::class)
+            ->execute($source, $validated['target_agent_id'], $validated['note'] ?? null);
+
+        return Response::json([
+            'source' => [
+                'id' => $result['source']->id,
+                'status' => $result['source']->status->value,
+            ],
+            'target' => [
+                'id' => $result['target']->id,
+                'agent_id' => $result['target']->agent_id,
+                'status' => $result['target']->status->value,
+            ],
+            'reused' => $result['reused'],
+        ]);
+    }
+}

--- a/app/Mcp/Tools/AgentSession/AgentSessionReplayTool.php
+++ b/app/Mcp/Tools/AgentSession/AgentSessionReplayTool.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Mcp\Tools\AgentSession;
+
+use App\Domain\AgentSession\Actions\ReplayAgentSessionAction;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class AgentSessionReplayTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'agent_session_replay';
+
+    protected string $description = 'Reconstruct an AgentSession by streaming its append-only event log plus session-wide summary stats (counts by kind, llm tokens/cost, tool failures, handoff count). Supports paginated streaming via since_seq. Replay = event reconstruction; deterministic re-execution against a fresh agent is a separate concern.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'session_id' => $schema->string()->description('AgentSession UUID')->required(),
+            'since_seq' => $schema->number()->description('Return events with seq strictly greater than this. Use 0 (default) for first page; pass the response\'s next_since_seq for subsequent pages.'),
+            'limit' => $schema->number()->description('Max events to return in this slice. Default 1000, hard max 5000.'),
+            'kinds' => $schema->string()->description('Comma-separated event kinds to filter the slice (e.g. "tool_call,llm_call"). Stats still cover all events. Allowed values: '.implode(',', array_map(fn ($k) => $k->value, AgentSessionEventKind::cases()))),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'session_id' => 'required|string',
+            'since_seq' => 'nullable|integer|min:0',
+            'limit' => 'nullable|integer|min:1',
+            'kinds' => 'nullable|string',
+        ]);
+
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $session = AgentSession::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['session_id']);
+        if (! $session) {
+            return $this->notFoundError('agent_session');
+        }
+
+        $kinds = null;
+        if (! empty($validated['kinds'])) {
+            $kinds = [];
+            foreach (explode(',', $validated['kinds']) as $raw) {
+                $value = trim($raw);
+                if ($value === '') {
+                    continue;
+                }
+                $kind = AgentSessionEventKind::tryFrom($value);
+                if ($kind === null) {
+                    return $this->invalidArgumentError("Unknown event kind '{$value}'.");
+                }
+                $kinds[] = $kind;
+            }
+            if ($kinds === []) {
+                $kinds = null;
+            }
+        }
+
+        $summary = app(ReplayAgentSessionAction::class)->execute(
+            session: $session,
+            sinceSeq: (int) ($validated['since_seq'] ?? 0),
+            limit: isset($validated['limit']) ? (int) $validated['limit'] : null,
+            kinds: $kinds,
+        );
+
+        return Response::json($summary->toArray());
+    }
+}

--- a/resources/views/livewire/git-repositories/git-repository-detail-page.blade.php
+++ b/resources/views/livewire/git-repositories/git-repository-detail-page.blade.php
@@ -134,6 +134,32 @@
                 @endif
             </div>
 
+            {{-- Test Ratchet Mode --}}
+            <div class="rounded-xl border border-gray-200 bg-white overflow-hidden">
+                <div class="border-b border-gray-200 px-5 py-3">
+                    <h3 class="text-sm font-semibold text-gray-900">Test Ratchet Guard</h3>
+                    <p class="mt-1 text-xs text-gray-500">Detects test deletions and assertion removals on every commit through this repo's GatedGitClient.</p>
+                </div>
+                <div class="p-5 space-y-3">
+                    <x-form-select wire:model="testRatchetMode" label="Mode">
+                        @foreach($testRatchetModes as $mode)
+                            <option value="{{ $mode->value }}">{{ $mode->label() }}</option>
+                        @endforeach
+                    </x-form-select>
+                    <div class="flex items-center justify-between gap-3">
+                        <p class="text-xs text-gray-500">
+                            <strong>Off</strong>: never inspect. <strong>Soft</strong>: log a warning. <strong>Hard</strong>: refuse the commit and raise an ActionProposal.
+                        </p>
+                        <button wire:click="saveTestRatchetMode" class="rounded-lg bg-primary-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-primary-700">
+                            Save
+                        </button>
+                    </div>
+                    @if($testRatchetSavedMessage)
+                        <p class="text-xs text-emerald-600">{{ $testRatchetSavedMessage }}</p>
+                    @endif
+                </div>
+            </div>
+
             {{-- Open pull requests --}}
             <div class="rounded-xl border border-gray-200 bg-white overflow-hidden">
                 <div class="border-b border-gray-200 px-5 py-3">

--- a/resources/views/livewire/projects/edit-project-form.blade.php
+++ b/resources/views/livewire/projects/edit-project-form.blade.php
@@ -295,6 +295,18 @@
                 <p class="mt-1.5 text-xs text-gray-500">Credits. Leave empty for unlimited. Project auto-pauses when a cap is hit and resumes when the period resets.</p>
             </div>
 
+            {{-- Quality Gates --}}
+            <div>
+                <h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500">Quality Gates</h3>
+                <div class="space-y-3 rounded-lg border border-gray-100 bg-gray-50/50 p-4">
+                    <x-form-checkbox wire:model="doneGateEnabled" label="Done-Condition Gate"
+                        hint="When enabled, transitions to Completed run a Haiku-judged check that the work matches the externalized done_criteria. Override the judge model in project.settings.done_gate_judge if needed." />
+                    <x-form-checkbox wire:model="doneGateKillSwitch" label="Kill switch (bypass gate)"
+                        hint="Bypasses the Done-Condition Gate even when enabled. Use only to break out of false-negative judge loops." />
+                </div>
+                <p class="mt-1.5 text-xs text-gray-500">The gate prevents premature completions by re-checking against feature-list.json — see AGENTS.md workspace contract.</p>
+            </div>
+
             {{-- Email Template --}}
             @if($emailTemplates->isNotEmpty())
                 <div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -36,6 +36,7 @@ Schedule::command('error-translator:harvest --format=json')
     ->appendOutputTo(storage_path('logs/error-translator-harvest.log'));
 
 Schedule::command('audit:cleanup')->dailyAt('02:00');
+Schedule::command('agent-session-events:cleanup')->dailyAt('03:45')->withoutOverlapping(60)->onOneServer();
 Schedule::command('worldmodel:rebuild')->dailyAt('02:15')->withoutOverlapping(60)->onOneServer();
 Schedule::command('kg:build-communities')->dailyAt('02:45')->withoutOverlapping(60)->onOneServer();
 Schedule::command('kg:merge-entities')->dailyAt('04:30')->withoutOverlapping(30)->onOneServer();

--- a/tests/Feature/Console/CleanupAgentSessionEventsCommandTest.php
+++ b/tests/Feature/Console/CleanupAgentSessionEventsCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Domain\AgentSession\Actions\AppendSessionEventAction;
+use App\Domain\AgentSession\Actions\CreateAgentSessionAction;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\AgentSession\Models\AgentSessionEvent;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CleanupAgentSessionEventsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deletes_events_older_than_retention(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $append = app(AppendSessionEventAction::class);
+
+        $stale = $append->execute($session, AgentSessionEventKind::Note, ['old' => true]);
+        $stale->forceFill(['created_at' => now()->subDays(120)])->save();
+
+        $append->execute($session, AgentSessionEventKind::Note, ['recent' => true]);
+
+        $this->artisan('agent-session-events:cleanup', ['--days' => 90])->assertSuccessful();
+
+        $remaining = AgentSessionEvent::all();
+        $this->assertCount(1, $remaining);
+        $this->assertNotSame($stale->id, $remaining->first()->id);
+    }
+
+    public function test_dry_run_does_not_delete(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $event = app(AppendSessionEventAction::class)
+            ->execute($session, AgentSessionEventKind::Note, ['stale' => true]);
+        $event->forceFill(['created_at' => now()->subDays(200)])->save();
+
+        $this->artisan('agent-session-events:cleanup', ['--days' => 90, '--dry-run' => true])
+            ->expectsOutputToContain('[dry-run]')
+            ->assertSuccessful();
+
+        $this->assertSame(1, AgentSessionEvent::count());
+    }
+
+    public function test_orphan_terminal_sessions_are_pruned(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $session->update([
+            'status' => AgentSessionStatus::Cancelled,
+            'ended_at' => now()->subDays(120),
+        ]);
+
+        $this->assertSame(1, AgentSession::count());
+        $this->artisan('agent-session-events:cleanup', ['--days' => 90])->assertSuccessful();
+        $this->assertSame(0, AgentSession::count());
+    }
+
+    public function test_active_session_is_preserved(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $session->update(['status' => AgentSessionStatus::Active]);
+
+        $this->artisan('agent-session-events:cleanup', ['--days' => 90])->assertSuccessful();
+        $this->assertSame(1, AgentSession::count());
+    }
+
+    public function test_invalid_days_flag_fails(): void
+    {
+        $this->artisan('agent-session-events:cleanup', ['--days' => 0])->assertFailed();
+    }
+}

--- a/tests/Feature/Domain/Agent/WorkspaceContractBuildSnapshotTest.php
+++ b/tests/Feature/Domain/Agent/WorkspaceContractBuildSnapshotTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Domain\Agent;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Agent\Services\WorkspaceContractWriter;
+use App\Domain\Project\Models\Project;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WorkspaceContractBuildSnapshotTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_build_snapshot_for_execution_returns_all_four_files(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create([
+            'name' => 'CodingBot',
+            'role' => 'Senior Developer',
+            'goal' => 'Ship a clean, tested PR.',
+        ]);
+
+        $writer = app(WorkspaceContractWriter::class);
+        $snapshot = $writer->buildSnapshotForExecution(
+            agent: $agent,
+            experimentId: null,
+            project: null,
+            input: ['task' => 'Fix the auth bug'],
+        );
+
+        $this->assertStringContainsString('CodingBot', $snapshot->agentsMd);
+        $this->assertStringContainsString('Senior Developer', $snapshot->agentsMd);
+        $this->assertStringContainsString('Ship a clean', $snapshot->agentsMd);
+
+        $featureList = json_decode($snapshot->featureListJson, true);
+        $this->assertSame($agent->id, $featureList['agent_id']);
+        $this->assertCount(1, $featureList['features']);
+        $this->assertSame('Primary execution goal', $featureList['features'][0]['title']);
+
+        $this->assertStringContainsString('progress.md', $snapshot->progressMd);
+        $this->assertStringContainsString('## Iteration log', $snapshot->progressMd);
+
+        $this->assertStringContainsString('#!/usr/bin/env bash', $snapshot->initSh);
+    }
+
+    public function test_build_snapshot_includes_project_title_in_rules(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create();
+        $project = Project::factory()->for($team)->create(['title' => 'Q3 Refactor']);
+
+        $writer = app(WorkspaceContractWriter::class);
+        $snapshot = $writer->buildSnapshotForExecution(
+            agent: $agent,
+            experimentId: null,
+            project: $project,
+            input: ['task' => 'Refactor module X'],
+        );
+
+        $this->assertStringContainsString("'Q3 Refactor'", $snapshot->agentsMd);
+    }
+
+    public function test_snapshot_serializes_to_array(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create();
+
+        $snapshot = app(WorkspaceContractWriter::class)->buildSnapshotForExecution(
+            agent: $agent,
+            experimentId: null,
+            project: null,
+            input: [],
+        );
+        $arr = $snapshot->toArray();
+
+        $this->assertArrayHasKey('agents_md', $arr);
+        $this->assertArrayHasKey('feature_list_json', $arr);
+        $this->assertArrayHasKey('progress_md', $arr);
+        $this->assertArrayHasKey('init_sh', $arr);
+    }
+}

--- a/tests/Feature/Domain/AgentSession/HandoffAgentSessionActionTest.php
+++ b/tests/Feature/Domain/AgentSession/HandoffAgentSessionActionTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature\Domain\AgentSession;
+
+use App\Domain\Agent\Enums\AgentStatus;
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentSession\Actions\CreateAgentSessionAction;
+use App\Domain\AgentSession\Actions\HandoffAgentSessionAction;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\AgentSession\Models\AgentSessionEvent;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HandoffAgentSessionActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handoff_creates_target_session_and_emits_paired_events(): void
+    {
+        $team = Team::factory()->create();
+        $sourceAgent = Agent::factory()->for($team)->create();
+        $targetAgent = Agent::factory()->for($team)->create();
+
+        $source = app(CreateAgentSessionAction::class)->execute(
+            teamId: $team->id,
+            agentId: $sourceAgent->id,
+        );
+        $source->update([
+            'status' => AgentSessionStatus::Active,
+            'workspace_contract_snapshot' => ['agents_md' => '# Agents'],
+        ]);
+
+        $result = app(HandoffAgentSessionAction::class)->execute(
+            $source->refresh(),
+            $targetAgent->id,
+            'Pass to QA bot',
+        );
+
+        $this->assertFalse($result['reused']);
+        $this->assertSame(AgentSessionStatus::Sleeping, $result['source']->status);
+        $this->assertSame(AgentSessionStatus::Pending, $result['target']->status);
+        $this->assertSame($targetAgent->id, $result['target']->agent_id);
+        $this->assertSame(['agents_md' => '# Agents'], $result['target']->workspace_contract_snapshot);
+
+        $this->assertSame(1, AgentSessionEvent::where('session_id', $source->id)
+            ->where('kind', AgentSessionEventKind::HandoffOut->value)->count());
+        $this->assertSame(1, AgentSessionEvent::where('session_id', $result['target']->id)
+            ->where('kind', AgentSessionEventKind::HandoffIn->value)->count());
+    }
+
+    public function test_handoff_is_idempotent_within_window(): void
+    {
+        $team = Team::factory()->create();
+        $sourceAgent = Agent::factory()->for($team)->create();
+        $targetAgent = Agent::factory()->for($team)->create();
+        $source = app(CreateAgentSessionAction::class)->execute(
+            teamId: $team->id,
+            agentId: $sourceAgent->id,
+        );
+        $source->update(['status' => AgentSessionStatus::Active]);
+        $source->refresh();
+
+        $first = app(HandoffAgentSessionAction::class)->execute($source, $targetAgent->id);
+        $second = app(HandoffAgentSessionAction::class)->execute($source->refresh(), $targetAgent->id);
+
+        $this->assertFalse($first['reused']);
+        $this->assertTrue($second['reused']);
+        $this->assertSame($first['target']->id, $second['target']->id);
+        $this->assertSame(2, AgentSession::count());
+    }
+
+    public function test_cross_team_target_is_rejected(): void
+    {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        $sourceAgent = Agent::factory()->for($teamA)->create();
+        $foreignAgent = Agent::factory()->for($teamB)->create();
+
+        $source = app(CreateAgentSessionAction::class)->execute(
+            teamId: $teamA->id,
+            agentId: $sourceAgent->id,
+        );
+        $source->update(['status' => AgentSessionStatus::Active]);
+        $source->refresh();
+
+        $this->expectException(\InvalidArgumentException::class);
+        app(HandoffAgentSessionAction::class)->execute($source, $foreignAgent->id);
+    }
+
+    public function test_terminal_source_is_rejected(): void
+    {
+        $team = Team::factory()->create();
+        $sourceAgent = Agent::factory()->for($team)->create();
+        $targetAgent = Agent::factory()->for($team)->create();
+        $source = app(CreateAgentSessionAction::class)->execute(
+            teamId: $team->id,
+            agentId: $sourceAgent->id,
+        );
+        $source->update(['status' => AgentSessionStatus::Cancelled, 'ended_at' => now()]);
+
+        $this->expectException(\RuntimeException::class);
+        app(HandoffAgentSessionAction::class)->execute($source->refresh(), $targetAgent->id);
+    }
+
+    public function test_disabled_target_is_rejected(): void
+    {
+        $team = Team::factory()->create();
+        $sourceAgent = Agent::factory()->for($team)->create();
+        $targetAgent = Agent::factory()->for($team)->create(['status' => AgentStatus::Disabled]);
+        $source = app(CreateAgentSessionAction::class)->execute(
+            teamId: $team->id,
+            agentId: $sourceAgent->id,
+        );
+        $source->update(['status' => AgentSessionStatus::Active]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        app(HandoffAgentSessionAction::class)->execute($source->refresh(), $targetAgent->id);
+    }
+
+    public function test_same_agent_target_is_rejected(): void
+    {
+        $team = Team::factory()->create();
+        $agent = Agent::factory()->for($team)->create();
+        $source = app(CreateAgentSessionAction::class)->execute(
+            teamId: $team->id,
+            agentId: $agent->id,
+        );
+        $source->update(['status' => AgentSessionStatus::Active]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        app(HandoffAgentSessionAction::class)->execute($source->refresh(), $agent->id);
+    }
+}

--- a/tests/Feature/Domain/AgentSession/ReplayAgentSessionActionTest.php
+++ b/tests/Feature/Domain/AgentSession/ReplayAgentSessionActionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\Domain\AgentSession;
+
+use App\Domain\AgentSession\Actions\AppendSessionEventAction;
+use App\Domain\AgentSession\Actions\CreateAgentSessionAction;
+use App\Domain\AgentSession\Actions\ReplayAgentSessionAction;
+use App\Domain\AgentSession\Enums\AgentSessionEventKind;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReplayAgentSessionActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_empty_session_returns_zero_totals(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+
+        $summary = app(ReplayAgentSessionAction::class)->execute($session);
+
+        $this->assertSame(0, $summary->totalEvents);
+        $this->assertSame([], $summary->eventsByKind);
+        $this->assertSame(0, $summary->llmTotalTokens);
+        $this->assertSame(0.0, $summary->llmTotalCostUsd);
+        $this->assertSame(0, $summary->toolCallCount);
+        $this->assertSame(0, $summary->handoffCount);
+        $this->assertSame([], $summary->events);
+        $this->assertNull($summary->nextSinceSeq);
+    }
+
+    public function test_summary_aggregates_llm_cost_and_tool_failures(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $append = app(AppendSessionEventAction::class);
+
+        $append->execute($session, AgentSessionEventKind::LlmCall, ['tokens_total' => 100, 'cost_usd' => 0.001]);
+        $append->execute($session, AgentSessionEventKind::LlmCall, ['tokens_total' => 250, 'cost_usd' => 0.0025]);
+        $append->execute($session, AgentSessionEventKind::ToolCall, ['tool' => 'bash']);
+        $append->execute($session, AgentSessionEventKind::ToolResult, ['error' => 'timeout']);
+        $append->execute($session, AgentSessionEventKind::ToolResult, ['ok' => true]);
+
+        $summary = app(ReplayAgentSessionAction::class)->execute($session);
+
+        $this->assertSame(5, $summary->totalEvents);
+        $this->assertSame(350, $summary->llmTotalTokens);
+        $this->assertEqualsWithDelta(0.0035, $summary->llmTotalCostUsd, 0.00001);
+        $this->assertSame(1, $summary->toolCallCount);
+        $this->assertSame(1, $summary->toolFailureCount);
+        $this->assertSame(2, $summary->eventsByKind[AgentSessionEventKind::LlmCall->value]);
+    }
+
+    public function test_since_seq_pagination(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $append = app(AppendSessionEventAction::class);
+        for ($i = 0; $i < 10; $i++) {
+            $append->execute($session, AgentSessionEventKind::Note, ['n' => $i]);
+        }
+
+        $page1 = app(ReplayAgentSessionAction::class)->execute($session, sinceSeq: 0, limit: 4);
+        $this->assertCount(4, $page1->events);
+        $this->assertSame(4, $page1->nextSinceSeq);
+        $this->assertSame(10, $page1->totalEvents);
+
+        $page2 = app(ReplayAgentSessionAction::class)->execute($session, sinceSeq: $page1->nextSinceSeq, limit: 4);
+        $this->assertCount(4, $page2->events);
+        $this->assertSame(8, $page2->nextSinceSeq);
+
+        $page3 = app(ReplayAgentSessionAction::class)->execute($session, sinceSeq: $page2->nextSinceSeq, limit: 4);
+        $this->assertCount(2, $page3->events);
+        $this->assertNull($page3->nextSinceSeq);
+    }
+
+    public function test_kinds_filter_returns_only_matching_events(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $append = app(AppendSessionEventAction::class);
+        $append->execute($session, AgentSessionEventKind::Note, ['n' => 1]);
+        $append->execute($session, AgentSessionEventKind::ToolCall, ['t' => 'bash']);
+        $append->execute($session, AgentSessionEventKind::Note, ['n' => 2]);
+
+        $summary = app(ReplayAgentSessionAction::class)->execute(
+            $session,
+            kinds: [AgentSessionEventKind::ToolCall],
+        );
+
+        $this->assertCount(1, $summary->events);
+        $this->assertSame('tool_call', $summary->events[0]['kind']);
+        // Stats still cover ALL events
+        $this->assertSame(3, $summary->totalEvents);
+    }
+
+    public function test_duration_seconds_uses_started_and_ended_timestamps(): void
+    {
+        $team = Team::factory()->create();
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $team->id);
+        $session->update([
+            'started_at' => now()->subMinutes(5),
+            'ended_at' => now(),
+            'status' => AgentSessionStatus::Completed,
+        ]);
+
+        $summary = app(ReplayAgentSessionAction::class)->execute($session->refresh());
+
+        $this->assertNotNull($summary->durationSeconds);
+        $this->assertGreaterThanOrEqual(290, $summary->durationSeconds);
+        $this->assertLessThanOrEqual(310, $summary->durationSeconds);
+    }
+}

--- a/tests/Feature/Livewire/GitRepositories/TestRatchetModeUiTest.php
+++ b/tests/Feature/Livewire/GitRepositories/TestRatchetModeUiTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Livewire\GitRepositories;
+
+use App\Domain\GitRepository\Enums\TestRatchetMode;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\GitRepositories\GitRepositoryDetailPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TestRatchetModeUiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    public function test_mount_defaults_to_soft_when_unset(): void
+    {
+        $repo = $this->makeRepo(['config' => []]);
+
+        Livewire::test(GitRepositoryDetailPage::class, ['gitRepository' => $repo])
+            ->assertSet('testRatchetMode', TestRatchetMode::Soft->value);
+    }
+
+    public function test_mount_hydrates_existing_value(): void
+    {
+        $repo = $this->makeRepo(['config' => ['test_ratchet_mode' => TestRatchetMode::Hard->value]]);
+
+        Livewire::test(GitRepositoryDetailPage::class, ['gitRepository' => $repo])
+            ->assertSet('testRatchetMode', TestRatchetMode::Hard->value);
+    }
+
+    public function test_save_persists_to_config_jsonb(): void
+    {
+        $repo = $this->makeRepo(['config' => ['unrelated' => 'keep']]);
+
+        Livewire::test(GitRepositoryDetailPage::class, ['gitRepository' => $repo])
+            ->set('testRatchetMode', TestRatchetMode::Hard->value)
+            ->call('saveTestRatchetMode')
+            ->assertSet('testRatchetSavedMessage', 'Test ratchet mode set to '.TestRatchetMode::Hard->label().'.');
+
+        $repo->refresh();
+        $this->assertSame(TestRatchetMode::Hard->value, $repo->config['test_ratchet_mode']);
+        $this->assertSame('keep', $repo->config['unrelated']);
+    }
+
+    public function test_invalid_mode_is_rejected(): void
+    {
+        $repo = $this->makeRepo();
+
+        Livewire::test(GitRepositoryDetailPage::class, ['gitRepository' => $repo])
+            ->set('testRatchetMode', 'invalid_value')
+            ->call('saveTestRatchetMode')
+            ->assertHasErrors(['testRatchetMode']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makeRepo(array $overrides = []): GitRepository
+    {
+        return GitRepository::create(array_merge([
+            'team_id' => $this->team->id,
+            'name' => 'repo-'.bin2hex(random_bytes(3)),
+            'url' => 'https://github.com/example/repo.git',
+            'provider' => 'generic',
+            'mode' => 'api_only',
+            'status' => 'active',
+            'config' => [],
+        ], $overrides))->refresh();
+    }
+}

--- a/tests/Feature/Livewire/Projects/EditProjectFormQualityGatesTest.php
+++ b/tests/Feature/Livewire/Projects/EditProjectFormQualityGatesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Livewire\Projects;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Project\Models\Project;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Projects\EditProjectForm;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class EditProjectFormQualityGatesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    public function test_mount_hydrates_done_gate_from_settings(): void
+    {
+        $project = $this->makeProject(['settings' => ['done_gate_enabled' => true, 'done_gate_kill_switch' => false]]);
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->assertSet('doneGateEnabled', true)
+            ->assertSet('doneGateKillSwitch', false);
+    }
+
+    public function test_save_persists_done_gate_to_project_settings(): void
+    {
+        $project = $this->makeProject(['settings' => []]);
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->set('doneGateEnabled', true)
+            ->set('doneGateKillSwitch', true)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $project->refresh();
+        $this->assertTrue($project->settings['done_gate_enabled']);
+        $this->assertTrue($project->settings['done_gate_kill_switch']);
+    }
+
+    public function test_save_preserves_other_settings_keys(): void
+    {
+        $project = $this->makeProject([
+            'settings' => [
+                'unrelated_setting' => 'keep me',
+                'done_gate_enabled' => false,
+            ],
+        ]);
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->set('doneGateEnabled', true)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $project->refresh();
+        $this->assertSame('keep me', $project->settings['unrelated_setting']);
+        $this->assertTrue($project->settings['done_gate_enabled']);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makeProject(array $overrides = []): Project
+    {
+        $agent = Agent::factory()->for($this->team)->create();
+
+        return Project::factory()->for($this->team)->create(array_merge([
+            'agent_config' => ['lead_agent_id' => $agent->id],
+        ], $overrides));
+    }
+}

--- a/tests/Feature/Mcp/AgentSession/AgentSessionCancelToolTest.php
+++ b/tests/Feature/Mcp/AgentSession/AgentSessionCancelToolTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Mcp\AgentSession;
+
+use App\Domain\AgentSession\Actions\CreateAgentSessionAction;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\AgentSession\AgentSessionCancelTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class AgentSessionCancelToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'T '.bin2hex(random_bytes(3)),
+            'slug' => 't-'.bin2hex(random_bytes(3)),
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    public function test_cancels_active_session(): void
+    {
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $this->team->id);
+        $session->update(['status' => AgentSessionStatus::Active]);
+
+        $tool = app(AgentSessionCancelTool::class);
+        $response = $tool->handle(new Request(['session_id' => $session->id]));
+
+        $payload = json_decode($this->responseText($response), true);
+        $this->assertSame('cancelled', $payload['status']);
+        $session->refresh();
+        $this->assertSame(AgentSessionStatus::Cancelled, $session->status);
+    }
+
+    public function test_idempotent_on_already_cancelled(): void
+    {
+        $session = app(CreateAgentSessionAction::class)->execute(teamId: $this->team->id);
+        $session->update(['status' => AgentSessionStatus::Cancelled, 'ended_at' => now()]);
+
+        $tool = app(AgentSessionCancelTool::class);
+        $response = $tool->handle(new Request(['session_id' => $session->id]));
+
+        $payload = json_decode($this->responseText($response), true);
+        $this->assertSame('cancelled', $payload['status']);
+    }
+
+    public function test_cross_team_session_not_found(): void
+    {
+        $other = Team::create([
+            'name' => 'Other',
+            'slug' => 'other-'.bin2hex(random_bytes(3)),
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $foreign = app(CreateAgentSessionAction::class)->execute(teamId: $other->id);
+
+        $tool = app(AgentSessionCancelTool::class);
+        $response = $tool->handle(new Request(['session_id' => $foreign->id]));
+
+        $payload = json_decode($this->responseText($response), true);
+        $this->assertSame('NOT_FOUND', $payload['error']['code']);
+    }
+
+    private function responseText(Response $response): string
+    {
+        return (string) $response->content();
+    }
+}


### PR DESCRIPTION
## Summary

Closes 6 deferred items from the long-running-agents sprint (2026-05-03):

1. **WorkspaceContractWriter** wired into `ExecuteAgentAction` (the actual long-running execution path — not the ad-hoc `AgentSandboxOrchestrator`). 4 contract files materialize into the sandbox before the LLM tool-loop, snapshot persists onto every `AgentExecution.workspace_contract`. Best-effort progress append on success.
2. **`agent_session_cancel`** MCP tool — wraps existing `CancelAgentSessionAction`.
3. **`agent_session_handoff`** — full implementation (no 501 stub). In-team agent→agent transfer; source goes Sleeping, target Pending with workspace_contract_snapshot copied. HandoffOut/HandoffIn events on both sides. 60s idempotency window. Cross-team / disabled / same-agent / terminal-source rejected.
4. **`agent_session_replay`** — full implementation (no 501 stub). Returns chronological event slice + session-wide summary stats (counts by kind, llm cost/tokens summed, tool failures, handoff count, duration). Paginated `since_seq`, default limit 1000, hard max 5000. "Replay = reconstruction"; deterministic re-execution intentionally out of scope.
5. **`agent-session-events:cleanup`** console command + 03:45 daily schedule. Mirrors `audit:cleanup` pattern. Chunked deletes, `--dry-run` flag, prunes orphan terminal sessions.
6. **Cloud UI toggles** — `done_gate_enabled` + `done_gate_kill_switch` in `EditProjectForm` (project.settings JSONB), `test_ratchet_mode` in `GitRepositoryDetailPage` (git_repositories.config JSONB).

## Numbers

- 23 files changed (+1634, -20)
- 35 new tests (107 assertions). All green.
- AgentSession MCP group: 5 → 8 tools (153 → 156 total)
- PHPStan: clean, no baseline regenerated
- Pint: clean

## Out of scope (Phase 4-5 follow-ups)

Memory drift monitor, METR time-horizon dashboard, per-agent capability ACLs, browser harness chromium binding, reverse Workflow YAML sync — each needs its own design phase.

## Test plan

- [x] HandoffAgentSessionActionTest (6 cases)
- [x] ReplayAgentSessionActionTest (5 cases)
- [x] AgentSessionCancelToolTest (3 cases)
- [x] CleanupAgentSessionEventsCommandTest (5 cases)
- [x] WorkspaceContractBuildSnapshotTest (3 cases)
- [x] EditProjectFormQualityGatesTest (3 cases)
- [x] TestRatchetModeUiTest (4 cases)
- [x] Existing AgentSessionLifecycleTest stays green
- [x] ToolAnnotationCoverageTest stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)