### PR TITLE
fix(phpstan): batch 2 — Agent + Marketplace + Trigger @property gaps, Resource @mixins

### DIFF
--- a/app/Domain/Agent/Models/Agent.php
+++ b/app/Domain/Agent/Models/Agent.php
@@ -45,7 +45,7 @@ use Illuminate\Support\Carbon;
  * @property string $provider
  * @property string $model
  * @property array<string, mixed>|null $output_schema
- * @property int $output_schema_max_retries
+ * @property int|null $output_schema_max_retries
  * @property AgentStatus $status
  * @property array<string, mixed>|null $config
  * @property array<string, mixed>|null $capabilities

--- a/app/Domain/Agent/Models/Agent.php
+++ b/app/Domain/Agent/Models/Agent.php
@@ -22,6 +22,7 @@ use App\Infrastructure\AI\Models\LlmRequestLog;
 use App\Models\User;
 use Database\Factories\Domain\Agent\AgentFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -33,24 +34,65 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
 /**
+ * @property string $id
  * @property string|null $team_id
  * @property string $name
+ * @property string $slug
  * @property string|null $role
  * @property string|null $goal
  * @property string|null $backstory
- * @property array|null $personality
+ * @property array<string, mixed>|null $personality
  * @property string $provider
  * @property string $model
+ * @property array<string, mixed>|null $output_schema
+ * @property int $output_schema_max_retries
  * @property AgentStatus $status
- * @property array|null $config
- * @property array|null $capabilities
- * @property array|null $constraints
+ * @property array<string, mixed>|null $config
+ * @property array<string, mixed>|null $capabilities
+ * @property array<string, mixed>|null $constraints
  * @property int|null $budget_cap_credits
  * @property int $budget_spent_credits
  * @property int|null $max_credits_per_call
+ * @property bool $evaluation_enabled
+ * @property float $evaluation_sample_rate
+ * @property string|null $evaluation_model
+ * @property array<string, mixed>|null $evaluation_criteria
  * @property int $cost_per_1k_input
  * @property int $cost_per_1k_output
  * @property Carbon|null $last_health_check
+ * @property int $equivocation_count
+ * @property Carbon|null $last_equivocated_at
+ * @property string|null $knowledge_base_id
+ * @property string|null $risk_score
+ * @property array<string, mixed>|null $risk_profile
+ * @property Carbon|null $risk_profile_updated_at
+ * @property array<string, mixed>|null $meta
+ * @property array<string, mixed>|null $heartbeat_definition
+ * @property DataClassification|null $data_classification
+ * @property array<string, mixed>|null $sandbox_profile
+ * @property string|null $tool_profile
+ * @property AgentEnvironment|null $environment
+ * @property array<string, mixed>|null $system_prompt_template
+ * @property AgentReasoningStrategy|null $reasoning_strategy
+ * @property AgentScope|null $scope
+ * @property string|null $owner_user_id
+ * @property bool $chat_protocol_enabled
+ * @property AgentChatVisibility|null $chat_protocol_visibility
+ * @property string|null $chat_protocol_slug
+ * @property array<string, mixed>|null $chat_protocol_config
+ * @property string|null $chat_protocol_secret
+ * @property array<string, mixed>|null $tool_deny_list
+ * @property string|null $default_workflow_id
+ * @property bool $strict_mode
+ * @property ToolPermissionLevel|null $tool_permission_default
+ * @property-read Team|null $team
+ * @property-read Collection<int, Skill> $skills
+ * @property-read Collection<int, Tool> $tools
+ * @property-read Collection<int, Toolset> $toolsets
+ * @property-read User|null $owner
+ * @property-read AgentRuntimeState|null $runtimeState
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class Agent extends Model
 {

--- a/app/Domain/Agent/Models/AgentRuntimeState.php
+++ b/app/Domain/Agent/Models/AgentRuntimeState.php
@@ -6,7 +6,22 @@ use App\Domain\Shared\Traits\BelongsToTeam;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property string $agent_id
+ * @property string|null $team_id
+ * @property string|null $session_id
+ * @property array<string, mixed>|null $state_json
+ * @property int $total_input_tokens
+ * @property int $total_output_tokens
+ * @property int $total_cached_tokens
+ * @property int $total_cost_credits
+ * @property int $total_executions
+ * @property string|null $last_error
+ * @property Carbon|null $last_active_at
+ */
 class AgentRuntimeState extends Model
 {
     use BelongsToTeam, HasUuids;

--- a/app/Domain/Marketplace/Models/MarketplaceListing.php
+++ b/app/Domain/Marketplace/Models/MarketplaceListing.php
@@ -7,6 +7,7 @@ use App\Domain\Marketplace\Enums\MarketplaceStatus;
 use App\Domain\Shared\Models\Team;
 use App\Models\User;
 use Database\Factories\Domain\Marketplace\MarketplaceListingFactory;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -49,6 +50,9 @@ use Illuminate\Support\Carbon;
  * @property float $community_reliability_rate
  * @property int $effective_run_count
  * @property Carbon|null $quality_computed_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Collection<int, MarketplaceReview> $reviews
  */
 class MarketplaceListing extends Model
 {

--- a/app/Domain/Trigger/Models/TriggerRule.php
+++ b/app/Domain/Trigger/Models/TriggerRule.php
@@ -10,7 +10,24 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property string $team_id
+ * @property string|null $project_id
+ * @property string $name
+ * @property string $source_type
+ * @property array<string, mixed>|null $conditions
+ * @property array<string, mixed>|null $input_mapping
+ * @property int $cooldown_seconds
+ * @property int $max_concurrent
+ * @property TriggerRuleStatus $status
+ * @property Carbon|null $last_triggered_at
+ * @property int $total_triggers
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class TriggerRule extends Model
 {
     use BelongsToTeam, HasUuids;

--- a/app/Http/Resources/Api/V1/AgentResource.php
+++ b/app/Http/Resources/Api/V1/AgentResource.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Agent\Models\Agent;
 use Illuminate\Http\Request;
 
+/** @mixin Agent */
 class AgentResource extends FleetQResource
 {
     public function toArray(Request $request): array
@@ -30,8 +32,9 @@ class AgentResource extends FleetQResource
                 'id' => $skill->id,
                 'name' => $skill->name,
                 'type' => $skill->type->value,
-                'priority' => $skill->pivot->priority,
-            ])),
+                /** @phpstan-ignore-next-line property.notFound — `pivot` is dynamically attached by BelongsToMany at runtime */
+                'priority' => $skill->pivot?->getAttribute('priority'),
+            ])->all()),
             'runtime_state' => $this->whenLoaded('runtimeState', fn () => $this->runtimeState ? [
                 'total_executions' => $this->runtimeState->total_executions,
                 'total_input_tokens' => $this->runtimeState->total_input_tokens,

--- a/app/Http/Resources/Api/V1/ChatbotResource.php
+++ b/app/Http/Resources/Api/V1/ChatbotResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Chatbot\Models\Chatbot;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/** @mixin Chatbot */
 class ChatbotResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/Api/V1/CredentialResource.php
+++ b/app/Http/Resources/Api/V1/CredentialResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Credential\Models\Credential;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/** @mixin Credential */
 class CredentialResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/Api/V1/CrewExecutionResource.php
+++ b/app/Http/Resources/Api/V1/CrewExecutionResource.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Crew\Models\CrewExecution;
 use Illuminate\Http\Request;
 
+/** @mixin CrewExecution */
 class CrewExecutionResource extends FleetQResource
 {
     public function toArray(Request $request): array
@@ -40,7 +42,7 @@ class CrewExecutionResource extends FleetQResource
                 'sort_order' => $t->sort_order,
                 'started_at' => $t->started_at?->toISOString(),
                 'completed_at' => $t->completed_at?->toISOString(),
-            ])),
+            ])->all()),
             'started_at' => $this->started_at?->toISOString(),
             'completed_at' => $this->completed_at?->toISOString(),
             'created_at' => $this->created_at->toISOString(),

--- a/app/Http/Resources/Api/V1/CrewResource.php
+++ b/app/Http/Resources/Api/V1/CrewResource.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Crew\Models\Crew;
 use Illuminate\Http\Request;
 
+/** @mixin Crew */
 class CrewResource extends FleetQResource
 {
     public function toArray(Request $request): array
@@ -35,7 +37,7 @@ class CrewResource extends FleetQResource
                 'role' => $m->role->value,
                 'sort_order' => $m->sort_order,
                 'config' => $m->config,
-            ])),
+            ])->all()),
             'executions_count' => $this->whenCounted('executions', fn () => $this->executions_count),
             'user_id' => $this->user_id,
             'created_at' => $this->created_at->toISOString(),

--- a/app/Http/Resources/Api/V1/MarketplaceListingResource.php
+++ b/app/Http/Resources/Api/V1/MarketplaceListingResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Marketplace\Models\MarketplaceListing;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/** @mixin MarketplaceListing */
 class MarketplaceListingResource extends JsonResource
 {
     public function toArray(Request $request): array
@@ -32,7 +34,7 @@ class MarketplaceListingResource extends JsonResource
                 'comment' => $r->comment,
                 'user_id' => $r->user_id,
                 'created_at' => $r->created_at->toISOString(),
-            ])),
+            ])->all()),
             'created_at' => $this->created_at->toISOString(),
             'updated_at' => $this->updated_at->toISOString(),
         ];

--- a/app/Http/Resources/Api/V1/SkillResource.php
+++ b/app/Http/Resources/Api/V1/SkillResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Skill\Models\Skill;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/** @mixin Skill */
 class SkillResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/Api/V1/ToolResource.php
+++ b/app/Http/Resources/Api/V1/ToolResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Tool\Models\Tool;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/** @mixin Tool */
 class ToolResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/Api/V1/TriggerRuleResource.php
+++ b/app/Http/Resources/Api/V1/TriggerRuleResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Trigger\Models\TriggerRule;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/** @mixin TriggerRule */
 class TriggerRuleResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/Api/V1/WebsitePageResource.php
+++ b/app/Http/Resources/Api/V1/WebsitePageResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Website\Models\WebsitePage;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/** @mixin WebsitePage */
 class WebsitePageResource extends JsonResource
 {
     public function toArray(Request $request): array

--- a/app/Http/Resources/Api/V1/WorkflowResource.php
+++ b/app/Http/Resources/Api/V1/WorkflowResource.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Domain\Workflow\Models\Workflow;
 use Illuminate\Http\Request;
 
+/** @mixin Workflow */
 class WorkflowResource extends FleetQResource
 {
     public function toArray(Request $request): array
@@ -29,7 +31,7 @@ class WorkflowResource extends FleetQResource
                 'position_y' => $n->position_y,
                 'config' => $n->config,
                 'order' => $n->order,
-            ])),
+            ])->all()),
             'edges' => $this->whenLoaded('edges', fn () => $this->edges->map(fn ($e) => [
                 'id' => $e->id,
                 'source_node_id' => $e->source_node_id,
@@ -38,7 +40,7 @@ class WorkflowResource extends FleetQResource
                 'label' => $e->label,
                 'is_default' => $e->is_default,
                 'sort_order' => $e->sort_order,
-            ])),
+            ])->all()),
             'user_id' => $this->user_id,
             'created_at' => $this->created_at->toISOString(),
             'updated_at' => $this->updated_at->toISOString(),


### PR DESCRIPTION
## Why

Continues [#82](https://github.com/escapeboy/agent-fleet-o/issues/82) after #86 merged. Targets deferred items from batch 1:

- AgentResource (21 entries) — blocked because Agent.php @property was incomplete
- MarketplaceListing's `reviews` relation
- TriggerRule had **no @property block at all**
- Several API Resources still lacked `@mixin`

## What

**Models**
- `Agent` — expanded the existing @property block from 18 fields to ~50 (covers all fillable + casts + relations + timestamps)
- `AgentRuntimeState` — greenfield @property block
- `MarketplaceListing` — added `reviews` relation + timestamps
- `TriggerRule` — greenfield @property block

**API Resources** (one-line `@mixin <Model>` each)
- AgentResource, SkillResource, ToolResource, CrewResource, CrewExecutionResource, WorkflowResource, MarketplaceListingResource, ChatbotResource, CredentialResource, WebsitePageResource, TriggerRuleResource

**Collection covariance** — Larastan flagged 5 `->map()` results where the closure return type didn't satisfy `Collection<int, X>` covariance. Fixed by appending `->all()` to convert to plain arrays (WorkflowResource ×2, CrewResource, CrewExecutionResource, AgentResource, MarketplaceListingResource).

One `@phpstan-ignore-next-line` for `$skill->pivot` since BelongsToMany attaches pivot dynamically at runtime.

## Verification

Targeted PHPStan on all 15 changed files: `[OK] No errors`. CI is the cross-check.

## Expected impact

Should resolve ~150-200 baselined entries (AgentResource 21 + SkillResource 20 + MarketplaceListingResource 19 + CrewExecutionResource 18 + ToolResource 16 + CrewResource 16 + ChatbotResource 16 + WorkflowResource 15 + CredentialResource 15 + WebsitePageResource 13 + TriggerRuleResource 13 — minus any second-order issues the tighter types may expose, which we'll iterate on).