### PR TITLE
feat(seeders): register Harbormaster as a popular MCP stdio tool

### DIFF
--- a/database/seeders/PopularToolsSeeder.php
+++ b/database/seeders/PopularToolsSeeder.php
@@ -148,6 +148,96 @@ class PopularToolsSeeder extends Seeder
             // ─── MCP Stdio Tools ────────────────────────────────────
 
             [
+                'name' => 'Harbormaster',
+                'slug' => 'harbormaster',
+                'description' => 'Project router MCP — ask any of your local projects (or remote SSH hosts) a question without changing cwd. Each project loads its own CLAUDE.md and Serena memories before answering. Read-only delegation in v1; allow_writes returns an error. Streams partial output via SSE for ask_project. Requires `uvx` (or `pipx`) and a per-project Anthropic seat. Part of the FleetQ ecosystem.',
+                'type' => ToolType::McpStdio,
+                'risk_level' => ToolRiskLevel::Read,
+                'transport_config' => [
+                    'command' => 'uvx',
+                    'args' => ['--prerelease=allow', 'harbormaster-mcp'],
+                    'env' => [],
+                ],
+                'tool_definitions' => [
+                    [
+                        'name' => 'list_projects',
+                        'description' => 'Enumerate configured projects (local) or remote dir listing (SSH).',
+                        'input_schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'host' => ['type' => 'string', 'description' => 'Optional host alias from ~/.ssh/config; omit or set to "local" for local projects'],
+                            ],
+                        ],
+                    ],
+                    [
+                        'name' => 'list_hosts',
+                        'description' => 'List configured [hosts] entries plus ~/.ssh/config Host aliases.',
+                        'input_schema' => [
+                            'type' => 'object',
+                            'properties' => new \stdClass,
+                        ],
+                    ],
+                    [
+                        'name' => 'project_status',
+                        'description' => 'Recent git log, Serena memories, log tails for a single project.',
+                        'input_schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'name' => ['type' => 'string', 'description' => 'Project directory name'],
+                                'host' => ['type' => 'string', 'description' => 'Optional SSH host alias'],
+                            ],
+                            'required' => ['name'],
+                        ],
+                    ],
+                    [
+                        'name' => 'ask_project',
+                        'description' => 'Spawn a Claude Code subagent inside the project, return a markdown summary (≤ 800 words). Streams partial output when called over SSE.',
+                        'input_schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'name' => ['type' => 'string', 'description' => 'Project directory name'],
+                                'question' => ['type' => 'string', 'description' => 'Question to ask the subagent'],
+                                'max_turns' => ['type' => 'integer', 'description' => 'Max conversation turns (default 5)'],
+                                'host' => ['type' => 'string', 'description' => 'Optional SSH host alias'],
+                            ],
+                            'required' => ['name', 'question'],
+                        ],
+                    ],
+                    [
+                        'name' => 'delegate_task',
+                        'description' => 'Delegate a task to a project subagent. Read-only in v1 (allow_writes=true returns an error).',
+                        'input_schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'name' => ['type' => 'string', 'description' => 'Project directory name'],
+                                'task' => ['type' => 'string', 'description' => 'Task description'],
+                                'deliverable' => ['type' => 'string', 'description' => 'Expected output shape'],
+                                'allow_writes' => ['type' => 'boolean', 'description' => 'Reserved for v1.x; v1 fails closed when true'],
+                                'host' => ['type' => 'string', 'description' => 'Optional SSH host alias'],
+                            ],
+                            'required' => ['name', 'task', 'deliverable'],
+                        ],
+                    ],
+                    [
+                        'name' => 'fan_out_ask',
+                        'description' => 'Ask the same question of N projects in parallel. Returns one markdown section per target.',
+                        'input_schema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'question' => ['type' => 'string', 'description' => 'Question to ask each project'],
+                                'project_filter' => ['type' => 'string', 'description' => 'Optional substring filter on project names'],
+                                'host_filter' => ['type' => 'string', 'description' => 'Optional substring filter on host aliases'],
+                                'max_concurrency' => ['type' => 'integer', 'description' => 'Max parallel subagents (default 5)'],
+                                'max_turns' => ['type' => 'integer', 'description' => 'Max conversation turns per subagent (default 3)'],
+                            ],
+                            'required' => ['question'],
+                        ],
+                    ],
+                ],
+                'settings' => ['timeout' => 90],
+            ],
+
+            [
                 'name' => 'Web Fetch',
                 'slug' => 'web-fetch',
                 'description' => 'Fetch and read web pages, converting HTML to markdown. Useful for agents that need to retrieve information from URLs, read documentation, or scrape web content.',


### PR DESCRIPTION
## Summary

Seeds Harbormaster as a popular MCP stdio tool so a fresh FleetQ install surfaces it in `/tools` alongside the rest of the seeded toolkit (Web Fetch, Brave Search, GitHub, Slack, etc.). Disabled by default, same as every other seeded tool.

## Why

Begins v1.1 scope from [`docs/design-harbormaster.md` §3](https://github.com/FleetQ/harbormaster/blob/main/docs/design-harbormaster.md):

> **FleetQ Platform Tool seed entry**: PR into `agent-fleet/base/database/seeders/PopularToolsSeeder.php` registering Harbormaster as an `McpStdio` tool with `risk_level = Read` (write delegation stays read-only). Teams activate via `/tools` UI with their own credentials.

This is the smallest possible v1.1 deliverable — one PR, one seeder entry, no new tables / migrations / columns. It makes Harbormaster *discoverable* at FleetQ install time, which is the precondition for the bigger pieces (A2A Agent Card per project, FleetQ Bridge auto-registration UX).

## What's seeded

| Field | Value |
|---|---|
| `slug` | `harbormaster` |
| `type` | `McpStdio` |
| `risk_level` | `Read` (read-only delegation; `allow_writes=true` fails closed in v1) |
| `transport_config.command` | `uvx` |
| `transport_config.args` | `["--prerelease=allow", "harbormaster-mcp"]` |
| `settings.timeout` | `90` (s) |
| `tool_definitions` | 6 entries with full input_schema |

The 6 tools listed match the v1 manifest exactly: `list_projects`, `list_hosts`, `project_status`, `ask_project`, `delegate_task`, `fan_out_ask`. Each carries its own input_schema with required fields (`name`, `question`, etc.) and optional host SSH alias so FleetQ's tool UI shows the same surface the daemon advertises via `/discover`.

The description specifically calls out:
- **read-only delegation** in v1 (so users don't expect write access)
- **SSE streaming** for `ask_project`
- **uvx (or pipx)** required on the host running the daemon
- **per-project Anthropic seat** required (so users know there's a cost side-effect when they enable this)

## Verification

Ran the seeder against the local Docker FleetQ:

\`\`\`
docker compose exec app php artisan db:seed --class=PopularToolsSeeder --force
  → 56 created, 0 already existed
\`\`\`

Inspected the resulting row:

\`\`\`
$t = Tool::withoutGlobalScopes()->where('slug', 'harbormaster')->first();
[name => Harbormaster, type => mcp_stdio, risk => read,
 transport => uvx, tool_count => 6]
\`\`\`

Pint clean.

## Backwards compatibility

100% additive — existing tool rows are untouched (PopularToolsSeeder uses `updateOrCreate` on `slug`, and `harbormaster` is a new slug). No schema changes. No test changes.

## Test plan

- [x] Pint passes
- [x] `db:seed --class=PopularToolsSeeder --force` runs cleanly and creates the Harbormaster row with the right shape
- [ ] (After merge) Verify the entry appears in the FleetQ Connections / Tools UI with description visible
- [ ] (Follow-up) Add an A2A Agent Card per project (the next v1.1 deliverable from the design doc)

## Related

- v1.0.0a12 retro action item #4 (begin v1.1 scope)
- harbormaster project: https://github.com/FleetQ/harbormaster
- Latest published version: https://pypi.org/project/harbormaster-mcp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)