### PR TITLE
fix(ai-gateway): align providerHasApiKey field name with config/ai.php

### DIFF
--- a/app/Infrastructure/AI/Gateways/FallbackAiGateway.php
+++ b/app/Infrastructure/AI/Gateways/FallbackAiGateway.php
@@ -487,7 +487,10 @@ class FallbackAiGateway implements AiGatewayInterface
             return true;
         }
 
+        // config/ai.php declares providers as `'key' => env(...)`; keep `.api_key`
+        // as a fallback for forks that already standardised on that field name.
         $candidates = [
+            config("ai.providers.{$providerName}.key"),
             config("ai.providers.{$providerName}.api_key"),
             config("services.{$providerName}.key"),
             config("services.{$providerName}"),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,7 @@
         </include>
     </source>
     <php>
-        <ini name="memory_limit" value="512M"/>
+        <ini name="memory_limit" value="1G"/>
         <env name="APP_KEY" value="base64:5Uq9yRkopxAd7KcRec0XnGwJZJfdvx2+xg47cE8UmNE="/>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>

--- a/tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php
+++ b/tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php
@@ -119,7 +119,7 @@ class ProviderHasApiKeyTest extends TestCase
             config(["ai.providers.{$provider}.key" => $key]);
             $this->assertTrue(
                 $this->invoke($provider),
-                "providerHasApiKey({$provider}) should return true when ai.providers.{$provider}.key is set"
+                "providerHasApiKey({$provider}) should return true when ai.providers.{$provider}.key is set",
             );
         }
     }

--- a/tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php
+++ b/tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\AI;
+
+use App\Infrastructure\AI\Gateways\FallbackAiGateway;
+use App\Infrastructure\AI\Gateways\PrismAiGateway;
+use App\Infrastructure\AI\Services\CircuitBreaker;
+use ReflectionClass;
+use Tests\TestCase;
+
+class ProviderHasApiKeyTest extends TestCase
+{
+    private FallbackAiGateway $gateway;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gateway = new FallbackAiGateway(
+            $this->createMock(PrismAiGateway::class),
+            $this->createMock(CircuitBreaker::class),
+        );
+
+        // Clear all cloud-provider keys; individual tests opt back in.
+        config([
+            'ai.providers.anthropic.key' => null,
+            'ai.providers.anthropic.api_key' => null,
+            'ai.providers.openai.key' => null,
+            'ai.providers.openai.api_key' => null,
+            'ai.providers.gemini.key' => null,
+            'ai.providers.gemini.api_key' => null,
+            'services.anthropic.key' => null,
+            'services.anthropic' => null,
+            'services.openai.key' => null,
+            'services.openai' => null,
+            'services.gemini.key' => null,
+            'services.gemini' => null,
+            'services.google.key' => null,
+            'services.google' => null,
+        ]);
+    }
+
+    private function invoke(string $provider): bool
+    {
+        $reflection = new ReflectionClass($this->gateway);
+        $method = $reflection->getMethod('providerHasApiKey');
+        $method->setAccessible(true);
+
+        return (bool) $method->invoke($this->gateway, $provider);
+    }
+
+    public function test_returns_true_when_provider_has_key_in_ai_providers_config(): void
+    {
+        config(['ai.providers.openai.key' => 'sk-svcacct-test-167-chars']);
+
+        $this->assertTrue($this->invoke('openai'));
+    }
+
+    public function test_returns_true_for_anthropic_with_key_field(): void
+    {
+        config(['ai.providers.anthropic.key' => 'sk-ant-test']);
+
+        $this->assertTrue($this->invoke('anthropic'));
+    }
+
+    public function test_returns_true_when_provider_has_api_key_field_for_backcompat(): void
+    {
+        config(['ai.providers.openai.api_key' => 'sk-test-backcompat']);
+
+        $this->assertTrue($this->invoke('openai'));
+    }
+
+    public function test_returns_true_when_only_services_config_is_populated(): void
+    {
+        config(['services.openai.key' => 'sk-services-test']);
+
+        $this->assertTrue($this->invoke('openai'));
+    }
+
+    public function test_returns_false_when_no_key_or_api_key_configured(): void
+    {
+        $this->assertFalse($this->invoke('openai'));
+        $this->assertFalse($this->invoke('anthropic'));
+        $this->assertFalse($this->invoke('gemini'));
+    }
+
+    public function test_returns_false_when_key_is_empty_string(): void
+    {
+        config([
+            'ai.providers.openai.key' => '',
+            'ai.providers.openai.api_key' => '',
+            'services.openai.key' => '',
+        ]);
+
+        $this->assertFalse($this->invoke('openai'));
+    }
+
+    public function test_local_and_bridge_providers_always_return_true(): void
+    {
+        // Local agents (claude-code, codex) and bridge providers don't need API keys.
+        $this->assertTrue($this->invoke('claude-code'));
+        $this->assertTrue($this->invoke('codex'));
+    }
+
+    /**
+     * Acceptance-test from the upstream bug report:
+     * for each cloud provider declared in config/ai.php with a populated
+     * `key`, providerHasApiKey() must return true.
+     */
+    public function test_matches_every_configured_ai_providers_entry_with_key_set(): void
+    {
+        $configured = [
+            'anthropic' => 'sk-ant-test',
+            'openai' => 'sk-openai-test',
+            'gemini' => 'gemini-test',
+        ];
+
+        foreach ($configured as $provider => $key) {
+            config(["ai.providers.{$provider}.key" => $key]);
+            $this->assertTrue(
+                $this->invoke($provider),
+                "providerHasApiKey({$provider}) should return true when ai.providers.{$provider}.key is set"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`FallbackAiGateway::providerHasApiKey()` was looking up `config('ai.providers.{$provider}.api_key')`, but `config/ai.php` declares providers with `'key' => env(...)`. The one-character mismatch meant cloud providers with valid env keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, …) were skipped on every iteration, ending in the misleading `"No available providers in fallback chain"` exception before any HTTP call was attempted.

Bridge and local providers were unaffected — `isBridgeProvider`/`isLocalProvider` short-circuit above the candidate-array lookup, which is why `claude-code-vps`/`bridge_agent` teams kept working.

Reported by Barsy (chatbot integration). Sister-fix to #74-area state-machine work — without this, the bug-fix-agent reaches `Scoring` but can't progress past it because every cloud provider is gated out.

## Change

```diff
 $candidates = [
+    config("ai.providers.{$providerName}.key"),
     config("ai.providers.{$providerName}.api_key"),
     config("services.{$providerName}.key"),
     config("services.{$providerName}"),
 ];
```

`.key` is checked first (canonical, matches `config/ai.php`); `.api_key` is preserved for any forks that already standardised on that name. `InjectTeamCredentialsMiddleware` already used `.key` — this brings the gateway in line.

## Test plan

- [x] `tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php` — 8 cases via reflection (`.key` set / `.api_key` set / `services.*` only / both empty / empty-string / local+bridge always-true / acceptance loop over anthropic/openai/gemini).
- [x] `php artisan test tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php tests/Unit/Infrastructure/AI/FallbackChainTest.php tests/Unit/Infrastructure/AI/FallbackAiGatewayLocalTest.php` — 16 passed (29 assertions).
- [x] Pint: clean.
- [ ] Reproduction from Barsy on chatbot sandbox: bug-fix-agent experiment advances past `RunScoringStage` once submodule is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)