### PR TITLE
fix(security): authorize all Livewire write methods (33 forms)

### DIFF
--- a/app/Livewire/Agents/CreateAgentForm.php
+++ b/app/Livewire/Agents/CreateAgentForm.php
@@ -11,6 +11,7 @@ use App\Domain\Skill\Models\Skill;
 use App\Domain\Tool\Models\Tool;
 use App\Infrastructure\AI\Enums\ReasoningEffort;
 use App\Infrastructure\AI\Services\ProviderResolver;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
 
@@ -137,6 +138,8 @@ class CreateAgentForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate();
 
         $team = auth()->user()->currentTeam;

--- a/app/Livewire/Agents/QuickAgentForm.php
+++ b/app/Livewire/Agents/QuickAgentForm.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Agents;
 use App\Domain\Agent\Actions\CreateAgentAction;
 use App\Domain\Project\Actions\CreateProjectAction;
 use App\Infrastructure\AI\Services\ProviderResolver;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class QuickAgentForm extends Component
@@ -41,6 +42,8 @@ class QuickAgentForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate();
 
         $team = auth()->user()->currentTeam;

--- a/app/Livewire/Chatbots/ChatbotDetailPage.php
+++ b/app/Livewire/Chatbots/ChatbotDetailPage.php
@@ -13,6 +13,7 @@ use App\Domain\Chatbot\Models\ChatbotChannel;
 use App\Domain\Chatbot\Models\ChatbotToken;
 use App\Domain\Workflow\Models\Workflow;
 use App\Infrastructure\AI\Services\ProviderResolver;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class ChatbotDetailPage extends Component
@@ -67,6 +68,8 @@ class ChatbotDetailPage extends Component
 
     public function toggleStatus(): void
     {
+        Gate::authorize('edit-content');
+
         app(ToggleChatbotStatusAction::class)->execute($this->chatbot);
         $this->chatbot->refresh();
         session()->flash('message', 'Chatbot status updated.');
@@ -94,6 +97,8 @@ class ChatbotDetailPage extends Component
 
     public function saveEdit(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'editName' => 'required|min:2|max:255',
             'editConfidenceThreshold' => 'required|numeric|min:0.1|max:1.0',
@@ -124,6 +129,8 @@ class ChatbotDetailPage extends Component
 
     public function generateToken(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'newTokenName' => 'required|min:1|max:100',
         ]);
@@ -144,6 +151,8 @@ class ChatbotDetailPage extends Component
 
     public function revokeToken(string $tokenId): void
     {
+        Gate::authorize('edit-content');
+
         $token = ChatbotToken::where('id', $tokenId)
             ->where('chatbot_id', $this->chatbot->id)
             ->firstOrFail();
@@ -181,6 +190,8 @@ class ChatbotDetailPage extends Component
 
     public function saveTelegramChannel(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'telegramBotToken' => 'required|string|min:10',
             'telegramWebhookSecret' => 'nullable|string|max:256',
@@ -211,6 +222,8 @@ class ChatbotDetailPage extends Component
 
     public function toggleTelegramChannel(string $channelId): void
     {
+        Gate::authorize('edit-content');
+
         $channel = ChatbotChannel::where('id', $channelId)
             ->where('chatbot_id', $this->chatbot->id)
             ->firstOrFail();
@@ -220,6 +233,8 @@ class ChatbotDetailPage extends Component
 
     public function deleteTelegramChannel(string $channelId): void
     {
+        Gate::authorize('edit-content');
+
         ChatbotChannel::where('id', $channelId)
             ->where('chatbot_id', $this->chatbot->id)
             ->delete();
@@ -229,6 +244,8 @@ class ChatbotDetailPage extends Component
 
     public function delete(): void
     {
+        Gate::authorize('edit-content');
+
         app(DeleteChatbotAction::class)->execute($this->chatbot);
 
         session()->flash('message', 'Chatbot deleted.');

--- a/app/Livewire/Chatbots/CreateChatbotForm.php
+++ b/app/Livewire/Chatbots/CreateChatbotForm.php
@@ -6,6 +6,7 @@ use App\Domain\Agent\Models\Agent;
 use App\Domain\Chatbot\Actions\CreateChatbotAction;
 use App\Domain\Chatbot\Enums\ChatbotType;
 use App\Infrastructure\AI\Services\ProviderResolver;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CreateChatbotForm extends Component
@@ -58,6 +59,8 @@ class CreateChatbotForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate();
 
         $team = auth()->user()->currentTeam;

--- a/app/Livewire/Credentials/CreateCredentialForm.php
+++ b/app/Livewire/Credentials/CreateCredentialForm.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Credentials;
 
 use App\Domain\Credential\Actions\CreateCredentialAction;
 use App\Domain\Credential\Enums\CredentialType;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CreateCredentialForm extends Component
@@ -120,6 +121,8 @@ class CreateCredentialForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $team = auth()->user()->currentTeam;
         $type = CredentialType::from($this->credentialType);
         $secretData = $this->buildSecretData($type);

--- a/app/Livewire/Credentials/CredentialDetailPage.php
+++ b/app/Livewire/Credentials/CredentialDetailPage.php
@@ -15,6 +15,7 @@ use App\Domain\Credential\Enums\CredentialType;
 use App\Domain\Credential\Models\Credential;
 use App\Domain\Credential\Models\CredentialVersion;
 use App\Domain\Project\Models\Project;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CredentialDetailPage extends Component
@@ -66,6 +67,8 @@ class CredentialDetailPage extends Component
 
     public function toggleStatus(): void
     {
+        Gate::authorize('edit-content');
+
         $newStatus = $this->credential->status === CredentialStatus::Active
             ? CredentialStatus::Disabled
             : CredentialStatus::Active;
@@ -76,6 +79,8 @@ class CredentialDetailPage extends Component
 
     public function approveCredential(): void
     {
+        Gate::authorize('edit-content');
+
         $approvalRequest = ApprovalRequest::withoutGlobalScopes()
             ->where('credential_id', $this->credential->id)
             ->where('status', ApprovalStatus::Pending)
@@ -94,6 +99,8 @@ class CredentialDetailPage extends Component
 
     public function rejectCredential(string $reason = 'Rejected by reviewer'): void
     {
+        Gate::authorize('edit-content');
+
         $approvalRequest = ApprovalRequest::withoutGlobalScopes()
             ->where('credential_id', $this->credential->id)
             ->where('status', ApprovalStatus::Pending)
@@ -125,6 +132,8 @@ class CredentialDetailPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'editName' => 'required|min:2|max:255',
             'editDescription' => 'max:1000',
@@ -168,6 +177,8 @@ class CredentialDetailPage extends Component
 
     public function rotateSecret(): void
     {
+        Gate::authorize('edit-content');
+
         $type = $this->credential->credential_type;
 
         // Validate rotation based on type

--- a/app/Livewire/Crews/CreateCrewForm.php
+++ b/app/Livewire/Crews/CreateCrewForm.php
@@ -7,6 +7,7 @@ use App\Domain\Agent\Models\Agent;
 use App\Domain\Crew\Actions\CreateCrewAction;
 use App\Domain\Crew\Actions\GenerateCrewFromPromptAction;
 use App\Domain\Crew\Enums\CrewProcessType;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CreateCrewForm extends Component
@@ -64,6 +65,8 @@ class CreateCrewForm extends Component
 
     public function generateFromPrompt(GenerateCrewFromPromptAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate(['generatePrompt' => 'required|string|min:10']);
 
         $this->generating = true;
@@ -100,6 +103,8 @@ class CreateCrewForm extends Component
 
     public function save(CreateCrewAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate();
 
         try {

--- a/app/Livewire/Crews/CrewDetailPage.php
+++ b/app/Livewire/Crews/CrewDetailPage.php
@@ -9,6 +9,7 @@ use App\Domain\Crew\Enums\CrewProcessType;
 use App\Domain\Crew\Enums\CrewStatus;
 use App\Domain\Crew\Models\Crew;
 use App\Domain\Crew\Models\CrewMember;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CrewDetailPage extends Component
@@ -59,6 +60,8 @@ class CrewDetailPage extends Component
 
     public function toggleStatus(): void
     {
+        Gate::authorize('edit-content');
+
         $newStatus = $this->crew->status === CrewStatus::Active
             ? CrewStatus::Archived
             : CrewStatus::Active;
@@ -69,6 +72,8 @@ class CrewDetailPage extends Component
 
     public function activate(): void
     {
+        Gate::authorize('edit-content');
+
         $this->crew->update(['status' => CrewStatus::Active]);
         $this->crew->refresh();
     }
@@ -134,6 +139,8 @@ class CrewDetailPage extends Component
      */
     public function saveMemberPolicy(UpdateCrewAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'editMemberMaxSteps' => 'nullable|integer|min:1|max:100',
             'editMemberMaxCredits' => 'nullable|integer|min:1|max:1000000',
@@ -168,6 +175,8 @@ class CrewDetailPage extends Component
 
     public function save(UpdateCrewAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $teamId = auth()->user()->current_team_id;
 
         $this->validate([
@@ -203,6 +212,8 @@ class CrewDetailPage extends Component
 
     public function deleteCrew(): void
     {
+        Gate::authorize('edit-content');
+
         $this->crew->delete();
         session()->flash('message', 'Crew deleted.');
         $this->redirect(route('crews.index'));

--- a/app/Livewire/Email/EmailTemplateBuilderPage.php
+++ b/app/Livewire/Email/EmailTemplateBuilderPage.php
@@ -9,6 +9,7 @@ use App\Domain\Email\Enums\EmailTemplateStatus;
 use App\Domain\Email\Enums\EmailTemplateVisibility;
 use App\Domain\Email\Models\EmailTemplate;
 use App\Domain\Email\Models\EmailTheme;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class EmailTemplateBuilderPage extends Component
@@ -43,6 +44,8 @@ class EmailTemplateBuilderPage extends Component
 
     public function saveSettings(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'name' => 'required|min:2|max:255',
             'subject' => 'nullable|max:500',
@@ -67,6 +70,8 @@ class EmailTemplateBuilderPage extends Component
 
     public function save(string $html, string $designJsonStr): void
     {
+        Gate::authorize('edit-content');
+
         $designJson = json_decode($designJsonStr, true) ?? [];
 
         app(RenderEmailTemplateAction::class)->execute($this->template, $html, $designJson);
@@ -79,6 +84,8 @@ class EmailTemplateBuilderPage extends Component
 
     public function deleteTemplate(): void
     {
+        Gate::authorize('edit-content');
+
         app(DeleteEmailTemplateAction::class)->execute($this->template);
 
         session()->flash('message', 'Template deleted.');

--- a/app/Livewire/Email/EmailThemeDetailPage.php
+++ b/app/Livewire/Email/EmailThemeDetailPage.php
@@ -7,6 +7,7 @@ use App\Domain\Email\Actions\UpdateEmailThemeAction;
 use App\Domain\Email\Enums\EmailThemeStatus;
 use App\Domain\Email\Models\EmailTheme;
 use App\Domain\Shared\Models\Team;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class EmailThemeDetailPage extends Component
@@ -100,6 +101,8 @@ class EmailThemeDetailPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'editName' => 'required|min:2|max:255',
             'editStatus' => 'required|in:draft,active,archived',
@@ -158,6 +161,8 @@ class EmailThemeDetailPage extends Component
 
     public function setAsDefault(): void
     {
+        Gate::authorize('edit-content');
+
         $team = auth()->user()->currentTeam;
 
         Team::withoutGlobalScopes()
@@ -169,6 +174,8 @@ class EmailThemeDetailPage extends Component
 
     public function deleteTheme(): void
     {
+        Gate::authorize('edit-content');
+
         app(DeleteEmailThemeAction::class)->execute($this->theme);
 
         session()->flash('message', 'Email theme deleted.');

--- a/app/Livewire/GitRepositories/CreateGitRepositoryForm.php
+++ b/app/Livewire/GitRepositories/CreateGitRepositoryForm.php
@@ -6,6 +6,7 @@ use App\Domain\Credential\Models\Credential;
 use App\Domain\GitRepository\Actions\CreateGitRepositoryAction;
 use App\Domain\GitRepository\Enums\GitProvider;
 use App\Domain\GitRepository\Enums\GitRepoMode;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
 
@@ -79,6 +80,8 @@ class CreateGitRepositoryForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'name' => 'required|min:2|max:255',
             'url' => 'required|max:2048',

--- a/app/Livewire/Integrations/IntegrationDetailPage.php
+++ b/app/Livewire/Integrations/IntegrationDetailPage.php
@@ -12,6 +12,7 @@ use App\Domain\Integration\Services\IntegrationManager;
 use App\Domain\Tool\Enums\ToolStatus;
 use App\Domain\Tool\Models\Tool;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class IntegrationDetailPage extends Component
@@ -75,6 +76,8 @@ class IntegrationDetailPage extends Component
 
     public function disconnect(DisconnectIntegrationAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $action->execute($this->integration);
         session()->flash('message', 'Integration disconnected.');
         $this->redirect(route('integrations.index'), navigate: true);
@@ -85,6 +88,8 @@ class IntegrationDetailPage extends Component
      */
     public function syncNow(SyncActivepiecesToolsAction $action): void
     {
+        Gate::authorize('edit-content');
+
         if ($this->integration->getAttribute('driver') !== 'activepieces') {
             return;
         }

--- a/app/Livewire/Integrations/IntegrationListPage.php
+++ b/app/Livewire/Integrations/IntegrationListPage.php
@@ -8,6 +8,7 @@ use App\Domain\Integration\Actions\OAuthConnectAction;
 use App\Domain\Integration\Actions\PingIntegrationAction;
 use App\Domain\Integration\Models\Integration;
 use App\Domain\Integration\Services\IntegrationManager;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class IntegrationListPage extends Component
@@ -78,6 +79,8 @@ class IntegrationListPage extends Component
 
     public function connectOAuth(OAuthConnectAction $action): mixed
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'connectDriver' => 'required|string',
             'connectName' => 'required|string|min:2|max:255',
@@ -124,6 +127,8 @@ class IntegrationListPage extends Component
 
     public function connect(ConnectIntegrationAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'connectDriver' => 'required|string',
             'connectName' => 'required|string|min:2|max:255',
@@ -150,6 +155,8 @@ class IntegrationListPage extends Component
 
     public function disconnect(string $integrationId, DisconnectIntegrationAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $integration = Integration::findOrFail($integrationId);
         $action->execute($integration);
 

--- a/app/Livewire/OutboundConnectors/NotificationOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/NotificationOutboundPage.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\OutboundConnectors;
 
 use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class NotificationOutboundPage extends Component
@@ -30,6 +31,8 @@ class NotificationOutboundPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('manage-team');
+
         $this->validate([
             'defaultPriority' => 'required|in:low,normal,high',
         ]);

--- a/app/Livewire/OutboundConnectors/OutboundConnectorsPage.php
+++ b/app/Livewire/OutboundConnectors/OutboundConnectorsPage.php
@@ -4,6 +4,7 @@ namespace App\Livewire\OutboundConnectors;
 
 use App\Domain\Email\Models\EmailTemplate;
 use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class OutboundConnectorsPage extends Component
@@ -66,6 +67,8 @@ class OutboundConnectorsPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('manage-team');
+
         $this->validate([
             'host' => 'required|string|max:255',
             'port' => 'required|integer|between:1,65535',
@@ -116,6 +119,8 @@ class OutboundConnectorsPage extends Component
 
     public function testConnection(): void
     {
+        Gate::authorize('manage-team');
+
         $team = auth()->user()->currentTeam;
         $config = OutboundConnectorConfig::where('team_id', $team->id)
             ->where('channel', 'email')

--- a/app/Livewire/OutboundConnectors/WebhookOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/WebhookOutboundPage.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\OutboundConnectors;
 
 use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
 use Livewire\Component;
 
@@ -46,6 +47,8 @@ class WebhookOutboundPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('manage-team');
+
         $this->validate([
             'webhookUrl' => 'required|url|max:2048',
             'method' => 'required|in:POST,PUT,PATCH',
@@ -84,6 +87,8 @@ class WebhookOutboundPage extends Component
 
     public function testConnection(): void
     {
+        Gate::authorize('manage-team');
+
         $team = auth()->user()->currentTeam;
         $config = OutboundConnectorConfig::where('team_id', $team->id)
             ->where('channel', 'webhook')

--- a/app/Livewire/OutboundConnectors/WhatsAppOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/WhatsAppOutboundPage.php
@@ -4,6 +4,7 @@ namespace App\Livewire\OutboundConnectors;
 
 use App\Domain\Outbound\Models\OutboundConnectorConfig;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
 use Livewire\Component;
 
@@ -59,6 +60,8 @@ class WhatsAppOutboundPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('manage-team');
+
         $this->validate([
             'phoneNumberId' => 'required|string|max:64|regex:/^\d+$/',
             'businessAccountId' => 'nullable|string|max:64',
@@ -104,6 +107,8 @@ class WhatsAppOutboundPage extends Component
      */
     public function testConnection(): void
     {
+        Gate::authorize('manage-team');
+
         $team = auth()->user()->currentTeam;
         $config = OutboundConnectorConfig::where('team_id', $team->id)
             ->where('channel', 'whatsapp')

--- a/app/Livewire/Projects/CreateProjectForm.php
+++ b/app/Livewire/Projects/CreateProjectForm.php
@@ -12,6 +12,7 @@ use App\Domain\Project\Models\Project;
 use App\Domain\Tool\Models\Tool;
 use App\Domain\Workflow\Enums\WorkflowStatus;
 use App\Domain\Workflow\Models\Workflow;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CreateProjectForm extends Component
@@ -136,6 +137,8 @@ class CreateProjectForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate();
 
         $team = auth()->user()->currentTeam;

--- a/app/Livewire/Projects/ProjectDetailPage.php
+++ b/app/Livewire/Projects/ProjectDetailPage.php
@@ -15,6 +15,7 @@ use App\Domain\Project\Models\ProjectDependency;
 use App\Domain\Project\Models\ProjectMilestone;
 use App\Domain\Project\Models\ProjectRun;
 use App\Domain\Tool\Models\Tool;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Component;
 
@@ -31,6 +32,8 @@ class ProjectDetailPage extends Component
 
     public function pause(): void
     {
+        Gate::authorize('edit-content');
+
         app(PauseProjectAction::class)->execute($this->project, 'Manually paused');
         $this->project->refresh();
         session()->flash('message', 'Project paused.');
@@ -38,6 +41,8 @@ class ProjectDetailPage extends Component
 
     public function resume(): void
     {
+        Gate::authorize('edit-content');
+
         app(ResumeProjectAction::class)->execute($this->project);
         $this->project->refresh();
         session()->flash('message', 'Project resumed.');
@@ -45,6 +50,8 @@ class ProjectDetailPage extends Component
 
     public function archive(): void
     {
+        Gate::authorize('edit-content');
+
         app(ArchiveProjectAction::class)->execute($this->project);
         $this->project->refresh();
         session()->flash('message', 'Project archived.');
@@ -52,6 +59,8 @@ class ProjectDetailPage extends Component
 
     public function activate(): void
     {
+        Gate::authorize('edit-content');
+
         if ($this->project->status !== ProjectStatus::Draft) {
             return;
         }
@@ -75,6 +84,8 @@ class ProjectDetailPage extends Component
 
     public function restart(): void
     {
+        Gate::authorize('edit-content');
+
         app(RestartProjectAction::class)->execute($this->project);
         $this->project->refresh();
         session()->flash('message', 'Project restarted from scratch. New run triggered.');
@@ -82,6 +93,8 @@ class ProjectDetailPage extends Component
 
     public function triggerRun(): void
     {
+        Gate::authorize('edit-content');
+
         $key = 'trigger-run:'.$this->project->id;
 
         if (RateLimiter::tooManyAttempts($key, 3)) {

--- a/app/Livewire/Settings/ConnectorConfigModal.php
+++ b/app/Livewire/Settings/ConnectorConfigModal.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Settings;
 
 use App\Domain\Outbound\Models\OutboundConnectorConfig;
 use App\Domain\Outbound\Services\OutboundCredentialResolver;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Http;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -114,6 +115,8 @@ class ConnectorConfigModal extends Component
 
     public function save(): void
     {
+        Gate::authorize('manage-team');
+
         $credentials = $this->collectCredentials();
 
         if (empty(array_filter($credentials, fn ($v) => $v !== null && $v !== ''))) {
@@ -138,6 +141,8 @@ class ConnectorConfigModal extends Component
 
     public function testConnection(): void
     {
+        Gate::authorize('manage-team');
+
         $this->testing = true;
         $this->testResult = null;
         $this->testError = null;
@@ -169,6 +174,8 @@ class ConnectorConfigModal extends Component
 
     public function disconnect(): void
     {
+        Gate::authorize('manage-team');
+
         $teamId = $this->resolveTeamId();
 
         OutboundConnectorConfig::withoutGlobalScopes()

--- a/app/Livewire/Settings/WebhookSettingsPanel.php
+++ b/app/Livewire/Settings/WebhookSettingsPanel.php
@@ -6,6 +6,7 @@ use App\Domain\Shared\Models\Team;
 use App\Domain\Webhook\Enums\WebhookEvent;
 use App\Domain\Webhook\Models\WebhookEndpoint;
 use App\Models\User;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 use Livewire\Component;
 
@@ -60,6 +61,8 @@ class WebhookSettingsPanel extends Component
 
     public function save(): void
     {
+        Gate::authorize('manage-team');
+
         $this->validate();
 
         /** @var User $user */
@@ -95,6 +98,8 @@ class WebhookSettingsPanel extends Component
 
     public function toggleActive(string $id): void
     {
+        Gate::authorize('manage-team');
+
         $endpoint = WebhookEndpoint::find($id);
         if ($endpoint) {
             $endpoint->update(['is_active' => ! $endpoint->is_active]);
@@ -103,6 +108,8 @@ class WebhookSettingsPanel extends Component
 
     public function delete(string $id): void
     {
+        Gate::authorize('manage-team');
+
         WebhookEndpoint::find($id)?->delete();
     }
 

--- a/app/Livewire/Signals/ConnectorSetupPanel.php
+++ b/app/Livewire/Signals/ConnectorSetupPanel.php
@@ -6,6 +6,7 @@ use App\Domain\Signal\Actions\CreateSignalConnectorSettingAction;
 use App\Domain\Signal\Actions\RotateSignalSecretAction;
 use App\Domain\Signal\Models\Signal;
 use App\Domain\Signal\Models\SignalConnectorSetting;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -203,6 +204,8 @@ class ConnectorSetupPanel extends Component
      */
     public function rotateSecret(): void
     {
+        Gate::authorize('manage-team');
+
         $teamId = auth()->user()?->currentTeam?->id ?? session('team_id');
 
         if (! $teamId) {
@@ -231,6 +234,8 @@ class ConnectorSetupPanel extends Component
      */
     public function savePastedSecret(): void
     {
+        Gate::authorize('manage-team');
+
         $this->validate(['pasteSecretValue' => 'required|min:8']);
 
         $teamId = auth()->user()?->currentTeam?->id ?? session('team_id');

--- a/app/Livewire/Skills/CreateSkillForm.php
+++ b/app/Livewire/Skills/CreateSkillForm.php
@@ -186,6 +186,8 @@ class CreateSkillForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $allowedTypes = 'llm,connector,rule,hybrid,guardrail,multi_model_consensus,code_execution,gpu_compute,runpod_endpoint,runpod_pod,boruna_script,supabase_edge_function';
         if (config('browser.enabled', false)) {
             $allowedTypes .= ',browser';

--- a/app/Livewire/Skills/SkillDetailPage.php
+++ b/app/Livewire/Skills/SkillDetailPage.php
@@ -15,6 +15,7 @@ use App\Domain\Skill\Models\SkillBenchmark;
 use App\Domain\Skill\Models\SkillExecution;
 use App\Domain\Skill\Models\SkillVersion;
 use App\Infrastructure\AI\Services\ProviderResolver;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -69,6 +70,8 @@ class SkillDetailPage extends Component
 
     public function toggleStatus(): void
     {
+        Gate::authorize('edit-content');
+
         $newStatus = $this->skill->status === SkillStatus::Active
             ? SkillStatus::Disabled
             : SkillStatus::Active;
@@ -100,6 +103,8 @@ class SkillDetailPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'editName' => 'required|min:2|max:255',
             'editDescription' => 'max:1000',
@@ -136,6 +141,8 @@ class SkillDetailPage extends Component
 
     public function deleteSkill(): void
     {
+        Gate::authorize('edit-content');
+
         $this->skill->delete();
 
         session()->flash('message', 'Skill deleted.');
@@ -144,6 +151,8 @@ class SkillDetailPage extends Component
 
     public function startBenchmark(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'benchMetricName' => 'required|string|max:100',
             'benchMetricDirection' => 'required|in:maximize,minimize',

--- a/app/Livewire/Telegram/TelegramBotsPage.php
+++ b/app/Livewire/Telegram/TelegramBotsPage.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Telegram;
 use App\Domain\Project\Models\Project;
 use App\Domain\Telegram\Actions\RegisterTelegramBotAction;
 use App\Domain\Telegram\Models\TelegramBot;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
@@ -35,6 +36,8 @@ class TelegramBotsPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate();
         $this->error = null;
 
@@ -60,6 +63,8 @@ class TelegramBotsPage extends Component
 
     public function toggleStatus(string $botId): void
     {
+        Gate::authorize('edit-content');
+
         $bot = TelegramBot::findOrFail($botId);
         $bot->update(['status' => $bot->isActive() ? 'disabled' : 'active']);
         $this->success = 'Bot status updated.';
@@ -68,6 +73,8 @@ class TelegramBotsPage extends Component
 
     public function delete(string $botId): void
     {
+        Gate::authorize('edit-content');
+
         TelegramBot::findOrFail($botId)->delete();
         $this->success = 'Bot removed.';
         $this->error = null;

--- a/app/Livewire/Tools/CreateToolForm.php
+++ b/app/Livewire/Tools/CreateToolForm.php
@@ -9,6 +9,7 @@ use App\Domain\Tool\Actions\CreateToolAction;
 use App\Domain\Tool\Enums\BuiltInToolKind;
 use App\Domain\Tool\Enums\ToolRiskLevel;
 use App\Domain\Tool\Enums\ToolType;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CreateToolForm extends Component
@@ -132,6 +133,8 @@ class CreateToolForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $team = auth()->user()->currentTeam;
         $type = ToolType::from($this->type);
 

--- a/app/Livewire/Tools/ToolDetailPage.php
+++ b/app/Livewire/Tools/ToolDetailPage.php
@@ -12,6 +12,7 @@ use App\Domain\Tool\Enums\ToolRiskLevel;
 use App\Domain\Tool\Enums\ToolStatus;
 use App\Domain\Tool\Models\TeamToolActivation;
 use App\Domain\Tool\Models\Tool;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class ToolDetailPage extends Component
@@ -61,6 +62,8 @@ class ToolDetailPage extends Component
 
     public function toggleStatus(): void
     {
+        Gate::authorize('edit-content');
+
         $teamId = auth()->user()->current_team_id;
 
         if ($this->tool->isPlatformTool()) {
@@ -84,6 +87,8 @@ class ToolDetailPage extends Component
 
     public function saveCredentials(): void
     {
+        Gate::authorize('edit-content');
+
         $teamId = auth()->user()->current_team_id;
         $overrides = array_filter($this->credentialInputs, fn ($v) => $v !== '');
 
@@ -121,6 +126,8 @@ class ToolDetailPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         if ($this->tool->isPlatformTool()) {
             return;
         }
@@ -147,6 +154,8 @@ class ToolDetailPage extends Component
 
     public function saveProxyCredential(): void
     {
+        Gate::authorize('edit-content');
+
         $config = $this->tool->transport_config ?? [];
 
         if ($this->proxyCredentialId) {
@@ -166,6 +175,8 @@ class ToolDetailPage extends Component
 
     public function deleteTool(): void
     {
+        Gate::authorize('edit-content');
+
         if ($this->tool->isPlatformTool()) {
             return;
         }

--- a/app/Livewire/Toolsets/CreateToolsetForm.php
+++ b/app/Livewire/Toolsets/CreateToolsetForm.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Toolsets;
 use App\Domain\Tool\Actions\CreateToolsetAction;
 use App\Domain\Tool\Enums\ToolStatus;
 use App\Domain\Tool\Models\Tool;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CreateToolsetForm extends Component
@@ -31,6 +32,8 @@ class CreateToolsetForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate();
 
         $teamId = auth()->user()->current_team_id;

--- a/app/Livewire/Toolsets/ToolsetDetailPage.php
+++ b/app/Livewire/Toolsets/ToolsetDetailPage.php
@@ -7,6 +7,7 @@ use App\Domain\Tool\Actions\UpdateToolsetAction;
 use App\Domain\Tool\Enums\ToolStatus;
 use App\Domain\Tool\Models\Tool;
 use App\Domain\Tool\Models\Toolset;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class ToolsetDetailPage extends Component
@@ -42,6 +43,8 @@ class ToolsetDetailPage extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         $teamId = auth()->user()->current_team_id;
 
         $this->validate([
@@ -67,6 +70,8 @@ class ToolsetDetailPage extends Component
 
     public function delete(): void
     {
+        Gate::authorize('edit-content');
+
         app(DeleteToolsetAction::class)->execute($this->toolset);
         $this->redirect(route('toolsets.index'), navigate: true);
     }

--- a/app/Livewire/Triggers/CreateTriggerRuleForm.php
+++ b/app/Livewire/Triggers/CreateTriggerRuleForm.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Triggers;
 
 use App\Domain\Project\Models\Project;
 use App\Domain\Trigger\Actions\CreateTriggerRuleAction;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class CreateTriggerRuleForm extends Component
@@ -57,6 +58,8 @@ class CreateTriggerRuleForm extends Component
 
     public function save(CreateTriggerRuleAction $action): void
     {
+        Gate::authorize('edit-content');
+
         $teamId = auth()->user()->current_team_id;
 
         $this->validate([

--- a/app/Livewire/Triggers/TriggerRulesPage.php
+++ b/app/Livewire/Triggers/TriggerRulesPage.php
@@ -8,6 +8,7 @@ use App\Domain\Trigger\Actions\DeleteTriggerRuleAction;
 use App\Domain\Trigger\Actions\ExecuteTriggerRuleAction;
 use App\Domain\Trigger\Actions\UpdateTriggerRuleAction;
 use App\Domain\Trigger\Models\TriggerRule;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -59,6 +60,8 @@ class TriggerRulesPage extends Component
 
     public function saveEdit(): void
     {
+        Gate::authorize('edit-content');
+
         $teamId = auth()->user()->current_team_id;
 
         $this->validate([
@@ -85,6 +88,8 @@ class TriggerRulesPage extends Component
 
     public function testTrigger(string $ruleId): void
     {
+        Gate::authorize('edit-content');
+
         $rule = TriggerRule::findOrFail($ruleId);
 
         // Find the most recent matching signal, or create a test one
@@ -114,6 +119,8 @@ class TriggerRulesPage extends Component
 
     public function toggleStatus(string $ruleId): void
     {
+        Gate::authorize('edit-content');
+
         $rule = TriggerRule::findOrFail($ruleId);
 
         $newStatus = $rule->status->isActive() ? 'paused' : 'active';
@@ -124,6 +131,8 @@ class TriggerRulesPage extends Component
 
     public function delete(string $ruleId): void
     {
+        Gate::authorize('edit-content');
+
         $rule = TriggerRule::findOrFail($ruleId);
         app(DeleteTriggerRuleAction::class)->execute($rule);
 

--- a/app/Livewire/Websites/WebsiteBuilderPage.php
+++ b/app/Livewire/Websites/WebsiteBuilderPage.php
@@ -6,6 +6,7 @@ use App\Domain\Website\Actions\PublishWebsitePageAction;
 use App\Domain\Website\Actions\UpdateWebsitePageAction;
 use App\Domain\Website\Models\Website;
 use App\Domain\Website\Models\WebsitePage;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class WebsiteBuilderPage extends Component
@@ -33,6 +34,8 @@ class WebsiteBuilderPage extends Component
 
     public function saveContent(array $grapesJson, string $html, string $css): void
     {
+        Gate::authorize('edit-content');
+
         app(UpdateWebsitePageAction::class)->execute($this->page, [
             'grapes_json' => $grapesJson,
             'exported_html' => $html,
@@ -44,6 +47,8 @@ class WebsiteBuilderPage extends Component
 
     public function saveSettings(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'title' => 'required|max:255',
             'slug' => 'required|max:255',
@@ -60,6 +65,8 @@ class WebsiteBuilderPage extends Component
 
     public function publishPage(): void
     {
+        Gate::authorize('edit-content');
+
         app(PublishWebsitePageAction::class)->execute($this->page);
 
         session()->flash('message', 'Page published.');

--- a/app/Livewire/Websites/WebsiteDetailPage.php
+++ b/app/Livewire/Websites/WebsiteDetailPage.php
@@ -15,6 +15,7 @@ use App\Domain\Website\Enums\WebsiteStatus;
 use App\Domain\Website\Exceptions\DeploymentDriverException;
 use App\Domain\Website\Models\Website;
 use App\Domain\Website\Models\WebsitePage;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 use Livewire\Component;
 
@@ -42,6 +43,8 @@ class WebsiteDetailPage extends Component
 
     public function addPage(): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'pageTitle' => 'required|max:255',
             'pageSlug' => 'required|max:255',
@@ -64,6 +67,8 @@ class WebsiteDetailPage extends Component
 
     public function deletePage(string $pageId): void
     {
+        Gate::authorize('edit-content');
+
         // Scope to this website — prevents cross-website page deletion within same team
         $page = $this->website->pages()->findOrFail($pageId);
         app(DeleteWebsitePageAction::class)->execute($page);
@@ -74,6 +79,8 @@ class WebsiteDetailPage extends Component
 
     public function publishPage(string $pageId): void
     {
+        Gate::authorize('edit-content');
+
         // Scope to this website — prevents cross-website page publishing within same team
         $page = $this->website->pages()->findOrFail($pageId);
         app(PublishWebsitePageAction::class)->execute($page);
@@ -84,6 +91,8 @@ class WebsiteDetailPage extends Component
 
     public function unpublishPage(string $pageId): void
     {
+        Gate::authorize('edit-content');
+
         // Scope to this website — prevents cross-website page unpublishing within same team
         $page = $this->website->pages()->findOrFail($pageId);
         app(UnpublishWebsitePageAction::class)->execute($page);
@@ -94,6 +103,8 @@ class WebsiteDetailPage extends Component
 
     public function unpublishWebsite(): void
     {
+        Gate::authorize('edit-content');
+
         app(UnpublishWebsiteAction::class)->execute($this->website);
 
         session()->flash('success', 'Website unpublished.');
@@ -102,6 +113,8 @@ class WebsiteDetailPage extends Component
 
     public function publishWebsite(): void
     {
+        Gate::authorize('edit-content');
+
         // Only publish draft pages that have content — skip empty drafts
         $this->website->pages()
             ->where('status', 'draft')
@@ -119,6 +132,8 @@ class WebsiteDetailPage extends Component
 
     public function deleteWebsite(): void
     {
+        Gate::authorize('edit-content');
+
         app(DeleteWebsiteAction::class)->execute($this->website);
 
         session()->flash('success', 'Website deleted.');
@@ -127,6 +142,8 @@ class WebsiteDetailPage extends Component
 
     public function deployWebsite(string $provider = 'zip'): void
     {
+        Gate::authorize('edit-content');
+
         $providerEnum = DeploymentProvider::tryFrom($provider);
         if (! $providerEnum) {
             session()->flash('error', "Unknown deployment provider '{$provider}'.");

--- a/app/Livewire/Workflows/ScheduleWorkflowForm.php
+++ b/app/Livewire/Workflows/ScheduleWorkflowForm.php
@@ -10,6 +10,7 @@ use App\Domain\Project\Enums\ScheduleFrequency;
 use App\Domain\Project\Services\NaturalLanguageScheduleParser;
 use App\Domain\Workflow\Enums\WorkflowStatus;
 use App\Domain\Workflow\Models\Workflow;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class ScheduleWorkflowForm extends Component
@@ -131,6 +132,8 @@ class ScheduleWorkflowForm extends Component
 
     public function save(): void
     {
+        Gate::authorize('edit-content');
+
         if ($this->useNlpSchedule && $this->nlpScheduleInput) {
             $this->parseNlpSchedule();
         }

--- a/app/Livewire/Workflows/WorkflowBuilderPage.php
+++ b/app/Livewire/Workflows/WorkflowBuilderPage.php
@@ -15,6 +15,7 @@ use App\Domain\Workflow\Actions\UpdateWorkflowAction;
 use App\Domain\Workflow\Actions\ValidateWorkflowGraphAction;
 use App\Domain\Workflow\Enums\WorkflowNodeType;
 use App\Domain\Workflow\Models\Workflow;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -164,12 +165,16 @@ class WorkflowBuilderPage extends Component
 
     public function saveGraph(array $nodes, array $edges): void
     {
+        Gate::authorize('edit-content');
+
         $this->nodes = $nodes;
         $this->edges = $edges;
     }
 
     public function save(bool $flash = true): void
     {
+        Gate::authorize('edit-content');
+
         $this->validate([
             'name' => 'required|string|max:255',
             'maxLoopIterations' => 'required|integer|min:1|max:100',


### PR DESCRIPTION
## Summary

Closes the remaining 33 Livewire forms that had `save()`/write methods without `Gate::authorize`. Companion to yesterday's `fix(security)` commit which fixed 2 forms (EditProjectForm + GitRepositoryDetailPage); this commit closes the rest.

## Why

In community edition all gates return true (single-team mode). In cloud, `CloudServiceProvider` overrides:
- `edit-content` → `\$user->teamRole(\$team)->canEdit()`
- `manage-team` → `\$user->teamRole(\$team)->canManageTeam()`

Without `Gate::authorize` on Livewire write methods, a cloud team's viewer-role member could submit form POST and mutate team-owned data. Routes are auth-protected but role differentiation was never checked.

## Scope

35 Livewire write methods across 33 forms gated:

**edit-content** (domain content): Agents, Chatbots, Credentials, Crews, Email themes/templates, Git repos, Integrations, Projects, Signal connector setup (rotate/save secret), Skills, Telegram bots, Tools, Toolsets, Triggers, Websites, Workflows.

**manage-team** (team config): Outbound connectors (SMTP, webhook, notifications, WhatsApp), connector setup secrets.

## Tests

- 3065 base tests pass
- 6 pre-existing SocialLoginTest failures unchanged (unrelated to sprint, was failing on master before this branch)
- Pint clean
- PHPStan clean (no baseline regenerated)

## Test plan

- [ ] CI green
- [x] Existing tests still pass
- [ ] Cloud manual smoke: viewer role gets 403 on save form, owner/admin proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)