### PR TITLE
feat(signal): idempotent add_comment via optional idempotency_key

### DIFF
--- a/app/Domain/Signal/Actions/AddSignalCommentAction.php
+++ b/app/Domain/Signal/Actions/AddSignalCommentAction.php
@@ -6,6 +6,7 @@ use App\Domain\Signal\Enums\CommentAuthorType;
 use App\Domain\Signal\Events\SignalCommentAdded;
 use App\Domain\Signal\Models\Signal;
 use App\Domain\Signal\Models\SignalComment;
+use Illuminate\Database\QueryException;
 
 class AddSignalCommentAction
 {
@@ -14,20 +15,63 @@ class AddSignalCommentAction
         string $body,
         CommentAuthorType|string $authorType = CommentAuthorType::Human,
         ?string $userId = null,
+        ?string $idempotencyKey = null,
+        bool $replace = false,
     ): SignalComment {
         $type = is_string($authorType) ? CommentAuthorType::from($authorType) : $authorType;
 
-        $comment = SignalComment::create([
-            'team_id' => $signal->team_id,
-            'signal_id' => $signal->id,
-            'user_id' => $userId,
-            'author_type' => $type->value,
-            'body' => $body,
-            'widget_visible' => $type->isWidgetVisible(),
-        ]);
+        if ($idempotencyKey !== null) {
+            $existing = SignalComment::query()
+                ->where('signal_id', $signal->id)
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+
+            if ($existing !== null) {
+                if ($replace && $existing->body !== $body) {
+                    $existing->update(['body' => $body]);
+                }
+
+                return $existing;
+            }
+
+            try {
+                $comment = SignalComment::create([
+                    'team_id' => $signal->team_id,
+                    'signal_id' => $signal->id,
+                    'user_id' => $userId,
+                    'author_type' => $type->value,
+                    'body' => $body,
+                    'widget_visible' => $type->isWidgetVisible(),
+                    'idempotency_key' => $idempotencyKey,
+                ]);
+            } catch (QueryException $e) {
+                // Race: another writer just inserted under the same partial unique index.
+                // Re-fetch the winner; honor `replace` semantics.
+                $comment = SignalComment::query()
+                    ->where('signal_id', $signal->id)
+                    ->where('idempotency_key', $idempotencyKey)
+                    ->firstOrFail();
+
+                if ($replace && $comment->body !== $body) {
+                    $comment->update(['body' => $body]);
+                }
+
+                return $comment;
+            }
+        } else {
+            $comment = SignalComment::create([
+                'team_id' => $signal->team_id,
+                'signal_id' => $signal->id,
+                'user_id' => $userId,
+                'author_type' => $type->value,
+                'body' => $body,
+                'widget_visible' => $type->isWidgetVisible(),
+            ]);
+        }
 
         // Only reporter comments trigger the event — agent/human/support comments
         // are authored server-side and already produce their own audit trail.
+        // Dispatch only on freshly created rows so retries don't double-fire.
         if ($type === CommentAuthorType::Reporter) {
             SignalCommentAdded::dispatch($comment);
         }

--- a/app/Domain/Signal/Models/SignalComment.php
+++ b/app/Domain/Signal/Models/SignalComment.php
@@ -22,6 +22,7 @@ class SignalComment extends Model implements HasMedia
         'author_type',
         'body',
         'widget_visible',
+        'idempotency_key',
     ];
 
     protected function casts(): array

--- a/app/Mcp/Tools/Signal/BugReportAddCommentTool.php
+++ b/app/Mcp/Tools/Signal/BugReportAddCommentTool.php
@@ -17,7 +17,15 @@ class BugReportAddCommentTool extends Tool
 {
     protected string $name = 'bug_report_add_comment';
 
-    protected string $description = 'Add a comment to a bug report. Agent comments are marked as author_type=agent.';
+    protected string $description = <<<'TXT'
+Add a comment to a bug report. Agent comments are marked as author_type=agent.
+
+Idempotency: pass `idempotency_key` to dedupe retries (e.g. `experiment:{id}:summary`,
+`experiment:{id}:stage:{stage}`, `agent:{id}:run:{ai_run_id}`). With the same key on a
+prior call, this is a no-op and returns the existing comment. Set `replace=true` to update
+the existing comment's body in place (created_at preserved, updated_at refreshed).
+Without a key, every call inserts a new comment (legacy behaviour).
+TXT;
 
     public function schema(JsonSchema $schema): array
     {
@@ -26,6 +34,10 @@ class BugReportAddCommentTool extends Tool
                 ->description('UUID of the bug report signal'),
             'body' => $schema->string()
                 ->description('Comment text'),
+            'idempotency_key' => $schema->string()
+                ->description('Optional dedupe key scoped to this signal. Same key + same signal = single row.'),
+            'replace' => $schema->boolean()
+                ->description('When true and the key already exists, update the existing comment body in place. Default false (no-op).'),
         ];
     }
 
@@ -37,16 +49,24 @@ class BugReportAddCommentTool extends Tool
             return Response::text(json_encode(['error' => 'Bug report not found']));
         }
 
+        $idempotencyKey = $request->get('idempotency_key');
+        $replace = (bool) $request->get('replace', false);
+
         $comment = app(AddSignalCommentAction::class)->execute(
             signal: $signal,
             body: $request->get('body'),
             authorType: 'agent',
+            idempotencyKey: $idempotencyKey !== null && $idempotencyKey !== '' ? (string) $idempotencyKey : null,
+            replace: $replace,
         );
 
         return Response::text(json_encode([
             'comment_id' => $comment->id,
             'body' => $comment->body,
+            'idempotency_key' => $comment->idempotency_key,
             'created_at' => $comment->created_at?->toISOString(),
+            'updated_at' => $comment->updated_at?->toISOString(),
+            'deduped' => $idempotencyKey !== null && ! $comment->wasRecentlyCreated,
         ]));
     }
 }

--- a/database/migrations/2026_05_09_120000_add_idempotency_key_to_signal_comments.php
+++ b/database/migrations/2026_05_09_120000_add_idempotency_key_to_signal_comments.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('signal_comments', function (Blueprint $table) {
+            $table->string('idempotency_key', 191)->nullable()->after('body');
+        });
+
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::statement(
+                'CREATE UNIQUE INDEX IF NOT EXISTS signal_comments_signal_idem_unique '
+                .'ON signal_comments (signal_id, idempotency_key) '
+                .'WHERE idempotency_key IS NOT NULL'
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::statement('DROP INDEX IF EXISTS signal_comments_signal_idem_unique');
+        }
+
+        Schema::table('signal_comments', function (Blueprint $table) {
+            $table->dropColumn('idempotency_key');
+        });
+    }
+};

--- a/tests/Feature/Domain/Signal/SignalCommentIdempotencyTest.php
+++ b/tests/Feature/Domain/Signal/SignalCommentIdempotencyTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature\Domain\Signal;
+
+use App\Domain\Signal\Actions\AddSignalCommentAction;
+use App\Domain\Signal\Enums\SignalStatus;
+use App\Domain\Signal\Models\Signal;
+use App\Domain\Signal\Models\SignalComment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Api\V1\ApiTestCase;
+
+class SignalCommentIdempotencyTest extends ApiTestCase
+{
+    use RefreshDatabase;
+
+    public function test_no_idempotency_key_still_inserts_each_call(): void
+    {
+        $signal = $this->createBugReportSignal();
+        $action = app(AddSignalCommentAction::class);
+
+        $action->execute($signal, body: 'first', authorType: 'agent');
+        $action->execute($signal, body: 'first', authorType: 'agent');
+
+        $this->assertSame(
+            2,
+            SignalComment::query()->where('signal_id', $signal->id)->count(),
+            'Without idempotency_key, the action must remain insert-on-every-call.',
+        );
+    }
+
+    public function test_same_idempotency_key_dedupes_to_single_row(): void
+    {
+        $signal = $this->createBugReportSignal();
+        $action = app(AddSignalCommentAction::class);
+
+        $first = $action->execute(
+            signal: $signal,
+            body: 'Fix complete — PR #22 open for review',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:summary',
+        );
+
+        $second = $action->execute(
+            signal: $signal,
+            body: 'Fix complete — PR #22 open for review',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:summary',
+        );
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame(
+            1,
+            SignalComment::query()->where('signal_id', $signal->id)->count(),
+        );
+    }
+
+    public function test_replace_true_updates_body_in_place(): void
+    {
+        $signal = $this->createBugReportSignal();
+        $action = app(AddSignalCommentAction::class);
+
+        $first = $action->execute(
+            signal: $signal,
+            body: 'Investigating…',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:summary',
+        );
+
+        $originalCreatedAt = $first->created_at;
+
+        // Force a measurable updated_at delta.
+        sleep(1);
+
+        $second = $action->execute(
+            signal: $signal,
+            body: 'Fix complete — PR #22 open for review',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:summary',
+            replace: true,
+        );
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame('Fix complete — PR #22 open for review', $second->fresh()->body);
+        $this->assertEquals(
+            $originalCreatedAt->timestamp,
+            $second->fresh()->created_at->timestamp,
+            'created_at must be preserved when replacing.',
+        );
+        $this->assertGreaterThan(
+            $originalCreatedAt->timestamp,
+            $second->fresh()->updated_at->timestamp,
+            'updated_at must advance when replacing.',
+        );
+        $this->assertSame(
+            1,
+            SignalComment::query()->where('signal_id', $signal->id)->count(),
+        );
+    }
+
+    public function test_replace_false_default_returns_existing_without_change(): void
+    {
+        $signal = $this->createBugReportSignal();
+        $action = app(AddSignalCommentAction::class);
+
+        $first = $action->execute(
+            signal: $signal,
+            body: 'Investigating…',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:summary',
+        );
+
+        $second = $action->execute(
+            signal: $signal,
+            body: 'A different body that must NOT overwrite',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:summary',
+        );
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame('Investigating…', $second->fresh()->body);
+        $this->assertSame(
+            1,
+            SignalComment::query()->where('signal_id', $signal->id)->count(),
+        );
+    }
+
+    public function test_different_keys_do_not_collide(): void
+    {
+        $signal = $this->createBugReportSignal();
+        $action = app(AddSignalCommentAction::class);
+
+        $action->execute(
+            signal: $signal,
+            body: 'summary',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:summary',
+        );
+
+        $action->execute(
+            signal: $signal,
+            body: 'stage:building',
+            authorType: 'agent',
+            idempotencyKey: 'experiment:abc:stage:building',
+        );
+
+        $this->assertSame(
+            2,
+            SignalComment::query()->where('signal_id', $signal->id)->count(),
+        );
+    }
+
+    public function test_keys_are_scoped_per_signal(): void
+    {
+        $signalA = $this->createBugReportSignal();
+        $signalB = $this->createBugReportSignal();
+        $action = app(AddSignalCommentAction::class);
+
+        $action->execute(
+            signal: $signalA,
+            body: 'on A',
+            authorType: 'agent',
+            idempotencyKey: 'shared-key',
+        );
+
+        $action->execute(
+            signal: $signalB,
+            body: 'on B',
+            authorType: 'agent',
+            idempotencyKey: 'shared-key',
+        );
+
+        $this->assertSame(1, SignalComment::query()->where('signal_id', $signalA->id)->count());
+        $this->assertSame(1, SignalComment::query()->where('signal_id', $signalB->id)->count());
+    }
+
+    private function createBugReportSignal(SignalStatus $status = SignalStatus::Received): Signal
+    {
+        return Signal::create([
+            'team_id' => $this->team->id,
+            'source_type' => 'bug_report',
+            'source_identifier' => 'client-platform',
+            'project_key' => 'client-platform',
+            'status' => $status,
+            'content_hash' => md5('bug_report-client-platform-'.microtime(true).'-'.bin2hex(random_bytes(4))),
+            'received_at' => now(),
+            'payload' => [
+                'title' => 'Submit button broken',
+                'description' => 'desc',
+                'severity' => 'major',
+                'url' => 'https://app.example.com/checkout',
+                'reporter_id' => 'user-123',
+                'reporter_name' => 'Alice',
+                'action_log' => [],
+                'console_log' => [],
+                'network_log' => [],
+                'browser' => 'Mozilla/5.0',
+                'viewport' => '1440x900',
+                'environment' => 'production',
+            ],
+            'tags' => ['bug_report', 'major'],
+        ]);
+    }
+}

--- a/tests/Feature/Mcp/BugReportAddCommentToolTest.php
+++ b/tests/Feature/Mcp/BugReportAddCommentToolTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Shared\Models\Team;
+use App\Domain\Signal\Enums\SignalStatus;
+use App\Domain\Signal\Models\Signal;
+use App\Domain\Signal\Models\SignalComment;
+use App\Mcp\Tools\Signal\BugReportAddCommentTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class BugReportAddCommentToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Comment Tool Team',
+            'slug' => 'comment-tool-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($this->user);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    public function test_idempotency_key_dedupes_via_mcp_tool(): void
+    {
+        $signal = $this->makeBugReport();
+        $tool = new BugReportAddCommentTool;
+
+        $first = $this->decode($tool->handle(new Request([
+            'signal_id' => $signal->id,
+            'body' => 'Fix complete — PR #22',
+            'idempotency_key' => 'experiment:abc:summary',
+        ])));
+
+        $second = $this->decode($tool->handle(new Request([
+            'signal_id' => $signal->id,
+            'body' => 'Fix complete — PR #22',
+            'idempotency_key' => 'experiment:abc:summary',
+        ])));
+
+        $this->assertSame($first['comment_id'], $second['comment_id']);
+        $this->assertTrue($second['deduped'], 'Second call must report deduped=true.');
+        $this->assertFalse($first['deduped'], 'First call must report deduped=false.');
+        $this->assertSame(1, SignalComment::query()->where('signal_id', $signal->id)->count());
+    }
+
+    public function test_replace_true_updates_body_via_mcp_tool(): void
+    {
+        $signal = $this->makeBugReport();
+        $tool = new BugReportAddCommentTool;
+
+        $tool->handle(new Request([
+            'signal_id' => $signal->id,
+            'body' => 'Investigating…',
+            'idempotency_key' => 'experiment:abc:summary',
+        ]));
+
+        $second = $this->decode($tool->handle(new Request([
+            'signal_id' => $signal->id,
+            'body' => 'Final summary',
+            'idempotency_key' => 'experiment:abc:summary',
+            'replace' => true,
+        ])));
+
+        $this->assertSame('Final summary', $second['body']);
+        $this->assertSame(1, SignalComment::query()->where('signal_id', $signal->id)->count());
+    }
+
+    public function test_no_key_inserts_each_call_via_mcp_tool(): void
+    {
+        $signal = $this->makeBugReport();
+        $tool = new BugReportAddCommentTool;
+
+        $tool->handle(new Request([
+            'signal_id' => $signal->id,
+            'body' => 'first',
+        ]));
+
+        $tool->handle(new Request([
+            'signal_id' => $signal->id,
+            'body' => 'first',
+        ]));
+
+        $this->assertSame(2, SignalComment::query()->where('signal_id', $signal->id)->count());
+    }
+
+    private function makeBugReport(): Signal
+    {
+        return Signal::create([
+            'team_id' => $this->team->id,
+            'source_type' => 'bug_report',
+            'source_identifier' => 'client-platform',
+            'project_key' => 'client-platform',
+            'status' => SignalStatus::Received,
+            'content_hash' => md5('bug_report-'.bin2hex(random_bytes(6))),
+            'received_at' => now(),
+            'payload' => [
+                'title' => 'x',
+                'description' => 'y',
+                'severity' => 'major',
+                'url' => 'https://app.example.com/x',
+                'reporter_id' => 'r',
+                'reporter_name' => 'n',
+                'action_log' => [],
+                'console_log' => [],
+                'network_log' => [],
+                'browser' => 'b',
+                'viewport' => 'v',
+                'environment' => 'production',
+            ],
+            'tags' => ['bug_report'],
+        ]);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+}


### PR DESCRIPTION
## Summary

Reported by Barsy's bug-fix-agent loop on `chat.sandbox.barsy.dev`: a single signal accumulated 5 near-duplicate "summary" comments during one verification loop because every retry of the agent re-posted via `bug_report_add_comment`.

This adds opt-in idempotency at the action layer so the invariant is server-side, not runbook-side.

## Changes

- **Migration** — `signal_comments.idempotency_key VARCHAR(191) NULL` + partial unique index `(signal_id, idempotency_key) WHERE idempotency_key IS NOT NULL` (PostgreSQL only).
- **Model** — `idempotency_key` added to `$fillable`.
- **Action** (`AddSignalCommentAction::execute`) — new optional params `?string $idempotencyKey = null`, `bool $replace = false`. Pre-checks `(signal_id, idempotency_key)`; on race the unique index fires → `QueryException` is caught and the winner is re-fetched. `SignalCommentAdded` never double-fires.
- **MCP tool** (`bug_report_add_comment`) — schema gains `idempotency_key` + `replace`. Response gains `deduped` boolean and `updated_at`.
- **Tests** — `SignalCommentIdempotencyTest` (6 cases, action layer) and `BugReportAddCommentToolTest` (3 cases, MCP wiring). Full Signal feature suite still green (168 tests).

Backward compatible: omitting `idempotency_key` keeps the old insert-on-every-call behaviour. All other existing callers (`UpdateSignalStatusAction`, widget controllers, `BugReportConfirmResolutionTool`, `BugReportDetailPage`) are untouched.

## Suggested keys (per Barsy's brief)

- `experiment:{id}:summary` — final summary per experiment
- `experiment:{id}:stage:{stage}` — per-stage updates
- `agent:{id}:run:{ai_run_id}` — per-LLM-run checkpoints

## Acceptance criteria from the report

- [x] Two consecutive calls with the same `(signal_id, idempotency_key)` produce one row.
- [x] `replace=true` with a different body updates the existing row's `body` and `updated_at`, leaves `created_at` intact.
- [x] Without a key, behaviour is unchanged (every call inserts).

## Trade-offs

Used a partial unique index on the same table rather than a side `signal_comment_idempotency` mapping table — simpler, single query, DB-level race guarantee. If we ever want TTL-based reclaim of old keys, a `WHERE updated_at < NOW() - INTERVAL '90 days'` purge job is straightforward.

## Test plan

- [x] `php artisan test tests/Feature/Domain/Signal/SignalCommentIdempotencyTest.php` (6/6 ✓)
- [x] `php artisan test tests/Feature/Mcp/BugReportAddCommentToolTest.php` (3/3 ✓)
- [x] `php artisan test tests/Feature/Domain/Signal/` — full Signal suite (168/168 ✓)
- [x] `vendor/bin/pint --dirty` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)