### PR TITLE
fix(test): TeamFactory slug must be unique (CI flake)

### DIFF
--- a/database/factories/Domain/Shared/TeamFactory.php
+++ b/database/factories/Domain/Shared/TeamFactory.php
@@ -13,11 +13,17 @@ class TeamFactory extends Factory
 
     public function definition(): array
     {
+        // Faker's company() pool is small enough that two `Team::factory()->create()`
+        // calls in the same test (e.g. BitbucketToolsTest::test_read_file_does_not_leak_other_team_credential)
+        // can collide on the resulting slug, hitting the UNIQUE constraint on
+        // teams.slug. Append a random suffix so two factory calls in the same
+        // process always produce distinct slugs without surprising tests that
+        // assert on the human-readable name.
         $name = fake()->company();
 
         return [
             'name' => $name,
-            'slug' => Str::slug($name),
+            'slug' => Str::slug($name).'-'.Str::lower(Str::random(6)),
             'owner_id' => User::factory(),
             'settings' => [],
         ];


### PR DESCRIPTION
## Why

PR #43's CI failed intermittently on:
\`\`\`
BitbucketToolsTest::test_read_file_does_not_leak_other_team_credential
UNIQUE constraint failed: teams.slug   slug=parker-and-sons
\`\`\`

Faker's \`company()\` pool is small enough that two \`Team::factory()->create()\` calls in the same test process can return the same name; \`Str::slug(\$name)\` then collides on the UNIQUE constraint.

## Fix

Append a 6-char random suffix to the slug so two factory calls always produce distinct slugs:

\`\`\`php
'slug' => Str::slug(\$name).'-'.Str::lower(Str::random(6)),
\`\`\`

The human-readable name stays intact, just the slug gets the suffix — tests that assert on \`->name\` are unaffected; tests that assert on the exact slug were already broken anyway under the old factory.

## Test plan

- [x] \`php artisan test base/tests/Feature/Mcp/Bitbucket/BitbucketToolsTest.php\` — all 17 cases pass locally
- [ ] CI green on this branch