### PR TITLE
fix(docker): remove hardcoded plugin paths from docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@
 Homestead.json
 Homestead.yaml
 Thumbs.db
+
+# Per-developer Docker Compose overrides (see docker-compose.override.yml.example)
+docker-compose.override.yml
 /.serena
 /plans
 /.claude

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,52 @@
+# docker-compose.override.yml — per-developer Compose overrides
+#
+# Copy this file to `docker-compose.override.yml` (gitignored) and customise.
+# Docker Compose automatically merges `docker-compose.override.yml` on top of
+# `docker-compose.yml` whenever you run `docker compose up`. The file is
+# ignored by git and never shipped, so each contributor can keep their own
+# local mounts, ports, or env tweaks here without polluting the shared config.
+#
+# The example below mounts plugin SDK and website-plugin checkouts from the
+# host into the same absolute paths inside the container so Composer path
+# repositories resolve. Adjust the host paths (`${HOME}/htdocs/…`) to wherever
+# you cloned those repos — and delete any line that doesn't apply.
+#
+# Skip this file entirely if you don't develop against the plugin SDK. The
+# app, horizon, scheduler, and reverb services start without these mounts.
+
+services:
+  app:
+    volumes:
+      - ${HOME}/htdocs/fleetq-plugin-sdk:${HOME}/htdocs/fleetq-plugin-sdk
+      - ${HOME}/htdocs/fleetq-website-plugin-core:${HOME}/htdocs/fleetq-website-plugin-core
+      - ${HOME}/htdocs/fleetq-website-plugin-blog:${HOME}/htdocs/fleetq-website-plugin-blog
+      - ${HOME}/htdocs/fleetq-website-plugin-forms:${HOME}/htdocs/fleetq-website-plugin-forms
+      - ${HOME}/htdocs/fleetq-website-plugin-chatbot:${HOME}/htdocs/fleetq-website-plugin-chatbot
+      - ${HOME}/htdocs/fleetq-website-plugin-ecommerce:${HOME}/htdocs/fleetq-website-plugin-ecommerce
+
+  horizon:
+    volumes:
+      - ${HOME}/htdocs/fleetq-plugin-sdk:${HOME}/htdocs/fleetq-plugin-sdk
+      - ${HOME}/htdocs/fleetq-website-plugin-core:${HOME}/htdocs/fleetq-website-plugin-core
+      - ${HOME}/htdocs/fleetq-website-plugin-blog:${HOME}/htdocs/fleetq-website-plugin-blog
+      - ${HOME}/htdocs/fleetq-website-plugin-forms:${HOME}/htdocs/fleetq-website-plugin-forms
+      - ${HOME}/htdocs/fleetq-website-plugin-chatbot:${HOME}/htdocs/fleetq-website-plugin-chatbot
+      - ${HOME}/htdocs/fleetq-website-plugin-ecommerce:${HOME}/htdocs/fleetq-website-plugin-ecommerce
+
+  scheduler:
+    volumes:
+      - ${HOME}/htdocs/fleetq-plugin-sdk:${HOME}/htdocs/fleetq-plugin-sdk
+      - ${HOME}/htdocs/fleetq-website-plugin-core:${HOME}/htdocs/fleetq-website-plugin-core
+      - ${HOME}/htdocs/fleetq-website-plugin-blog:${HOME}/htdocs/fleetq-website-plugin-blog
+      - ${HOME}/htdocs/fleetq-website-plugin-forms:${HOME}/htdocs/fleetq-website-plugin-forms
+      - ${HOME}/htdocs/fleetq-website-plugin-chatbot:${HOME}/htdocs/fleetq-website-plugin-chatbot
+      - ${HOME}/htdocs/fleetq-website-plugin-ecommerce:${HOME}/htdocs/fleetq-website-plugin-ecommerce
+
+  reverb:
+    volumes:
+      - ${HOME}/htdocs/fleetq-plugin-sdk:${HOME}/htdocs/fleetq-plugin-sdk
+      - ${HOME}/htdocs/fleetq-website-plugin-core:${HOME}/htdocs/fleetq-website-plugin-core
+      - ${HOME}/htdocs/fleetq-website-plugin-blog:${HOME}/htdocs/fleetq-website-plugin-blog
+      - ${HOME}/htdocs/fleetq-website-plugin-forms:${HOME}/htdocs/fleetq-website-plugin-forms
+      - ${HOME}/htdocs/fleetq-website-plugin-chatbot:${HOME}/htdocs/fleetq-website-plugin-chatbot
+      - ${HOME}/htdocs/fleetq-website-plugin-ecommerce:${HOME}/htdocs/fleetq-website-plugin-ecommerce

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,9 @@ services:
     volumes:
       - .:/var/www
       - vendor_data:/var/www/vendor
-      - /Users/katsarov/htdocs/fleetq-plugin-sdk:/Users/katsarov/htdocs/fleetq-plugin-sdk
-      - /Users/katsarov/htdocs/fleetq-website-plugin-core:/Users/katsarov/htdocs/fleetq-website-plugin-core
-      - /Users/katsarov/htdocs/fleetq-website-plugin-blog:/Users/katsarov/htdocs/fleetq-website-plugin-blog
-      - /Users/katsarov/htdocs/fleetq-website-plugin-forms:/Users/katsarov/htdocs/fleetq-website-plugin-forms
-      - /Users/katsarov/htdocs/fleetq-website-plugin-chatbot:/Users/katsarov/htdocs/fleetq-website-plugin-chatbot
-      - /Users/katsarov/htdocs/fleetq-website-plugin-ecommerce:/Users/katsarov/htdocs/fleetq-website-plugin-ecommerce
+      # Optional plugin source mounts live in docker-compose.override.yml.example.
+      # Copy that file to docker-compose.override.yml on machines that have the
+      # plugin checkouts; Compose merges overrides automatically.
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -90,12 +87,7 @@ services:
       - .:/var/www
       - vendor_data:/var/www/vendor
       - ./docker/php/conf.d/horizon.ini:/usr/local/etc/php/conf.d/zz-horizon.ini
-      - /Users/katsarov/htdocs/fleetq-plugin-sdk:/Users/katsarov/htdocs/fleetq-plugin-sdk
-      - /Users/katsarov/htdocs/fleetq-website-plugin-core:/Users/katsarov/htdocs/fleetq-website-plugin-core
-      - /Users/katsarov/htdocs/fleetq-website-plugin-blog:/Users/katsarov/htdocs/fleetq-website-plugin-blog
-      - /Users/katsarov/htdocs/fleetq-website-plugin-forms:/Users/katsarov/htdocs/fleetq-website-plugin-forms
-      - /Users/katsarov/htdocs/fleetq-website-plugin-chatbot:/Users/katsarov/htdocs/fleetq-website-plugin-chatbot
-      - /Users/katsarov/htdocs/fleetq-website-plugin-ecommerce:/Users/katsarov/htdocs/fleetq-website-plugin-ecommerce
+      # Optional plugin mounts: docker-compose.override.yml.example
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -124,12 +116,7 @@ services:
       - .:/var/www
       - vendor_data:/var/www/vendor
       - ./docker/php/conf.d/horizon.ini:/usr/local/etc/php/conf.d/zz-horizon.ini
-      - /Users/katsarov/htdocs/fleetq-plugin-sdk:/Users/katsarov/htdocs/fleetq-plugin-sdk
-      - /Users/katsarov/htdocs/fleetq-website-plugin-core:/Users/katsarov/htdocs/fleetq-website-plugin-core
-      - /Users/katsarov/htdocs/fleetq-website-plugin-blog:/Users/katsarov/htdocs/fleetq-website-plugin-blog
-      - /Users/katsarov/htdocs/fleetq-website-plugin-forms:/Users/katsarov/htdocs/fleetq-website-plugin-forms
-      - /Users/katsarov/htdocs/fleetq-website-plugin-chatbot:/Users/katsarov/htdocs/fleetq-website-plugin-chatbot
-      - /Users/katsarov/htdocs/fleetq-website-plugin-ecommerce:/Users/katsarov/htdocs/fleetq-website-plugin-ecommerce
+      # Optional plugin mounts: docker-compose.override.yml.example
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -170,12 +157,7 @@ services:
     volumes:
       - .:/var/www
       - vendor_data:/var/www/vendor
-      - /Users/katsarov/htdocs/fleetq-plugin-sdk:/Users/katsarov/htdocs/fleetq-plugin-sdk
-      - /Users/katsarov/htdocs/fleetq-website-plugin-core:/Users/katsarov/htdocs/fleetq-website-plugin-core
-      - /Users/katsarov/htdocs/fleetq-website-plugin-blog:/Users/katsarov/htdocs/fleetq-website-plugin-blog
-      - /Users/katsarov/htdocs/fleetq-website-plugin-forms:/Users/katsarov/htdocs/fleetq-website-plugin-forms
-      - /Users/katsarov/htdocs/fleetq-website-plugin-chatbot:/Users/katsarov/htdocs/fleetq-website-plugin-chatbot
-      - /Users/katsarov/htdocs/fleetq-website-plugin-ecommerce:/Users/katsarov/htdocs/fleetq-website-plugin-ecommerce
+      # Optional plugin mounts: docker-compose.override.yml.example
     environment:
       - APP_ENV=local
       - RUNNING_IN_DOCKER=true


### PR DESCRIPTION
## Summary

- Strip 24 hardcoded `/Users/katsarov/htdocs/…` volume mounts from `docker-compose.yml` (4 services × 6 plugin dirs).
- Add `docker-compose.override.yml.example` with the same mounts written as `${HOME}/htdocs/<plugin>` so contributors who develop against the FleetQ plugin SDK can opt in.
- Gitignore `docker-compose.override.yml` — Docker Compose merges it automatically on `docker compose up` and per-developer overrides never ship.

## Why

Followup to #83 (closed). @Jijun-TANG pointed out in [this comment](https://github.com/escapeboy/agent-fleet-o/issues/83#issuecomment-4509243395) that the maintainer's home path was still hardcoded into `docker-compose.yml`, so any clone aborted on `docker compose up` unless the developer happened to have an identical `~/htdocs/fleetq-plugin-*` layout.

A bare `${HOME}` substitution would still require every contributor to clone six plugin repos into a specific layout. The override pattern keeps the shared file clean and lets each contributor opt in to whatever subset they actually need.

## Test plan

- [x] `docker compose -f docker-compose.yml config` passes (validates base file).
- [x] `docker compose -f docker-compose.yml -f docker-compose.override.yml config` passes (validates merge with the example file copied to the override name).
- [ ] Maintainer: copy `docker-compose.override.yml.example` → `docker-compose.override.yml` locally and confirm plugin source still resolves inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)