### PR TITLE
feat: credit pricing P1+P2 — sync, agent cap, BYOK fee scaffolding

### DIFF
--- a/app/Console/Commands/LlmPricingSyncCommand.php
+++ b/app/Console/Commands/LlmPricingSyncCommand.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Detect price drift from Helicone aggregator and propose snapshot rotations.
+ *
+ * Lives in BASE so community installs can also run it. Community has no
+ * PricingSnapshotService binding and exits gracefully with a hint message.
+ *
+ * Cloud snapshot rotation goes through Cloud\Domain\Budget\Services\PricingSnapshotService
+ * via app()->bound() container check — keeps this command edition-agnostic.
+ */
+class LlmPricingSyncCommand extends Command
+{
+    protected $signature = 'llm-pricing:sync {--dry-run : Show drift without rotating snapshot}';
+
+    protected $description = 'Sync LLM pricing from Helicone aggregator; rotate snapshot if drift > threshold';
+
+    private const HELICONE_URL = 'https://www.helicone.ai/api/llm-costs';
+
+    private const SNAPSHOT_SERVICE = '\\Cloud\\Domain\\Budget\\Services\\PricingSnapshotService';
+
+    private const SNAPSHOT_MODEL = '\\Cloud\\Domain\\Budget\\Models\\LlmPricingSnapshot';
+
+    /** Hard sanity-check ceiling — drift > this is treated as parser bug, not a real change. */
+    private const SANITY_DRIFT = 0.50;
+
+    public function handle(): int
+    {
+        $threshold = (float) config('llm_pricing.sync_drift_threshold', 0.05);
+
+        $rows = $this->fetchHeliconeRates();
+        if ($rows === null) {
+            return self::FAILURE;
+        }
+
+        if ($rows === []) {
+            $this->warn('Helicone returned no rows; nothing to compare.');
+
+            return self::SUCCESS;
+        }
+
+        $current = $this->resolveCurrentRates();
+        if ($current === null) {
+            $this->warn('Snapshot service not available — manual config edit required (community edition).');
+
+            return self::SUCCESS;
+        }
+
+        $drifts = $this->detectDrifts($current['providers'] ?? [], $rows, $threshold);
+
+        if ($drifts === []) {
+            $this->info('No drift detected above '.($threshold * 100).'% threshold across '.count($rows).' Helicone entries.');
+
+            return self::SUCCESS;
+        }
+
+        $this->renderDriftTable($drifts);
+
+        $manualReview = array_filter($drifts, fn ($d) => $d['drift'] > self::SANITY_DRIFT);
+        if ($manualReview !== []) {
+            $this->warn('Drift > '.(self::SANITY_DRIFT * 100).'% on '.count($manualReview).' models — flagged as manual review (likely Helicone parsing bug). Skipping auto-rotation.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — snapshot not rotated.');
+
+            return self::SUCCESS;
+        }
+
+        $newRates = $this->mergeNewRates($current, $drifts);
+
+        $service = app(self::SNAPSHOT_SERVICE);
+        $service->recordChange(
+            $newRates,
+            constant(self::SNAPSHOT_MODEL.'::SOURCE_AUTO_SYNC'),
+            null,
+            $this->buildNotes($drifts),
+        );
+
+        $this->info('Rotated snapshot with '.count($drifts).' updated model(s).');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<int,array{provider:string,model:string,input:float,output:float}>|null
+     */
+    private function fetchHeliconeRates(): ?array
+    {
+        try {
+            $response = Http::timeout(30)
+                ->acceptJson()
+                ->get(self::HELICONE_URL);
+        } catch (Throwable $e) {
+            $this->error('Helicone fetch failed: '.$e->getMessage());
+            Log::error('llm-pricing:sync fetch failure', ['error' => $e->getMessage()]);
+
+            return null;
+        }
+
+        if (! $response->successful()) {
+            $this->error('Helicone HTTP '.$response->status());
+            Log::error('llm-pricing:sync non-200', ['status' => $response->status()]);
+
+            return null;
+        }
+
+        try {
+            $body = $response->json();
+        } catch (Throwable $e) {
+            $this->error('Helicone returned malformed JSON: '.$e->getMessage());
+
+            return null;
+        }
+
+        if (! is_array($body)) {
+            $this->error('Helicone payload not an array.');
+
+            return null;
+        }
+
+        // Helicone may wrap rows under "data" or return them at root. Accept either.
+        $rows = isset($body['data']) && is_array($body['data']) ? $body['data'] : $body;
+
+        return $this->normalizeRows($rows);
+    }
+
+    /**
+     * @param  array<int|string,mixed>  $rows
+     * @return array<int,array{provider:string,model:string,input:float,output:float}>
+     */
+    private function normalizeRows(array $rows): array
+    {
+        $out = [];
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $provider = (string) ($row['provider'] ?? $row['provider_slug'] ?? '');
+            $model = (string) ($row['model'] ?? $row['model_id'] ?? '');
+            if ($provider === '' || $model === '') {
+                continue;
+            }
+
+            $input = $this->extractRate($row, ['input_cost_per_1m', 'input_usd_per_mtok', 'input_cost', 'prompt_cost_per_1m']);
+            $output = $this->extractRate($row, ['output_cost_per_1m', 'output_usd_per_mtok', 'output_cost', 'completion_cost_per_1m']);
+
+            if ($input === null || $output === null) {
+                continue;
+            }
+
+            $out[] = [
+                'provider' => strtolower($provider),
+                'model' => $model,
+                'input' => $input,
+                'output' => $output,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  array<int,string>  $keys
+     */
+    private function extractRate(array $row, array $keys): ?float
+    {
+        foreach ($keys as $key) {
+            if (! array_key_exists($key, $row)) {
+                continue;
+            }
+            $val = $row[$key];
+            if (is_numeric($val)) {
+                return (float) $val;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function resolveCurrentRates(): ?array
+    {
+        if (! app()->bound(self::SNAPSHOT_SERVICE) && ! class_exists(self::SNAPSHOT_SERVICE)) {
+            return null;
+        }
+
+        try {
+            $service = app(self::SNAPSHOT_SERVICE);
+            $snapshot = $service->current();
+        } catch (Throwable $e) {
+            $this->error('Snapshot lookup failed: '.$e->getMessage());
+
+            return null;
+        }
+
+        return $snapshot->rates;
+    }
+
+    /**
+     * @param  array<string,mixed>  $currentProviders
+     * @param  array<int,array{provider:string,model:string,input:float,output:float}>  $heliconeRows
+     * @return array<int,array{provider:string,model:string,field:string,current:float,proposed:float,drift:float}>
+     */
+    private function detectDrifts(array $currentProviders, array $heliconeRows, float $threshold): array
+    {
+        $heliconeIndex = [];
+        foreach ($heliconeRows as $row) {
+            $heliconeIndex[$row['provider']][$row['model']] = $row;
+        }
+
+        $drifts = [];
+        foreach ($currentProviders as $provider => $models) {
+            if (! is_array($models)) {
+                continue;
+            }
+            $heliconeForProvider = $heliconeIndex[(string) $provider] ?? [];
+            foreach ($models as $model => $cfg) {
+                if (! is_array($cfg) || ! isset($heliconeForProvider[$model])) {
+                    continue;
+                }
+                $hRow = $heliconeForProvider[$model];
+
+                foreach ([
+                    'input_usd_per_mtok' => $hRow['input'],
+                    'output_usd_per_mtok' => $hRow['output'],
+                ] as $field => $newVal) {
+                    $current = (float) ($cfg[$field] ?? 0.0);
+                    if ($current <= 0.0) {
+                        // Skip zero-cost passthroughs; drift is mathematically undefined.
+                        continue;
+                    }
+                    $drift = abs($newVal - $current) / $current;
+                    if ($drift > $threshold) {
+                        $drifts[] = [
+                            'provider' => $provider,
+                            'model' => $model,
+                            'field' => $field,
+                            'current' => $current,
+                            'proposed' => $newVal,
+                            'drift' => $drift,
+                        ];
+                    }
+                }
+            }
+        }
+
+        return $drifts;
+    }
+
+    /**
+     * @param  array<int,array{provider:string,model:string,field:string,current:float,proposed:float,drift:float}>  $drifts
+     */
+    private function renderDriftTable(array $drifts): void
+    {
+        $rows = array_map(fn ($d) => [
+            $d['provider'],
+            $d['model'],
+            $d['field'],
+            number_format($d['current'], 4),
+            number_format($d['proposed'], 4),
+            number_format($d['drift'] * 100, 2).'%',
+        ], $drifts);
+
+        $this->table(['Provider', 'Model', 'Field', 'Current $/Mtok', 'Proposed $/Mtok', 'Drift'], $rows);
+    }
+
+    /**
+     * Apply detected drift values into the rates structure, preserving every
+     * other field (cache_*, tier, context_window, last_verified_at, source_url).
+     *
+     * @param  array<string,mixed>  $current
+     * @param  array<int,array{provider:string,model:string,field:string,current:float,proposed:float,drift:float}>  $drifts
+     * @return array<string,mixed>
+     */
+    private function mergeNewRates(array $current, array $drifts): array
+    {
+        $newRates = $current;
+        foreach ($drifts as $d) {
+            $newRates['providers'][$d['provider']][$d['model']][$d['field']] = $d['proposed'];
+        }
+
+        return $newRates;
+    }
+
+    /**
+     * @param  array<int,array{provider:string,model:string,field:string,current:float,proposed:float,drift:float}>  $drifts
+     */
+    private function buildNotes(array $drifts): string
+    {
+        $lines = ['Auto-sync from Helicone — '.count($drifts).' field(s) updated:'];
+        foreach ($drifts as $d) {
+            $lines[] = sprintf(
+                '%s/%s %s: %.4f → %.4f (%.2f%% drift)',
+                $d['provider'], $d['model'], $d['field'], $d['current'], $d['proposed'], $d['drift'] * 100,
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/app/Domain/Agent/Models/Agent.php
+++ b/app/Domain/Agent/Models/Agent.php
@@ -10,6 +10,7 @@ use App\Domain\AgentChatProtocol\Enums\AgentChatVisibility;
 use App\Domain\Evolution\Models\EvolutionProposal;
 use App\Domain\Knowledge\Models\KnowledgeBase;
 use App\Domain\Shared\Enums\DataClassification;
+use App\Domain\Shared\Models\Team;
 use App\Domain\Shared\Traits\BelongsToTeam;
 use App\Domain\Shared\Traits\HasPluginMeta;
 use App\Domain\Skill\Models\Skill;
@@ -45,6 +46,7 @@ use Illuminate\Support\Carbon;
  * @property array|null $constraints
  * @property int|null $budget_cap_credits
  * @property int $budget_spent_credits
+ * @property int|null $max_credits_per_call
  * @property int $cost_per_1k_input
  * @property int $cost_per_1k_output
  * @property Carbon|null $last_health_check
@@ -78,6 +80,7 @@ class Agent extends Model
         'constraints',
         'budget_cap_credits',
         'budget_spent_credits',
+        'max_credits_per_call',
         'evaluation_enabled',
         'evaluation_sample_rate',
         'evaluation_model',
@@ -126,6 +129,7 @@ class Agent extends Model
             'cost_per_1k_output' => 'integer',
             'budget_cap_credits' => 'integer',
             'budget_spent_credits' => 'integer',
+            'max_credits_per_call' => 'integer',
             'evaluation_enabled' => 'boolean',
             'evaluation_sample_rate' => 'float',
             'evaluation_criteria' => 'array',
@@ -277,5 +281,25 @@ class Agent extends Model
         }
 
         return max(0, $this->budget_cap_credits - $this->budget_spent_credits);
+    }
+
+    /**
+     * Resolve the effective max-credits-per-call cap with precedence:
+     * agent.max_credits_per_call → team.effectiveMaxCreditsPerCall() → config.
+     * Returns null when uncapped.
+     */
+    public function effectiveMaxCreditsPerCall(?Team $team = null): ?int
+    {
+        if ($this->max_credits_per_call !== null) {
+            return (int) $this->max_credits_per_call;
+        }
+
+        if ($team !== null) {
+            return $team->effectiveMaxCreditsPerCall();
+        }
+
+        $configMax = config('llm_pricing.max_credits_per_call');
+
+        return $configMax !== null ? (int) $configMax : null;
     }
 }

--- a/app/Domain/Budget/Actions/EnforceMaxCreditsPerCallAction.php
+++ b/app/Domain/Budget/Actions/EnforceMaxCreditsPerCallAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Budget\Actions;
 
+use App\Domain\Agent\Models\Agent;
 use App\Domain\Budget\Exceptions\InsufficientBudgetException;
 use App\Domain\Budget\Services\CostCalculator;
 use App\Domain\Shared\Models\Team;
@@ -27,6 +28,7 @@ class EnforceMaxCreditsPerCallAction
         int $maxOutputTokens,
         int $estimatedInputTokens = 500,
         ?string $cacheStrategy = null,
+        ?string $agentId = null,
     ): void {
         if ($teamId === '') {
             return;
@@ -37,7 +39,13 @@ class EnforceMaxCreditsPerCallAction
             return;
         }
 
-        $cap = $team->effectiveMaxCreditsPerCall();
+        if ($agentId !== null) {
+            $agent = Agent::withoutGlobalScopes()->find($agentId);
+            $cap = $agent ? $agent->effectiveMaxCreditsPerCall($team) : $team->effectiveMaxCreditsPerCall();
+        } else {
+            $cap = $team->effectiveMaxCreditsPerCall();
+        }
+
         if ($cap === null) {
             return;
         }

--- a/app/Domain/Shared/Models/Team.php
+++ b/app/Domain/Shared/Models/Team.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Str;
  * @property string|null $sub_program_slug
  * @property float|null $credit_margin_multiplier
  * @property int|null $max_credits_per_call
+ * @property int|null $byok_platform_fee_per_call
  */
 class Team extends Model
 {
@@ -150,6 +151,14 @@ class Team extends Model
         $configMax = config('llm_pricing.max_credits_per_call');
 
         return $configMax !== null ? (int) $configMax : null;
+    }
+
+    /**
+     * Community edition has no per-team BYOK fee — falls through to config.
+     */
+    public function effectiveByokPlatformFee(): int
+    {
+        return (int) config('llm_pricing.byok_platform_fee_per_call', 0);
     }
 
     /**

--- a/app/Infrastructure/AI/Middleware/BudgetEnforcement.php
+++ b/app/Infrastructure/AI/Middleware/BudgetEnforcement.php
@@ -33,6 +33,7 @@ class BudgetEnforcement implements AiMiddlewareInterface
             provider: $request->provider,
             model: $request->model,
             maxOutputTokens: $request->maxTokens,
+            agentId: $request->agentId,
         );
 
         $estimatedCost = $this->costCalculator->estimateCost(

--- a/app/Livewire/Agents/AgentDetailPage.php
+++ b/app/Livewire/Agents/AgentDetailPage.php
@@ -30,6 +30,7 @@ use App\Domain\Tool\Models\ToolSearchLog;
 use App\Infrastructure\AI\Enums\ReasoningEffort;
 use App\Infrastructure\AI\Services\ProviderResolver;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -56,6 +57,8 @@ class AgentDetailPage extends Component
     public string $editModel = '';
 
     public ?int $editBudgetCap = null;
+
+    public ?int $editMaxCreditsPerCall = null;
 
     public array $editFallbackChain = [];
 
@@ -238,6 +241,9 @@ class AgentDetailPage extends Component
         $this->editProvider = $this->agent->provider;
         $this->editModel = $this->agent->model;
         $this->editBudgetCap = $this->agent->budget_cap_credits;
+        $this->editMaxCreditsPerCall = Schema::hasColumn('agents', 'max_credits_per_call')
+            ? $this->agent->max_credits_per_call
+            : null;
         $this->editFallbackChain = $this->agent->config['fallback_chain'] ?? [];
         $this->editExecutionTier = $this->agent->config['execution_tier'] ?? 'standard';
         /** @var array<string, mixed> $personality */
@@ -411,13 +417,21 @@ class AgentDetailPage extends Component
             'model' => $this->editModel,
             'budget_cap_credits' => $this->editBudgetCap,
             'tool_profile' => $this->editToolProfile ?: null,
+            // max_credits_per_call only applied when the cloud column exists.
+        ];
+
+        if (Schema::hasColumn('agents', 'max_credits_per_call')) {
+            $newConfig['max_credits_per_call'] = $this->editMaxCreditsPerCall;
+        }
+
+        $newConfig = array_merge($newConfig, [
             'environment' => $this->editEnvironment ?: null,
             'evaluation_enabled' => $this->editEvaluationEnabled,
             'evaluation_sample_rate' => $this->editEvaluationEnabled ? ($this->editEvaluationSampleRate ?? 0.2) : 0.0,
             'config' => $config,
             'cost_per_1k_input' => $pricing['input'] ?? 0,
             'cost_per_1k_output' => $pricing['output'] ?? 0,
-        ];
+        ]);
 
         app(RecordAgentConfigRevisionAction::class)->execute(
             agent: $this->agent,

--- a/app/Livewire/Agents/CreateAgentForm.php
+++ b/app/Livewire/Agents/CreateAgentForm.php
@@ -12,6 +12,7 @@ use App\Domain\Tool\Models\Tool;
 use App\Infrastructure\AI\Enums\ReasoningEffort;
 use App\Infrastructure\AI\Services\ProviderResolver;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Validation\Rule;
 use Livewire\Component;
 
@@ -41,6 +42,8 @@ class CreateAgentForm extends Component
     public string $model = '';
 
     public ?int $budgetCapCredits = null;
+
+    public ?int $maxCreditsPerCall = null;
 
     public array $selectedSkillIds = [];
 
@@ -133,6 +136,8 @@ class CreateAgentForm extends Component
             'environment' => ['nullable', Rule::enum(AgentEnvironment::class)],
             'useToolSearch' => ['nullable', 'boolean'],
             'toolSearchTopK' => ['nullable', 'integer', 'min:1', 'max:20'],
+            'budgetCapCredits' => ['nullable', 'integer', 'min:0'],
+            'maxCreditsPerCall' => ['nullable', 'integer', 'min:1'],
         ];
     }
 
@@ -217,6 +222,10 @@ class CreateAgentForm extends Component
             config: $config,
             personality: $personality,
         );
+
+        if ($this->maxCreditsPerCall !== null && Schema::hasColumn('agents', 'max_credits_per_call')) {
+            $agent->update(['max_credits_per_call' => $this->maxCreditsPerCall]);
+        }
 
         if ($this->toolProfile !== '') {
             $agent->update(['tool_profile' => $this->toolProfile]);
@@ -349,6 +358,7 @@ class CreateAgentForm extends Component
             'canCreate' => true,
             'availableGitRepositories' => $availableGitRepositories,
             'availableKnowledgeBases' => $availableKnowledgeBases,
+            'supportsMaxCreditsPerCall' => Schema::hasColumn('agents', 'max_credits_per_call'),
         ])->layout('layouts.app', ['header' => 'Create Agent']);
     }
 }

--- a/config/llm_pricing.php
+++ b/config/llm_pricing.php
@@ -30,6 +30,21 @@ return [
         ? (int) env('FLEETQ_MAX_CREDITS_PER_CALL')
         : null,
 
+    // BYOK platform fee — flat platform_credits charged per LLM call when team uses
+    // their own provider key. Default 0 preserves current "BYOK skips deduction" behavior.
+    // Per-team override via teams.byok_platform_fee_per_call.
+    'byok_platform_fee_per_call' => (int) env('FLEETQ_BYOK_PLATFORM_FEE', 0),
+
+    // Cost-alert thresholds for EvaluateCostAlertsCommand (P1-3).
+    'alerts' => [
+        'bleeding_team_ratio' => (float) env('FLEETQ_ALERT_BLEEDING_RATIO', 1.5),
+        'stale_pricing_days' => (int) env('FLEETQ_ALERT_STALE_DAYS', 90),
+        'margin_drift_threshold_pct' => (float) env('FLEETQ_ALERT_MARGIN_DRIFT', 25),
+    ],
+
+    // Helicone auto-sync drift threshold (fraction). >this triggers snapshot rotation. (P1-1)
+    'sync_drift_threshold' => (float) env('FLEETQ_PRICING_DRIFT_THRESHOLD', 0.05),
+
     'usd_to_eur_rate' => (float) env('FLEETQ_USD_TO_EUR', 0.91),
 
     'last_updated_at' => '2026-05-04',

--- a/resources/views/livewire/agents/agent-detail-page.blade.php
+++ b/resources/views/livewire/agents/agent-detail-page.blade.php
@@ -63,6 +63,13 @@
                         hint="Leave empty for unlimited" />
                 </div>
 
+                @if(\Illuminate\Support\Facades\Schema::hasColumn('agents', 'max_credits_per_call'))
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <x-form-input wire:model.number="editMaxCreditsPerCall" label="Max credits per call (override)" type="number" min="1"
+                        hint="Per-agent cap, overrides the team default for a single LLM call. Leave empty to inherit." />
+                </div>
+                @endif
+
                 <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                     <x-form-select wire:model="editExecutionTier" label="Execution Tier">
                         @foreach(\App\Domain\Agent\Enums\ExecutionTier::cases() as $tier)

--- a/resources/views/livewire/agents/create-agent-form.blade.php
+++ b/resources/views/livewire/agents/create-agent-form.blade.php
@@ -72,6 +72,13 @@
                 <x-form-input wire:model.number="budgetCapCredits" label="Budget Cap (credits)" type="number" min="0" placeholder="Leave empty for unlimited" />
             </div>
 
+            @if($supportsMaxCreditsPerCall)
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <x-form-input wire:model.number="maxCreditsPerCall" label="Max credits per call (override)" type="number" min="1"
+                    hint="Per-agent cap that overrides the team default for a single LLM call. Leave empty to inherit team / platform setting." />
+            </div>
+            @endif
+
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
                 <x-form-select wire:model="executionTier" label="Execution Tier">
                     @foreach(\App\Domain\Agent\Enums\ExecutionTier::cases() as $tier)


### PR DESCRIPTION
## Summary

Base companion to escapeboy/agent-fleet#TBD (cloud P1+P2). Stacked on PR #63 (P0). Adds:

- **P1-1**: \`LlmPricingSyncCommand\` — Helicone drift sync, graceful no-op in community
- **P2-1**: \`agents.max_credits_per_call\` + Agent::effectiveMaxCreditsPerCall(?Team) precedence helper, EnforceMaxCreditsPerCallAction accepts agentId, BudgetEnforcement threads it from AiRequestDTO, UI gated on Schema::hasColumn
- **P2-5**: BYOK platform fee scaffolding — \`config('llm_pricing.byok_platform_fee_per_call')\` (default 0), Team::effectiveByokPlatformFee() helper. Cloud handles per-team override + actual deduction.
- **P1-3 config**: alert thresholds added to \`config/llm_pricing.php\` (consumed by cloud's EvaluateCostAlertsCommand)

## Test plan

- [x] LlmPricingSyncCommand tests in cloud (covers cloud + base behavior)
- [x] Agent::effectiveMaxCreditsPerCall tests in cloud
- [x] All existing budget tests pass
- [x] Pint clean, PHPStan: no new errors in base