### PR TITLE
test(mcp): catch attribute namespace bugs via newInstance()

### DIFF
--- a/tests/Feature/Mcp/AgentFleetServerSchemaBuildTest.php
+++ b/tests/Feature/Mcp/AgentFleetServerSchemaBuildTest.php
@@ -10,29 +10,39 @@ use Tests\TestCase;
 use Throwable;
 
 /**
- * Guards `/mcp/full` and `/mcp` against framework-level JsonSchema API drift.
+ * Guards `/mcp/full` and `/mcp` against MCP-layer regressions that crash
+ * `tools/list` at runtime:
  *
- * Eager schema build is what `tools/list` does at the MCP layer — a single tool whose
- * `schema()` body uses an unsupported method (e.g. `->minimum()` after Laravel 13's
- * JsonSchema migrated to `->min()`) crashes the entire listing for every client.
+ *   1. JsonSchema API drift — e.g. `->minimum()` after Laravel 13's migration
+ *      to `->min()`. Caught by `schema()` invocation.
  *
- * This test instantiates each registered tool, calls `schema()` with the real JsonSchema
- * factory, and asserts no `Throwable` propagates. We stop at the first failure with the
- * tool class name in the message so future regressions point at the offending file.
+ *   2. Attribute namespace typos — e.g. `Laravel\Mcp\Server\Attributes\IsReadOnly`
+ *      (does not exist) instead of `Laravel\Mcp\Server\Tools\Annotations\IsReadOnly`.
+ *      ReflectionClass::getAttributes() with ReflectionAttribute::IS_INSTANCEOF
+ *      flag throws an `Error` if the referenced class is missing — same path
+ *      the MCP server walks during tool registration. Plain instantiation
+ *      does NOT trigger attribute resolution; an explicit getAttributes()
+ *      call is required.
+ *
+ * One bad tool stops the entire listing for every client, so this test fails
+ * fast with the offending class name.
  */
 class AgentFleetServerSchemaBuildTest extends TestCase
 {
     public function test_full_server_tool_schemas_build_without_throwing(): void
     {
-        $this->assertSchemaBuildsForServer(AgentFleetServer::class);
+        $this->assertToolsLoadCleanlyForServer(AgentFleetServer::class);
     }
 
     public function test_compact_server_tool_schemas_build_without_throwing(): void
     {
-        $this->assertSchemaBuildsForServer(CompactMcpServer::class);
+        $this->assertToolsLoadCleanlyForServer(CompactMcpServer::class);
     }
 
-    private function assertSchemaBuildsForServer(string $serverClass): void
+    /**
+     * @param  class-string  $serverClass
+     */
+    protected function assertToolsLoadCleanlyForServer(string $serverClass): void
     {
         $reflection = new ReflectionClass($serverClass);
         $tools = $reflection->getProperty('tools')->getDefaultValue();
@@ -45,10 +55,22 @@ class AgentFleetServerSchemaBuildTest extends TestCase
         foreach ($tools as $toolClass) {
             try {
                 $tool = app($toolClass);
-                // Most tools accept a JsonSchema parameter; a handful (umbrella tools without
-                // input args) define schema() without parameters. Reflect-and-call so both
-                // shapes succeed.
-                $method = (new ReflectionClass($tool))->getMethod('schema');
+                $toolReflection = new ReflectionClass($tool);
+
+                // (2) Force attribute INSTANTIATION. ReflectionAttribute->getName()
+                // returns the class name as a string without loading the class;
+                // ->newInstance() actually instantiates it, throwing "Attribute class
+                // ... not found" if the use-statement points at a non-existent
+                // namespace. This is the same path Laravel\Mcp's HasAnnotations
+                // trait walks at registration time, so a typo'd #[IsReadOnly]
+                // surfaces here instead of in production.
+                foreach ($toolReflection->getAttributes() as $attribute) {
+                    $attribute->newInstance();
+                }
+
+                // (1) Build the schema. Most tools accept a JsonSchema parameter;
+                // a few umbrella tools omit it. Reflect-and-call so both shapes work.
+                $method = $toolReflection->getMethod('schema');
                 $args = $method->getNumberOfParameters() > 0 ? [$jsonSchema] : [];
                 $schema = $method->invoke($tool, ...$args);
 
@@ -58,7 +80,7 @@ class AgentFleetServerSchemaBuildTest extends TestCase
                 );
             } catch (Throwable $e) {
                 $this->fail(sprintf(
-                    "Tool %s failed schema build: %s\n%s",
+                    "Tool %s failed to load: %s\n%s",
                     $toolClass,
                     $e->getMessage(),
                     $e->getTraceAsString(),


### PR DESCRIPTION
## Why

PR #42's \`AgentFleetServerSchemaBuildTest\` covered (1) JsonSchema API drift but missed (2) **attribute namespace typos** like \`Laravel\Mcp\Server\Attributes\IsReadOnly\` (does not exist) instead of \`Laravel\Mcp\Server\Tools\Annotations\IsReadOnly\`. PR #42's ship-agent caught the gap in production: \`tools/list\` against \`/mcp/full\` returned JSON-RPC \`-32603\` with "Attribute class ... not found" because three cloud Sku tools had the wrong namespace.

## Root cause of the gap

\`ReflectionClass::getAttributes()\` returns \`ReflectionAttribute\` objects WITHOUT loading the referenced class. The test was calling \`->getName()\` (returns the class name as a string, no class load) — so wrong-namespace imports were invisible. The actual failure path is \`->newInstance()\`, which Laravel\Mcp's \`HasAnnotations\` trait calls at registration time.

## Fix

Switch the per-tool loop from \`getAttributes()\` only to \`getAttributes() + newInstance()\` on each. Any namespace typo in \`#[IsReadOnly]\`, \`#[IsIdempotent]\`, \`#[IsDestructive]\` now fails fast with the offending tool's class name in the message.

## Companion PR

agent-fleet#46 (parent) corrects the three Sku tools' imports AND adds \`Cloud\Tests\Feature\Mcp\CloudAgentFleetServerSchemaBuildTest\` that extends this base class so cloud-only tools (CloudAgentFleetServer's \`$tools\`) are also exercised.

## Test plan

- [x] Forward: 4 tests pass locally with all 6 namespaces correct (867 assertions across full + compact, base + cloud)
- [x] Reverse: re-introduce the wrong namespace in SkuListTool — test fails with "Tool Cloud\Mcp\Tools\Sku\SkuListTool failed to load: Attribute class ... not found" pointing at the offending file
- [ ] CI green