### PR TITLE
fix(test): isolate Redis cache DB per paratest worker (CI flake)

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -68,7 +68,7 @@ abstract class TestCase extends BaseTestCase
         $token = getenv('TEST_TOKEN');
         if ($token !== false && $token !== '' && (int) $token > 0) {
             $cacheDb = (int) $token;
-            putenv('REDIS_CACHE_DB=' . $cacheDb);
+            putenv('REDIS_CACHE_DB='.$cacheDb);
             $_ENV['REDIS_CACHE_DB'] = $cacheDb;
             $_SERVER['REDIS_CACHE_DB'] = $cacheDb;
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,6 +58,21 @@ abstract class TestCase extends BaseTestCase
             ? $parentBootstrap
             : __DIR__.'/../bootstrap/app.php';
 
+        // paratest worker isolation: when running under paratest, each worker
+        // gets a unique TEST_TOKEN env var (1..N for --processes=N). Map that
+        // to a distinct Redis DB so per-test tearDown() flushdb() calls
+        // don't wipe the keys another worker just wrote. Without this the
+        // CreditsTest deduct assertions fail intermittently because worker
+        // A's flushdb clears worker B's just-written usage counter mid-test.
+        // No-op when phpunit runs serially (TEST_TOKEN unset).
+        $token = getenv('TEST_TOKEN');
+        if ($token !== false && $token !== '' && (int) $token > 0) {
+            $cacheDb = (int) $token;
+            putenv('REDIS_CACHE_DB=' . $cacheDb);
+            $_ENV['REDIS_CACHE_DB'] = $cacheDb;
+            $_SERVER['REDIS_CACHE_DB'] = $cacheDb;
+        }
+
         $app = require $bootstrap;
 
         $app->make(Kernel::class)->bootstrap();


### PR DESCRIPTION
## Why

Develop's CI broke after PRs #45 (paratest) and #46 merged. Failure:
\`\`\`
Cloud\Tests\Feature\CreditsTest::test_deduct_action_charges_platform_credits_for_llm_call
Failed asserting that 0 matches expected 3.
\`\`\`

Reproduced reliably under \`paratest --processes=4\`. Root cause: \`CreditsTest::tearDown()\` calls \`Redis::connection('cache')->flushdb()\` to clean per-test state. Under serial phpunit that's fine. Under paratest, all 4 workers share the same Redis DB:

1. Worker A: deducts → writes \`team:{id}:usage:platform_credits\`
2. Worker B (different test): tearDown → \`flushdb\` wipes ALL keys
3. Worker A: \`assertSame(3, currentUsage)\` → reads 0 → fails

## Fix

In \`tests/TestCase::createApplication()\` before bootstrapping, read \`TEST_TOKEN\` (paratest sets 1..N per worker) and route \`REDIS_CACHE_DB\` to a unique DB number. \`flushdb\` in worker A's DB doesn't touch worker B's. No-op when phpunit runs serially (TEST_TOKEN unset).

## Verification

\`vendor/bin/paratest --processes=4\` on full suite locally:
\`\`\`
Tests: 3544, Assertions: 13709, PHPUnit Deprecations: 8, Skipped: 11.
Time: 00:35.021, Memory: 68.00 MB
\`\`\`
**Zero failures.** Companion parent PR bumps the submodule.