### PR TITLE
feat(bridge): HTTP-direct MCP routing for HTTP-tunnel-mode bridges

### DIFF
--- a/app/Http/Controllers/Api/V1/BridgeController.php
+++ b/app/Http/Controllers/Api/V1/BridgeController.php
@@ -286,10 +286,18 @@ class BridgeController extends Controller
     }
 
     /**
-     * Proxy an MCP tool call through the relay to a bridge-hosted MCP server.
+     * Proxy an MCP tool call to a bridge-hosted MCP server.
      *
-     * Uses the same Redis frame-based protocol as all bridge communication:
-     * RPUSH to bridge:req:{teamId} → relay binary → WebSocket → bridge daemon → MCP server.
+     * Two transport paths:
+     *  - HTTP-mode bridges (endpoint_url set): POST directly to
+     *    {endpoint_url}/mcp/{server} with the validated body and
+     *    return whatever the bridge returns (must be MCP JSON-RPC shape).
+     *  - Relay-binary bridges (default): RPUSH to bridge:req:{teamId} →
+     *    relay binary → WebSocket → bridge daemon → MCP server, response
+     *    streamed back via bridge:stream:{request_id}.
+     *
+     * Both paths use the same validated body shape, so callers don't have
+     * to know which transport is in play.
      *
      * @response 200 {"result": {"content": [{"type": "text", "text": "..."}]}}
      */
@@ -322,7 +330,24 @@ class BridgeController extends Controller
             'server' => $serverName,
             'method' => $validated['method'],
             'tool' => $validated['params']['name'] ?? null,
+            'transport' => $bridge->isHttpMode() ? 'http_direct' : 'relay',
         ]);
+
+        // HTTP-tunnel-mode bridges (Cloudflare Tunnel / Tailscale Funnel /
+        // ngrok / etc.): the daemon exposes an HTTP endpoint at endpoint_url.
+        // Skip the Redis+relay path entirely and POST directly. Synchronous
+        // request/response with no streaming for now — daemons that want
+        // chunked output can keep the relay path.
+        if ($bridge->isHttpMode()) {
+            return $this->mcpCallViaHttp(
+                bridge: $bridge,
+                serverName: $serverName,
+                method: $validated['method'],
+                params: $validated['params'],
+                requestId: $requestId,
+                timeout: $timeout,
+            );
+        }
 
         try {
             $registry = app(BridgeRequestRegistry::class);
@@ -372,6 +397,77 @@ class BridgeController extends Controller
                 'error' => "Bridge MCP call failed: {$e->getMessage()}",
             ], 502);
         }
+    }
+
+    /**
+     * HTTP-direct path of mcpCall: POST to {endpoint_url}/mcp/{server} on
+     * the bridge daemon and forward the response.
+     *
+     * Auth: Bearer {endpoint_secret} when present. Bridge daemons that
+     * configure no secret accept anonymous calls (loopback-only deployment).
+     *
+     * Failure modes:
+     *   - HTTP exception (DNS / connect / timeout) → 502
+     *   - Non-2xx response from the daemon → 502 with status + body tail
+     *   - Successful 2xx → forward the parsed JSON body verbatim
+     */
+    private function mcpCallViaHttp(
+        BridgeConnection $bridge,
+        string $serverName,
+        string $method,
+        array $params,
+        string $requestId,
+        int $timeout,
+    ): JsonResponse {
+        $headers = ['Accept' => 'application/json'];
+        if (! empty($bridge->endpoint_secret)) {
+            $headers['Authorization'] = 'Bearer '.$bridge->endpoint_secret;
+        }
+
+        $url = rtrim($bridge->endpoint_url, '/').'/mcp/'.$serverName;
+        $body = [
+            'request_id' => $requestId,
+            'method' => $method,
+            'params' => $params,
+            'timeout' => $timeout,
+        ];
+
+        try {
+            // Add a small buffer over the per-call timeout so the HTTP layer
+            // doesn't fire before the daemon's own timeout check returns.
+            $response = Http::timeout($timeout + 5)
+                ->withHeaders($headers)
+                ->post($url, $body);
+        } catch (\Throwable $e) {
+            Log::error('BridgeController: HTTP-direct MCP call failed', [
+                'request_id' => $requestId,
+                'bridge_id' => $bridge->id,
+                'endpoint_url' => $bridge->endpoint_url,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'error' => "Bridge HTTP-direct call failed: {$e->getMessage()}",
+            ], 502);
+        }
+
+        if (! $response->successful()) {
+            return response()->json([
+                'error' => "Bridge HTTP {$response->status()}: ".substr((string) $response->body(), 0, 500),
+            ], 502);
+        }
+
+        // Touch last_seen_at so the connection's health stays fresh.
+        $bridge->update(['last_seen_at' => now()]);
+
+        $payload = $response->json();
+        if (! is_array($payload)) {
+            return response()->json([
+                'error' => 'Bridge returned non-JSON body for an HTTP-direct MCP call.',
+            ], 502);
+        }
+
+        return response()->json($payload);
     }
 
     /**

--- a/tests/Feature/Api/V1/BridgeControllerTest.php
+++ b/tests/Feature/Api/V1/BridgeControllerTest.php
@@ -270,4 +270,153 @@ class BridgeControllerTest extends ApiTestCase
         $response->assertOk()
             ->assertJsonPath('auth', "fleetq-key:{$expectedSignature}");
     }
+
+    // -----------------------------------------------------------------------
+    // POST /api/v1/bridge/mcp-call — HTTP-direct path for HTTP-tunnel-mode bridges
+    // -----------------------------------------------------------------------
+
+    public function test_mcp_call_routes_via_http_when_bridge_is_in_http_mode(): void
+    {
+        $this->actingAsApiUser();
+
+        $bridge = BridgeConnection::create([
+            'team_id' => $this->team->id,
+            'session_id' => 'http-mode-session',
+            'status' => BridgeConnectionStatus::Connected,
+            'endpoint_url' => 'https://harbormaster.tunnel.example',
+            'endpoint_secret' => 'shared-token-xyz',
+            'tunnel_provider' => 'cloudflare',
+            'endpoints' => [
+                'mcp_servers' => [['name' => 'harbormaster', 'tools' => ['list_hosts']]],
+            ],
+            'connected_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://harbormaster.tunnel.example/mcp/harbormaster' => Http::response([
+                'result' => [
+                    'content' => [['type' => 'text', 'text' => 'friday, hetzner-1']],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->postJson('/api/v1/bridge/mcp/call', [
+            'server' => 'harbormaster',
+            'method' => 'tools/call',
+            'params' => ['name' => 'list_hosts', 'arguments' => []],
+            'timeout' => 30,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('result.content.0.text', 'friday, hetzner-1');
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://harbormaster.tunnel.example/mcp/harbormaster'
+                && $request->hasHeader('Authorization', 'Bearer shared-token-xyz')
+                && $request['method'] === 'tools/call'
+                && $request['params']['name'] === 'list_hosts'
+                && $request['timeout'] === 30
+                && ! empty($request['request_id']);
+        });
+
+        // last_seen_at should be touched by a successful HTTP-direct call
+        $this->assertNotNull($bridge->fresh()->last_seen_at);
+    }
+
+    public function test_mcp_call_skips_authorization_header_when_bridge_has_no_secret(): void
+    {
+        $this->actingAsApiUser();
+
+        BridgeConnection::create([
+            'team_id' => $this->team->id,
+            'session_id' => 'no-secret-session',
+            'status' => BridgeConnectionStatus::Connected,
+            'endpoint_url' => 'http://localhost:7531',
+            'endpoint_secret' => null,
+            'endpoints' => [
+                'mcp_servers' => [['name' => 'harbormaster']],
+            ],
+            'connected_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        Http::fake([
+            'http://localhost:7531/mcp/harbormaster' => Http::response(['result' => ['content' => []]], 200),
+        ]);
+
+        $response = $this->postJson('/api/v1/bridge/mcp/call', [
+            'server' => 'harbormaster',
+            'method' => 'tools/list',
+            'params' => ['cursor' => null],
+        ]);
+
+        $response->assertOk();
+
+        Http::assertSent(fn ($request) => ! $request->hasHeader('Authorization'));
+    }
+
+    public function test_mcp_call_returns_502_when_http_mode_bridge_responds_non_2xx(): void
+    {
+        $this->actingAsApiUser();
+
+        BridgeConnection::create([
+            'team_id' => $this->team->id,
+            'session_id' => 'broken-bridge',
+            'status' => BridgeConnectionStatus::Connected,
+            'endpoint_url' => 'https://broken.example',
+            'endpoint_secret' => 'secret',
+            'endpoints' => [
+                'mcp_servers' => [['name' => 'harbormaster']],
+            ],
+            'connected_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://broken.example/mcp/harbormaster' => Http::response('Internal Server Error', 500),
+        ]);
+
+        $response = $this->postJson('/api/v1/bridge/mcp/call', [
+            'server' => 'harbormaster',
+            'method' => 'tools/list',
+            'params' => ['cursor' => null],
+        ]);
+
+        $response->assertStatus(502)
+            ->assertJsonStructure(['error']);
+    }
+
+    public function test_mcp_call_returns_502_when_http_mode_bridge_unreachable(): void
+    {
+        $this->actingAsApiUser();
+
+        BridgeConnection::create([
+            'team_id' => $this->team->id,
+            'session_id' => 'unreachable',
+            'status' => BridgeConnectionStatus::Connected,
+            'endpoint_url' => 'https://unreachable.example',
+            'endpoint_secret' => null,
+            'endpoints' => [
+                'mcp_servers' => [['name' => 'harbormaster']],
+            ],
+            'connected_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://unreachable.example/mcp/harbormaster' => function () {
+                throw new \Illuminate\Http\Client\ConnectionException('connect timeout');
+            },
+        ]);
+
+        $response = $this->postJson('/api/v1/bridge/mcp/call', [
+            'server' => 'harbormaster',
+            'method' => 'tools/list',
+            'params' => ['cursor' => null],
+        ]);
+
+        $response->assertStatus(502)
+            ->assertJsonPath('error', fn ($v) => str_contains($v, 'connect timeout'));
+    }
 }


### PR DESCRIPTION
## Summary

Adds a second transport path to `BridgeController::mcpCall`: when the resolved `BridgeConnection` is in HTTP-tunnel mode (`endpoint_url` set), POST directly to `{endpoint_url}/mcp/{server}` instead of pushing into the Redis+relay-binary path.

Existing relay-mode behaviour is **unchanged** — the routing decision is per-connection (`\$bridge->isHttpMode()`).

## Why

HTTP-tunnel-mode bridges (Cloudflare Tunnel / Tailscale Funnel / ngrok / Tailscale Serve) already register via `/api/v1/bridge/connect` and pass `/discover` validation, but until now their `endpoint_url` was only used by the `ping` endpoint. `mcpCall` always routed via Redis, so HTTP-mode bridges showed up as \"connected\" but couldn't actually receive MCP tool calls — they had no relay binary in front of them.

This change unblocks lightweight bridge daemons that don't ship a relay binary. The motivating case is **harbormaster** (https://github.com/FleetQ/harbormaster) — a Python MCP server that exposes its tools via a simple HTTP endpoint and registers itself via FleetQ's HTTP-tunnel UI flow. Without this PR, harbormaster shows up in the FleetQ Connections UI but every \`mcpCall\` returns \"no active bridge with MCP server harbormaster\".

## What's implemented

New private \`mcpCallViaHttp()\` method:

- **POST** \`{endpoint_url}/mcp/{server}\`
- **Auth**: \`Bearer {endpoint_secret}\` (omitted when secret is null — for local-loopback deployments)
- **Body**: \`{request_id, method, params, timeout}\` — same shape as the relay path's frame \`payload\` field, so daemons can share handler logic across transports.
- **Response**: 2xx JSON body forwarded verbatim. Daemon owns the MCP JSON-RPC envelope.
- **Failure modes**:
    - DNS / connect / timeout / TLS errors → 502 with throwable message
    - 4xx/5xx from daemon → 502 with status + body tail (truncated to 500 chars)
    - Non-JSON 2xx body → 502 \"returned non-JSON body\"
    - Successful 2xx → \`bridge.last_seen_at\` is touched, body forwarded

\`mcpCall()\` routes to the new method when \`\$bridge->isHttpMode()\` returns true. Both transports log with a \`transport\` tag for observability.

## Tests

4 new feature tests in \`tests/Feature/Api/V1/BridgeControllerTest.php\` via \`Http::fake()\`:

- HTTP-mode bridge → POST is sent with Bearer + correct body shape; \`last_seen_at\` touched on success.
- Bridge with no \`endpoint_secret\` → no Authorization header sent.
- Daemon returns 5xx → controller returns 502 with error.
- Daemon unreachable (ConnectionException) → 502 with error message.

\`docker compose exec app php artisan test --compact tests/Feature/Api/V1/BridgeControllerTest.php\` → **15 passed (40 assertions)**.

## Backwards compatibility

- Relay-binary-mode bridges (no \`endpoint_url\`) take the unchanged code path. No protocol bytes change for existing daemons.
- Validation rules on \`/api/v1/bridge/mcp/call\` are unchanged. Same payload shape, same failure modes for missing fields.
- HTTP-mode bridges that DON'T expose \`/mcp/{server}\` get a 502 from the daemon's response, which is more meaningful than the previous \"no active bridge\" 404.

## Related

- harbormaster's receive-side endpoint (\`POST /mcp/{server}\` on the UI app): https://github.com/FleetQ/harbormaster/commit/7bbbd4c (v1.0.0a9 work)
- Discovery doc: https://github.com/FleetQ/harbormaster/blob/main/docs/agent-request-payload-spike.md

## Test plan

- [x] Unit / feature tests pass (\`docker compose exec app php artisan test base/tests/Feature/Api/V1/BridgeControllerTest.php\`).
- [x] Pint passes (\`docker compose exec app vendor/bin/pint --dirty --format agent\`).
- [ ] (After merge) Live integration with harbormaster v1.0.0a9 against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)