### PR TITLE
feat(console): add opcache:clear command

### DIFF
--- a/app/Console/Commands/OpcacheClearCommand.php
+++ b/app/Console/Commands/OpcacheClearCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Resets the PHP OPcache so freshly-deployed PHP files take effect.
+ *
+ * Laravel core does NOT ship an `opcache:clear` command — `optimize:clear`
+ * only flushes framework caches (config, route, view, event), not PHP-FPM's
+ * compiled bytecode. After a deploy, FPM workers keep executing the previous
+ * build's bytecode until natural eviction kicks in.
+ *
+ * Wire this into `scripts/deploy.sh` AFTER rebuilding framework caches so
+ * the new compiled files become immediately visible.
+ */
+class OpcacheClearCommand extends Command
+{
+    protected $signature = 'opcache:clear';
+
+    protected $description = 'Reset PHP OPcache (compiled bytecode + JIT) so newly-deployed files are picked up.';
+
+    public function handle(): int
+    {
+        if (! function_exists('opcache_reset')) {
+            $this->warn('OPcache extension not loaded — nothing to reset.');
+
+            return self::SUCCESS;
+        }
+
+        $status = function_exists('opcache_get_status') ? @opcache_get_status(false) : false;
+
+        if ($status === false) {
+            $this->warn('OPcache disabled or restricted (opcache.restrict_api may be set) — nothing to reset.');
+
+            return self::SUCCESS;
+        }
+
+        $cachedScripts = (int) ($status['opcache_statistics']['num_cached_scripts'] ?? 0);
+
+        if (! @opcache_reset()) {
+            $this->error('opcache_reset() returned false — likely opcache.restrict_api is restricting this PID.');
+
+            return self::FAILURE;
+        }
+
+        $this->info("OPcache reset. Evicted {$cachedScripts} cached script(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Feature/Console/OpcacheClearCommandTest.php
+++ b/tests/Feature/Console/OpcacheClearCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+class OpcacheClearCommandTest extends TestCase
+{
+    public function test_command_runs_without_throwing_in_any_opcache_state(): void
+    {
+        // The CI runner may have OPcache disabled, restricted, or fully enabled.
+        // The command must exit with a recognized status (0=SUCCESS, 1=FAILURE)
+        // and never throw — `php artisan opcache:clear` runs unconditionally
+        // from `scripts/deploy.sh`.
+        $exitCode = $this->artisan('opcache:clear')->run();
+
+        $this->assertContains(
+            $exitCode,
+            [0, 1],
+            'opcache:clear must exit cleanly regardless of OPcache state, got exit code '.$exitCode,
+        );
+    }
+
+    public function test_command_emits_skip_message_when_opcache_unavailable(): void
+    {
+        // Opcache isn't available in PHPUnit by default (OPcache disables itself
+        // for CLI unless opcache.enable_cli=1). The command should warn and
+        // succeed rather than fail.
+        if (function_exists('opcache_reset') && function_exists('opcache_get_status') && @opcache_get_status(false) !== false) {
+            $this->markTestSkipped('OPcache is enabled in this environment — covered by the integration test path.');
+        }
+
+        $this->artisan('opcache:clear')
+            ->expectsOutputToContain('OPcache')
+            ->assertSuccessful();
+    }
+}


### PR DESCRIPTION
## Why

Laravel core has no \`opcache:clear\` — \`optimize:clear\` only flushes framework caches (config, route, view, event), not PHP-FPM's compiled bytecode. After a deploy, FPM workers keep executing the previous build's bytecode until natural eviction kicks in.

PR #41 ship-agent ran \`php -r 'opcache_reset();'\` as a fallback because \`php artisan opcache:clear\` returned "Command not found". This PR registers the command properly so \`scripts/deploy.sh\` (companion parent PR) can call it unconditionally.

## Behavior

| State | Output | Exit |
|---|---|---|
| OPcache extension absent | Warn | 0 |
| OPcache disabled / restricted (\`opcache.restrict_api\`) | Warn | 0 |
| \`opcache_reset()\` returns false | Error | 1 |
| Reset succeeds | Info with evicted-script count | 0 |

The graceful-on-disabled behavior matters because CLI PHP often has OPcache off (\`opcache.enable_cli=0\`) — the deploy script must not fail just because the command is invoked from a context where OPcache isn't running.

## Tests

\`tests/Feature/Console/OpcacheClearCommandTest.php\` — 2 cases:
- Command exits cleanly (0 or 1) under any OPcache state
- Skip-message branch when OPcache is unavailable

## Companion PR

agent-fleet#43 (parent) bumps the submodule pointer and wires the command into \`scripts/deploy.sh\` after the framework caches are rebuilt.