### PR TITLE
fix(mcp): unblock Barsy — schema drift + null-bind null-blindness

### DIFF
--- a/app/Http/Middleware/McpTeamBinding.php
+++ b/app/Http/Middleware/McpTeamBinding.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Binds `mcp.team_id` in the container from the authenticated user's current team.
+ *
+ * Required for HTTP MCP transports (`/mcp`, `/mcp/full`) on the base community
+ * edition: tool handlers expect `app('mcp.team_id')` to resolve, but no other
+ * middleware on the base routes populates the binding. Without this, the
+ * Compact umbrella's wrapped tools (`signal_manage`, `memory_manage`) throw
+ * `BindingResolutionException` because `app('mcp.team_id')` falls through to
+ * `Container::build()` and can't autoresolve the dotted string.
+ *
+ * Cloud's `Cloud\Http\Middleware\McpTeamContext` is a strict superset of this
+ * (additional Postgres RLS context, scope checks). On cloud routes that
+ * middleware overwrites the binding via `instance()` and wins by registration
+ * order — so this middleware can stay registered without conflicting.
+ */
+class McpTeamBinding
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $teamId = $request->user()?->current_team_id;
+
+        if ($teamId) {
+            // instance() is the correct shape here: a non-null value is fully
+            // visible to bound() and app() resolution (no null-blindness).
+            // Defensive callers using `bound() ? app() : fallback` see this as
+            // "bound", and bare callers using `app() ?? fallback` get the value
+            // straight back.
+            $this->app('mcp.team_id', $teamId);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Wrapper to keep the middleware testable without booting the full app —
+     * tests can swap this method to capture the binding without an actual
+     * container roundtrip.
+     */
+    protected function app(string $abstract, mixed $value): void
+    {
+        app()->instance($abstract, $value);
+    }
+}

--- a/app/Mcp/Tools/Evaluation/EvaluationRunTool.php
+++ b/app/Mcp/Tools/Evaluation/EvaluationRunTool.php
@@ -26,7 +26,8 @@ class EvaluationRunTool extends Tool
                 ->required(),
             'run_id' => $schema->string()
                 ->description('Run ID (for get action)'),
-            'criteria' => $schema->array(items: $schema->string())
+            'criteria' => $schema->array()
+                ->items($schema->string())
                 ->description('Criteria to evaluate: faithfulness, relevance, correctness, completeness'),
             'input' => $schema->string()
                 ->description('The input/task that was given'),

--- a/app/Mcp/Tools/Evaluation/FlowEvaluationDatasetCreateTool.php
+++ b/app/Mcp/Tools/Evaluation/FlowEvaluationDatasetCreateTool.php
@@ -29,11 +29,12 @@ class FlowEvaluationDatasetCreateTool extends Tool
                 ->description('Optional description'),
             'workflow_id' => $schema->string()
                 ->description('UUID of the workflow this dataset targets'),
-            'rows' => $schema->array(items: $schema->object(properties: [
-                'input' => $schema->object()->description('Input data as a JSON object (e.g. {"prompt": "..."}')->required(),
-                'expected_output' => $schema->string()->description('Expected output text for judge scoring'),
-                'metadata' => $schema->object()->description('Optional metadata'),
-            ]))
+            'rows' => $schema->array()
+                ->items($schema->object(properties: [
+                    'input' => $schema->object()->description('Input data as a JSON object (e.g. {"prompt": "..."}')->required(),
+                    'expected_output' => $schema->string()->description('Expected output text for judge scoring'),
+                    'metadata' => $schema->object()->description('Optional metadata'),
+                ]))
                 ->description('Test rows for the dataset'),
         ];
     }

--- a/app/Mcp/Tools/Experiment/WorkflowSnapshotListTool.php
+++ b/app/Mcp/Tools/Experiment/WorkflowSnapshotListTool.php
@@ -27,8 +27,8 @@ class WorkflowSnapshotListTool extends Tool
             'limit' => $schema->integer()
                 ->description('Max snapshots to return (default 50)')
                 ->default(50)
-                ->minimum(1)
-                ->maximum(200),
+                ->min(1)
+                ->max(200),
         ];
     }
 

--- a/app/Mcp/Tools/GitRepository/CodeCallChainTool.php
+++ b/app/Mcp/Tools/GitRepository/CodeCallChainTool.php
@@ -40,8 +40,8 @@ class CodeCallChainTool extends Tool
                 ->required(),
             'hops' => $schema->integer()
                 ->description('Traversal depth (1–4, default 2)')
-                ->minimum(1)
-                ->maximum(4)
+                ->min(1)
+                ->max(4)
                 ->default(2),
             'edge_type' => $schema->string()
                 ->description('Filter by edge type: calls, imports, or inherits')

--- a/app/Mcp/Tools/GitRepository/CodeSearchTool.php
+++ b/app/Mcp/Tools/GitRepository/CodeSearchTool.php
@@ -44,8 +44,8 @@ class CodeSearchTool extends Tool
                 ->enum(['class', 'function', 'method', 'file']),
             'limit' => $schema->integer()
                 ->description('Maximum number of results to return (1–20)')
-                ->minimum(1)
-                ->maximum(20)
+                ->min(1)
+                ->max(20)
                 ->default(5),
         ];
     }

--- a/app/Mcp/Tools/Skill/SkillPlaygroundTestTool.php
+++ b/app/Mcp/Tools/Skill/SkillPlaygroundTestTool.php
@@ -6,11 +6,11 @@ use App\Domain\Skill\Actions\SkillPlaygroundRunAction;
 use App\Domain\Skill\Models\Skill;
 use App\Mcp\Concerns\HasStructuredErrors;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Laravel\Mcp\Attributes\IsIdempotent;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
 
 /**
  * MCP tool: skill_playground_test

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -170,17 +170,22 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // Pre-bind 'mcp.team_id' as null so any caller doing
+        // Pre-bind 'mcp.team_id' so any caller doing
         // `app('mcp.team_id') ?? auth()->user()?->current_team_id` works
         // without first checking $app->bound(). MCP request handlers
         // overwrite this with the resolved team ID via app()->instance(...).
-        // Without this default, calling app('mcp.team_id') on an unbound
-        // container (e.g. in test setup that has called forgetInstance)
-        // throws BindingResolutionException because Laravel tries to
-        // autoresolve the dotted string as a class name.
-        if (! $this->app->bound('mcp.team_id')) {
-            $this->app->instance('mcp.team_id', null);
-        }
+        //
+        // We MUST use bind(closure) instead of instance(null): Laravel's
+        // Container::resolve() and ::bound() both use isset() against
+        // $this->instances, and isset() is null-blind — a key bound to
+        // literal null behaves identically to an unbound key, so
+        // app('mcp.team_id') falls through to Container::build() and
+        // throws "Target class [mcp.team_id] does not exist." A closure
+        // binding populates $this->bindings (non-null entry), so resolve()
+        // finds it and invokes the closure to get null. Caller's `?? fallback`
+        // then evaluates correctly. Hit by Compact umbrella tools on the
+        // base HTTP MCP path where no middleware sets mcp.team_id.
+        $this->app->bind('mcp.team_id', fn () => null);
 
         $this->app->singleton(DeploymentMode::class, fn () => new DeploymentMode);
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -170,22 +170,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // Pre-bind 'mcp.team_id' so any caller doing
-        // `app('mcp.team_id') ?? auth()->user()?->current_team_id` works
-        // without first checking $app->bound(). MCP request handlers
-        // overwrite this with the resolved team ID via app()->instance(...).
-        //
-        // We MUST use bind(closure) instead of instance(null): Laravel's
-        // Container::resolve() and ::bound() both use isset() against
-        // $this->instances, and isset() is null-blind — a key bound to
-        // literal null behaves identically to an unbound key, so
-        // app('mcp.team_id') falls through to Container::build() and
-        // throws "Target class [mcp.team_id] does not exist." A closure
-        // binding populates $this->bindings (non-null entry), so resolve()
-        // finds it and invokes the closure to get null. Caller's `?? fallback`
-        // then evaluates correctly. Hit by Compact umbrella tools on the
-        // base HTTP MCP path where no middleware sets mcp.team_id.
-        $this->app->bind('mcp.team_id', fn () => null);
+        // 'mcp.team_id' is bound per-request by McpTeamBinding middleware (HTTP MCP)
+        // or BootstrapsMcpAuth trait (stdio MCP). Outside MCP context the binding
+        // is intentionally absent so callers fall back to auth()->user()->current_team_id
+        // via the `app()->bound('mcp.team_id') ? app('mcp.team_id') : auth()->...`
+        // defensive pattern. Do NOT pre-bind here: a `bind('mcp.team_id', fn () => null)`
+        // pre-bind makes bound() return true with a null value, breaking that fallback.
+        // A `instance('mcp.team_id', null)` pre-bind is null-blind via isset() and
+        // also doesn't help. The only correct shape is "bound iff middleware ran".
 
         $this->app->singleton(DeploymentMode::class, fn () => new DeploymentMode);
 

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\OAuthRevokeController;
+use App\Http\Middleware\McpTeamBinding;
 use App\Mcp\Servers\AgentFleetServer;
 use App\Mcp\Servers\CompactMcpServer;
 use Illuminate\Support\Facades\Route;
@@ -63,11 +64,11 @@ Route::post('oauth/revoke', OAuthRevokeController::class)
 // tokens are validated by their team-scoping ability inside the server's
 // BootstrapsMcpAuth trait.
 Mcp::web('/mcp', CompactMcpServer::class)
-    ->middleware(['auth:sanctum,passport']);
+    ->middleware(['auth:sanctum,passport', McpTeamBinding::class]);
 
 // Full MCP endpoint (HTTP/SSE) — all 259 tools for power users and clients without tool limits
 Mcp::web('/mcp/full', AgentFleetServer::class)
-    ->middleware(['auth:sanctum,passport']);
+    ->middleware(['auth:sanctum,passport', McpTeamBinding::class]);
 
 // Local MCP server (stdio) — for CLI agents like Codex, Claude Code (no tool limit)
 Mcp::local('agent-fleet', AgentFleetServer::class);

--- a/tests/Feature/Mcp/AgentFleetServerSchemaBuildTest.php
+++ b/tests/Feature/Mcp/AgentFleetServerSchemaBuildTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Mcp\Servers\AgentFleetServer;
+use App\Mcp\Servers\CompactMcpServer;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use ReflectionClass;
+use Tests\TestCase;
+use Throwable;
+
+/**
+ * Guards `/mcp/full` and `/mcp` against framework-level JsonSchema API drift.
+ *
+ * Eager schema build is what `tools/list` does at the MCP layer — a single tool whose
+ * `schema()` body uses an unsupported method (e.g. `->minimum()` after Laravel 13's
+ * JsonSchema migrated to `->min()`) crashes the entire listing for every client.
+ *
+ * This test instantiates each registered tool, calls `schema()` with the real JsonSchema
+ * factory, and asserts no `Throwable` propagates. We stop at the first failure with the
+ * tool class name in the message so future regressions point at the offending file.
+ */
+class AgentFleetServerSchemaBuildTest extends TestCase
+{
+    public function test_full_server_tool_schemas_build_without_throwing(): void
+    {
+        $this->assertSchemaBuildsForServer(AgentFleetServer::class);
+    }
+
+    public function test_compact_server_tool_schemas_build_without_throwing(): void
+    {
+        $this->assertSchemaBuildsForServer(CompactMcpServer::class);
+    }
+
+    private function assertSchemaBuildsForServer(string $serverClass): void
+    {
+        $reflection = new ReflectionClass($serverClass);
+        $tools = $reflection->getProperty('tools')->getDefaultValue();
+
+        $this->assertIsArray($tools);
+        $this->assertNotEmpty($tools, "{$serverClass} registered no tools.");
+
+        $jsonSchema = new JsonSchemaTypeFactory;
+
+        foreach ($tools as $toolClass) {
+            try {
+                $tool = app($toolClass);
+                // Most tools accept a JsonSchema parameter; a handful (umbrella tools without
+                // input args) define schema() without parameters. Reflect-and-call so both
+                // shapes succeed.
+                $method = (new ReflectionClass($tool))->getMethod('schema');
+                $args = $method->getNumberOfParameters() > 0 ? [$jsonSchema] : [];
+                $schema = $method->invoke($tool, ...$args);
+
+                $this->assertIsArray(
+                    $schema,
+                    "{$toolClass}::schema() must return an array, got ".get_debug_type($schema),
+                );
+            } catch (Throwable $e) {
+                $this->fail(sprintf(
+                    "Tool %s failed schema build: %s\n%s",
+                    $toolClass,
+                    $e->getMessage(),
+                    $e->getTraceAsString(),
+                ));
+            }
+        }
+    }
+}

--- a/tests/Feature/Mcp/McpTeamIdBindingTest.php
+++ b/tests/Feature/Mcp/McpTeamIdBindingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use Tests\TestCase;
+
+/**
+ * Locks in the contract that `app('mcp.team_id')` ALWAYS resolves without throwing,
+ * even on request paths that don't have an MCP middleware to populate the binding.
+ *
+ * Regression: a previous `instance('mcp.team_id', null)` pre-bind was null-blind
+ * because Laravel's Container::resolve() uses isset() against $instances, and
+ * isset() against a literal-null value returns false. The container then fell
+ * through to Container::build('mcp.team_id') which threw
+ * "Target class [mcp.team_id] does not exist." Compact umbrella tools (signal_manage,
+ * memory_manage) hit this on the base HTTP MCP path (no McpTeamContext middleware),
+ * surfacing as INTERNAL errors to spawned MCP clients.
+ */
+class McpTeamIdBindingTest extends TestCase
+{
+    public function test_mcp_team_id_resolves_to_null_when_no_middleware_set_it(): void
+    {
+        // Ensure no instance() override is active.
+        $this->app->forgetInstance('mcp.team_id');
+
+        $this->assertTrue($this->app->bound('mcp.team_id'),
+            'mcp.team_id must be bound by AppServiceProvider before any request runs.');
+
+        $this->assertNull(app('mcp.team_id'),
+            'mcp.team_id must resolve to null (not throw) when no middleware has overwritten it.');
+    }
+
+    public function test_middleware_can_overwrite_the_binding_via_instance(): void
+    {
+        $this->app->bind('mcp.team_id', fn () => null);
+
+        $this->app->instance('mcp.team_id', 'team-uuid-fixture');
+        $this->assertSame('team-uuid-fixture', app('mcp.team_id'));
+
+        // After forgetInstance, the closure is back in effect.
+        $this->app->forgetInstance('mcp.team_id');
+        $this->assertNull(app('mcp.team_id'));
+    }
+}

--- a/tests/Feature/Mcp/McpTeamIdBindingTest.php
+++ b/tests/Feature/Mcp/McpTeamIdBindingTest.php
@@ -2,43 +2,100 @@
 
 namespace Tests\Feature\Mcp;
 
+use App\Domain\Shared\Models\Team;
+use App\Http\Middleware\McpTeamBinding;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Tests\TestCase;
 
 /**
- * Locks in the contract that `app('mcp.team_id')` ALWAYS resolves without throwing,
- * even on request paths that don't have an MCP middleware to populate the binding.
+ * Locks in the contract that ONLY the McpTeamBinding middleware (or cloud's
+ * McpTeamContext, or BootstrapsMcpAuth in stdio) populates `mcp.team_id`.
  *
- * Regression: a previous `instance('mcp.team_id', null)` pre-bind was null-blind
- * because Laravel's Container::resolve() uses isset() against $instances, and
- * isset() against a literal-null value returns false. The container then fell
- * through to Container::build('mcp.team_id') which threw
- * "Target class [mcp.team_id] does not exist." Compact umbrella tools (signal_manage,
- * memory_manage) hit this on the base HTTP MCP path (no McpTeamContext middleware),
- * surfacing as INTERNAL errors to spawned MCP clients.
+ * Background: a previous attempt pre-bound `mcp.team_id` in AppServiceProvider
+ * to fix the Compact umbrella INTERNAL error reported by Barsy. Two pre-bind
+ * shapes were considered, both wrong:
+ *
+ *   - `instance($key, null)` — null-blind via isset(); bound() returns false
+ *     anyway, so callers using the defensive `bound() ? app() : fallback`
+ *     pattern fall back correctly, but bare `app()` callers still throw
+ *     (BindingResolutionException). This is the original buggy state.
+ *
+ *   - `bind($key, fn () => null)` — binds a non-null entry to $bindings, so
+ *     bound() returns true, app() returns null. This FIXES bare callers but
+ *     BREAKS the 15+ tools that use the defensive pattern: they see bound() ==
+ *     true and use the null value instead of falling back to auth, producing
+ *     "No current team." errors throughout the Livewire surface.
+ *
+ * The correct fix is to bind from middleware (with the actual team ID) and
+ * leave the binding absent everywhere else. This test asserts both.
  */
 class McpTeamIdBindingTest extends TestCase
 {
-    public function test_mcp_team_id_resolves_to_null_when_no_middleware_set_it(): void
+    use RefreshDatabase;
+
+    public function test_binding_is_absent_outside_mcp_request_context(): void
     {
-        // Ensure no instance() override is active.
+        // Fresh app boot — no McpTeamBinding middleware has run.
         $this->app->forgetInstance('mcp.team_id');
 
-        $this->assertTrue($this->app->bound('mcp.team_id'),
-            'mcp.team_id must be bound by AppServiceProvider before any request runs.');
-
-        $this->assertNull(app('mcp.team_id'),
-            'mcp.team_id must resolve to null (not throw) when no middleware has overwritten it.');
+        $this->assertFalse($this->app->bound('mcp.team_id'),
+            'mcp.team_id MUST be unbound outside MCP request context. The defensive '
+            .'`bound() ? app() : fallback` pattern in 15+ tools relies on bound()==false '
+            .'to fall back to auth()->user()->current_team_id.');
     }
 
-    public function test_middleware_can_overwrite_the_binding_via_instance(): void
+    public function test_middleware_binds_team_id_from_authenticated_user(): void
     {
-        $this->app->bind('mcp.team_id', fn () => null);
+        $user = User::factory()->create();
+        $team = Team::factory()->create(['owner_id' => $user->id]);
+        $user->update(['current_team_id' => $team->id]);
 
-        $this->app->instance('mcp.team_id', 'team-uuid-fixture');
-        $this->assertSame('team-uuid-fixture', app('mcp.team_id'));
+        $request = Request::create('/mcp', 'POST');
+        $request->setUserResolver(fn () => $user);
 
-        // After forgetInstance, the closure is back in effect.
         $this->app->forgetInstance('mcp.team_id');
-        $this->assertNull(app('mcp.team_id'));
+
+        (new McpTeamBinding)->handle($request, function () use ($team) {
+            $this->assertTrue($this->app->bound('mcp.team_id'));
+            $this->assertSame($team->id, app('mcp.team_id'));
+
+            return response('ok');
+        });
+    }
+
+    public function test_middleware_skips_binding_when_user_has_no_team(): void
+    {
+        $user = User::factory()->create(['current_team_id' => null]);
+
+        $request = Request::create('/mcp', 'POST');
+        $request->setUserResolver(fn () => $user);
+
+        $this->app->forgetInstance('mcp.team_id');
+
+        (new McpTeamBinding)->handle($request, function () {
+            // Still unbound — caller's defensive pattern falls back to auth's null
+            // and tools return "No current team." gracefully (not the original
+            // BindingResolutionException).
+            $this->assertFalse($this->app->bound('mcp.team_id'));
+
+            return response('ok');
+        });
+    }
+
+    public function test_middleware_skips_binding_when_no_user(): void
+    {
+        $request = Request::create('/mcp', 'POST');
+        // No user resolver — represents an unauthenticated request reaching
+        // the middleware (auth:sanctum normally rejects this earlier).
+
+        $this->app->forgetInstance('mcp.team_id');
+
+        (new McpTeamBinding)->handle($request, function () {
+            $this->assertFalse($this->app->bound('mcp.team_id'));
+
+            return response('ok');
+        });
     }
 }


### PR DESCRIPTION
## Why

Two unrelated MCP regressions surfaced by Barsy's bug-fix-agent dry-run on `chat.sandbox.barsy.dev` (after the `022ebaf2` bump). Bundled because they share the same recovery path.

## Issue 1 — JsonSchema API drift breaks tools/list

After Laravel 13's `Illuminate\JsonSchema` migration, six tools used the pre-13 API and crashed `tools/list` with cascading errors:

| File | Fix |
|---|---|
| `app/Mcp/Tools/GitRepository/CodeSearchTool.php` | `IntegerType::minimum()/maximum()` → `min()/max()` |
| `app/Mcp/Tools/GitRepository/CodeCallChainTool.php` | same |
| `app/Mcp/Tools/Experiment/WorkflowSnapshotListTool.php` | same |
| `app/Mcp/Tools/Evaluation/EvaluationRunTool.php` | `array(items: …)` → `array()->items(…)` (`ArrayType` has no constructor) |
| `app/Mcp/Tools/Evaluation/FlowEvaluationDatasetCreateTool.php` | same |
| `app/Mcp/Tools/Skill/SkillPlaygroundTestTool.php` | wrong `IsIdempotent` namespace |

`MarketplacePublishTool.php` was a false positive in Barsy's report (`items: $items` is a PublishBundleAction named arg, not JsonSchema).

## Issue 2 — Compact umbrella INTERNAL ("mcp.team_id does not exist")

Compact umbrella tools (`signal_manage`, `memory_manage`) returned INTERNAL when called over HTTP MCP on a base-only install (no cloud `McpTeamContext` middleware). Stack:

```
Target class [mcp.team_id] does not exist.
... Container::build('mcp.team_id') ...
... SignalGetTool->handle() at app('mcp.team_id') ...
... CompactTool->handle() ...
```

### Root cause

`AppServiceProvider`'s `instance('mcp.team_id', null)` pre-bind is null-blind. Laravel's `Container::resolve()` and `::bound()` use `isset()` against `$this->instances`, and `isset(null) === false`. A key bound to literal null is indistinguishable from an unbound key. The container falls through to `::build()` which can't autoresolve the dotted string and throws.

### What I tried first (BROKEN — see commit history)

The first revision of this PR replaced the null-instance with a closure-bind:
```php
$this->app->bind('mcp.team_id', fn () => null);
```
This made `bound()` return true with a null value, which broke 15+ defensive-pattern tools using:
```php
$teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : auth()->user()?->current_team_id;
```
Five Livewire tests went red (`SelfServiceEndToEndTest`, `FixWithAssistantTest`). Reverted.

### Real fix (this PR)

1. **Remove** the AppServiceProvider pre-bind entirely. Container goes back to its natural "bound iff something actually set it" state.
2. **Add** `App\Http\Middleware\McpTeamBinding` that reads `auth()->user()->current_team_id` and `instance()`-binds it. Skips the binding when the user has no team so defensive callers fall back gracefully.
3. **Wire** the middleware on `Mcp::web('/mcp')` and `Mcp::web('/mcp/full')` in `base/routes/ai.php`.
4. Cloud's existing `McpTeamContext` middleware is a strict superset and wins on cloud routes by registration order.

## Tests

| Test | Coverage |
|---|---|
| `AgentFleetServerSchemaBuildTest` (NEW) | 2 tests, **569 schema-build assertions** across full + compact servers — guards Issue 1 against future framework drift. |
| `McpTeamIdBindingTest` (NEW, 4 cases) | binding absent outside MCP context, middleware binds with a team, skips without team, skips without user. |
| `SelfServiceEndToEndTest`, `FixWithAssistantTest` | Pre-existing Livewire tests — verified passing under the new shape. |
| `CloudMcpToolsTest`, `McpTeamContextTest` | Cloud security tests — `bound() === false` at startup contract preserved. |

**38 tests, 643 assertions** locally green. Pint + PHPStan clean.

## Acceptance (per Barsy)

- `POST /mcp/full {jsonrpc, id, method:"tools/list"}` with a Sanctum bearer returns 200 with non-empty `result.tools` including the four Bitbucket tools.
- A spawned `claude` process can call `signal_manage action=get` and get back Signal data, not INTERNAL.
- A small test exercises both paths so the same drift can't recur silently. ✓