### PR TITLE
fix(bridge): pass 4xx daemon errors through, drop generic 502 wrap

### DIFF
--- a/app/Http/Controllers/Api/V1/BridgeController.php
+++ b/app/Http/Controllers/Api/V1/BridgeController.php
@@ -408,7 +408,11 @@ class BridgeController extends Controller
      *
      * Failure modes:
      *   - HTTP exception (DNS / connect / timeout) → 502
-     *   - Non-2xx response from the daemon → 502 with status + body tail
+     *   - 4xx response from the daemon → forward status + body verbatim so
+     *     callers see the original "tool not found" / "bad payload" error
+     *     instead of a generic 502 wrapping
+     *   - 5xx response from the daemon → 502 with status + body tail
+     *     (the daemon itself is broken)
      *   - Successful 2xx → forward the parsed JSON body verbatim
      */
     private function mcpCallViaHttp(
@@ -451,7 +455,22 @@ class BridgeController extends Controller
             ], 502);
         }
 
-        if (! $response->successful()) {
+        if ($response->clientError()) {
+            // 4xx from the daemon: pass the daemon's status + body to the
+            // caller unchanged. The daemon already produced a meaningful
+            // error (e.g. 404 "tool not found", 400 "bad payload") and
+            // wrapping it as 502 obscures the real cause.
+            $payload = $response->json();
+            if (is_array($payload)) {
+                return response()->json($payload, $response->status());
+            }
+
+            return response()->json([
+                'error' => "Bridge HTTP {$response->status()}: ".substr((string) $response->body(), 0, 500),
+            ], $response->status());
+        }
+
+        if ($response->serverError()) {
             return response()->json([
                 'error' => "Bridge HTTP {$response->status()}: ".substr((string) $response->body(), 0, 500),
             ], 502);

--- a/tests/Feature/Api/V1/BridgeControllerTest.php
+++ b/tests/Feature/Api/V1/BridgeControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api\V1;
 use App\Domain\Bridge\Enums\BridgeConnectionStatus;
 use App\Domain\Bridge\Models\BridgeConnection;
 use App\Domain\Shared\Models\Team;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 
 class BridgeControllerTest extends ApiTestCase
@@ -356,7 +357,7 @@ class BridgeControllerTest extends ApiTestCase
         Http::assertSent(fn ($request) => ! $request->hasHeader('Authorization'));
     }
 
-    public function test_mcp_call_returns_502_when_http_mode_bridge_responds_non_2xx(): void
+    public function test_mcp_call_returns_502_when_http_mode_bridge_responds_5xx(): void
     {
         $this->actingAsApiUser();
 
@@ -387,6 +388,76 @@ class BridgeControllerTest extends ApiTestCase
             ->assertJsonStructure(['error']);
     }
 
+    public function test_mcp_call_passes_4xx_through_from_http_mode_bridge(): void
+    {
+        $this->actingAsApiUser();
+
+        BridgeConnection::create([
+            'team_id' => $this->team->id,
+            'session_id' => 'http-bridge-4xx',
+            'status' => BridgeConnectionStatus::Connected,
+            'endpoint_url' => 'https://daemon.example',
+            'endpoint_secret' => 'secret',
+            'endpoints' => [
+                'mcp_servers' => [['name' => 'harbormaster']],
+            ],
+            'connected_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://daemon.example/mcp/harbormaster' => Http::response(
+                ['detail' => "tool not found: 'i_do_not_exist'"],
+                404,
+            ),
+        ]);
+
+        $response = $this->postJson('/api/v1/bridge/mcp/call', [
+            'server' => 'harbormaster',
+            'method' => 'tools/call',
+            'params' => ['name' => 'i_do_not_exist', 'arguments' => []],
+        ]);
+
+        // 4xx from the daemon must reach the caller unchanged — neither the
+        // status nor the body is wrapped in a generic 502.
+        $response->assertStatus(404)
+            ->assertExactJson(['detail' => "tool not found: 'i_do_not_exist'"]);
+    }
+
+    public function test_mcp_call_passes_4xx_through_with_non_json_body(): void
+    {
+        $this->actingAsApiUser();
+
+        BridgeConnection::create([
+            'team_id' => $this->team->id,
+            'session_id' => 'http-bridge-4xx-text',
+            'status' => BridgeConnectionStatus::Connected,
+            'endpoint_url' => 'https://daemon.example',
+            'endpoint_secret' => null,
+            'endpoints' => [
+                'mcp_servers' => [['name' => 'harbormaster']],
+            ],
+            'connected_at' => now(),
+            'last_seen_at' => now(),
+        ]);
+
+        Http::fake([
+            'https://daemon.example/mcp/harbormaster' => Http::response('Bad Request', 400),
+        ]);
+
+        $response = $this->postJson('/api/v1/bridge/mcp/call', [
+            'server' => 'harbormaster',
+            'method' => 'tools/call',
+            'params' => ['name' => 'whatever', 'arguments' => []],
+        ]);
+
+        // Non-JSON 4xx body falls back to the wrapper shape but keeps the
+        // original status code so callers can distinguish bad-request from
+        // gateway-error semantics.
+        $response->assertStatus(400)
+            ->assertJsonStructure(['error']);
+    }
+
     public function test_mcp_call_returns_502_when_http_mode_bridge_unreachable(): void
     {
         $this->actingAsApiUser();
@@ -406,7 +477,7 @@ class BridgeControllerTest extends ApiTestCase
 
         Http::fake([
             'https://unreachable.example/mcp/harbormaster' => function () {
-                throw new \Illuminate\Http\Client\ConnectionException('connect timeout');
+                throw new ConnectionException('connect timeout');
             },
         ]);
 


### PR DESCRIPTION
## Summary

- Pass-through 4xx responses from HTTP-mode bridge daemons instead of always wrapping them as 502. 5xx still wraps (the daemon itself is broken).
- Fixes the Pint style failure that landed with #72 (`fully_qualified_strict_types` on `ConnectionException`) so `Code Quality` returns to green and `Tests` actually runs.
- Adds two test cases for the new error mapping; renames the existing 502-on-non-2xx test to 502-on-5xx to make the contract explicit.

## Why

Followup flagged in the harbormaster v1.0.0a9 sprint retro:

> Error mapping is asymmetric. harbormaster's `/mcp/{server}` returns 404 for unknown tools; agent-fleet's `mcpCallViaHttp` wraps that as 502. From the FleetQ caller's perspective, "tool not found" looks like a generic gateway error.

A daemon's 404 "tool not found" or 400 "bad payload" is a **client error** in MCP terms — the caller asked for something the daemon refused. Wrapping it as 502 makes diagnostics harder and is semantically wrong. 5xx stays 502 because, from the caller's perspective, the gateway itself is the failing dependency.

## What's implemented

In `BridgeController::mcpCallViaHttp()`:

| Daemon response | Before | After |
|---|---|---|
| 2xx JSON | forward verbatim | forward verbatim *(unchanged)* |
| 2xx non-JSON | 502 wrap | 502 wrap *(unchanged — contract violation)* |
| 4xx JSON | 502 wrap | **forward status + body verbatim** |
| 4xx non-JSON | 502 wrap | **forward status, wrap body in {error: …}** |
| 5xx | 502 wrap | 502 wrap *(unchanged — daemon broken)* |
| connect/DNS/timeout | 502 | 502 *(unchanged)* |

Also: `tests/Feature/Api/V1/BridgeControllerTest.php` adds a `use Illuminate\Http\Client\ConnectionException;` import to satisfy `fully_qualified_strict_types` Pint rule. This was a single-line miss in #72 that broke `Code Quality` and skipped `Tests`.

## Tests

- Renamed `test_mcp_call_returns_502_when_http_mode_bridge_responds_non_2xx` → `…_responds_5xx` (still asserts 502 for HTTP 500).
- New `test_mcp_call_passes_4xx_through_from_http_mode_bridge` — verifies daemon 404 with JSON body `{detail: …}` reaches the caller as 404 with the same payload.
- New `test_mcp_call_passes_4xx_through_with_non_json_body` — verifies daemon 400 with plain text reaches the caller as 400 with `{error: …}` wrapper.

\`\`\`
docker compose exec app php artisan test --compact tests/Feature/Api/V1/BridgeControllerTest.php
  → 17 passed (44 assertions), 1.56s

docker compose exec app vendor/bin/pint --test
  → PASS 3311 files
\`\`\`

## Backwards compatibility

- Relay-mode bridges are untouched.
- HTTP-mode bridges that previously got 502 from a daemon's 4xx will now see the actual status. Any caller that was specifically branching on 502 to detect a daemon error will need to look at the body — but that branching was already wrong (502 conflated multiple failure modes).

## Test plan

- [x] Unit / feature tests pass (\`docker compose exec app php artisan test base/tests/Feature/Api/V1/BridgeControllerTest.php\`).
- [x] Pint passes (\`docker compose exec app vendor/bin/pint --test\`).
- [ ] (After merge) CI \`Code Quality\` and \`Tests\` jobs both green — first time on \`develop\` since #72 landed.

## Related

- Followup to #72 — error-mapping polish from harbormaster v1.0.0a9 sprint retro.
- harbormaster docs: [docs/sprint-retro-harbormaster-v1.0.0a9.md](https://github.com/FleetQ/harbormaster/blob/main/docs/sprint-retro-harbormaster-v1.0.0a9.md) action item #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)