### PR TITLE
fix: pipeline-hardening — graceful tool degradation + memory query/embedding fixes

### DIFF
--- a/app/Domain/Agent/Actions/ExecuteAgentAction.php
+++ b/app/Domain/Agent/Actions/ExecuteAgentAction.php
@@ -381,6 +381,13 @@ class ExecuteAgentAction
                         $workspace->teardown();
                     }
                 }
+            } elseif (! empty($input['task'])) {
+                // Tools resolved to empty (unreachable/misconfigured mcp_http, empty
+                // tool_definitions). For a tool-only agent (0 skills) the skill chain
+                // would fail hard with "Agent has no skills or tools assigned",
+                // bricking every reply. Degrade gracefully to a plain LLM completion
+                // using the provided context instead.
+                $result = $this->executeDirectPrompt($agent, $input, $teamId, $userId, $experimentId, $stepId, $ctx->systemPromptParts);
             } else {
                 // Fallback: existing skill-chain execution
                 $result = $this->executeSkillChain($agent, $input, $teamId, $userId, $experimentId);

--- a/app/Domain/Memory/Actions/RetrieveRelevantMemoriesAction.php
+++ b/app/Domain/Memory/Actions/RetrieveRelevantMemoriesAction.php
@@ -44,7 +44,12 @@ class RetrieveRelevantMemoriesAction
         $threshold = $threshold ?? config('memory.similarity_threshold', 0.7);
 
         try {
-            $queryEmbedding = $this->generateEmbedding($query);
+            // Skip the embedding call (and the semantic clauses that depend on it)
+            // when the query text is blank. OpenAI's embeddings endpoint rejects an
+            // empty input with a 400 "Invalid 'input[0]'"; without a query we simply
+            // score by recency + importance instead of semantic similarity.
+            $hasQuery = trim($query) !== '';
+            $queryEmbedding = $hasQuery ? $this->generateEmbedding($query) : null;
 
             $semanticWeight = config('memory.scoring.semantic_weight', 0.5);
             $recencyWeight = config('memory.scoring.recency_weight', 0.3);
@@ -55,8 +60,10 @@ class RetrieveRelevantMemoriesAction
             // Curated tiers (canonical, facts, decisions, failures, successes) receive a +0.10 boost
             // so human-approved knowledge surfaces preferentially over agent-proposed memories.
             // User feedback boost: COALESCE(boost, 0) * 0.05 — max +0.5 for boost=10.
-            $compositeScoreSql = <<<'SQL'
-                (? * (1 - (embedding <=> ?))) +
+            // The semantic term is only included when a query embedding exists.
+            $semanticTerm = $hasQuery ? '(? * (1 - (embedding <=> ?))) +' : '';
+            $compositeScoreSql = <<<SQL
+                {$semanticTerm}
                 (? * POWER(0.5, EXTRACT(EPOCH FROM (NOW() - COALESCE(last_accessed_at, created_at))) / 86400.0 / ?)) +
                 (? * LEAST(COALESCE(importance, 0.5) + LN(1 + COALESCE(retrieval_count, 0)) * 0.15, 1.0)) +
                 CASE WHEN COALESCE(tier, 'working') IN ('canonical','facts','decisions','failures','successes') THEN 0.10 ELSE 0.0 END +
@@ -64,14 +71,14 @@ class RetrieveRelevantMemoriesAction
                 AS composite_score
             SQL;
 
+            $compositeBindings = $hasQuery
+                ? [$semanticWeight, $queryEmbedding, $recencyWeight, $halfLifeDays, $importanceWeight]
+                : [$recencyWeight, $halfLifeDays, $importanceWeight];
+
             $builder = Memory::withoutGlobalScopes()
                 ->select('memories.*')
-                ->selectRaw($compositeScoreSql, [
-                    $semanticWeight, $queryEmbedding,
-                    $recencyWeight, $halfLifeDays,
-                    $importanceWeight,
-                ])
-                ->whereRaw('1 - (embedding <=> ?) >= ?', [$queryEmbedding, $threshold])
+                ->selectRaw($compositeScoreSql, $compositeBindings)
+                ->when($hasQuery, fn ($q) => $q->whereRaw('1 - (embedding <=> ?) >= ?', [$queryEmbedding, $threshold]))
                 ->where('confidence', '>=', $minConfidence)
                 // Exclude rejected proposals — keep NULL (legacy) and approved.
                 ->where(fn ($q) => $q->whereNull('proposal_status')->orWhere('proposal_status', '!=', 'rejected'))
@@ -215,8 +222,12 @@ class RetrieveRelevantMemoriesAction
     private function applyTagFilter(Builder $builder, array $tags): void
     {
         if (config('database.default') === 'pgsql') {
-            // ?| checks if the JSONB array contains ANY of the given text values
-            $builder->whereRaw('tags ?| ?', ['{'.implode(',', $tags).'}']);
+            // jsonb_exists_any() is the function form of the JSONB ?| operator. The
+            // operator form collides with PDO's ? placeholders ("syntax error at or
+            // near ... tags $11| $12" → SQLSTATE[42601]); the function form takes a
+            // bound text[] and is placeholder-safe.
+            $placeholders = implode(',', array_fill(0, count($tags), '?'));
+            $builder->whereRaw("jsonb_exists_any(tags, ARRAY[{$placeholders}]::text[])", array_values($tags));
         } else {
             // SQLite fallback: unnest the JSON array and check membership
             $placeholders = implode(',', array_fill(0, count($tags), '?'));

--- a/tests/Feature/Domain/Agent/GracefulToolDegradationTest.php
+++ b/tests/Feature/Domain/Agent/GracefulToolDegradationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\Domain\Agent;
+
+use App\Domain\Agent\Actions\ExecuteAgentAction;
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Budget\Enums\LedgerType;
+use App\Domain\Budget\Models\CreditLedger;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Tool\Actions\ResolveAgentToolsAction;
+use App\Domain\Tool\Enums\ToolStatus;
+use App\Domain\Tool\Enums\ToolType;
+use App\Domain\Tool\Models\Tool;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * An agent WITH a tool attached but whose tools resolve to EMPTY (unreachable /
+ * misconfigured mcp_http, empty tool_definitions) used to fall through to the
+ * skill chain, which fails hard with "Agent has no skills or tools assigned" for
+ * a tool-only agent — bricking every reply. With a task in the input we now
+ * degrade gracefully to a plain LLM completion instead.
+ */
+class GracefulToolDegradationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Test Team',
+            'slug' => 'test-team-gtd',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+
+        CreditLedger::withoutGlobalScopes()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->user->id,
+            'type' => LedgerType::Purchase,
+            'amount' => 100000,
+            'balance_after' => 100000,
+            'description' => 'Test credit',
+        ]);
+
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')->andReturn(new AiResponseDTO(
+            content: 'graceful completion response',
+            parsedOutput: null,
+            usage: new AiUsageDTO(promptTokens: 10, completionTokens: 10, costCredits: 1),
+            provider: 'test',
+            model: 'test-model',
+            latencyMs: 100,
+        ))->byDefault();
+        $this->app->instance(AiGatewayInterface::class, $gateway);
+    }
+
+    public function test_tool_only_agent_with_unresolvable_tool_completes_via_direct_prompt(): void
+    {
+        $agent = Agent::factory()->create(['team_id' => $this->team->id]);
+
+        // A misconfigured mcp_http tool with no usable tool definitions —
+        // $agentHasTools is true, but ResolveAgentToolsAction yields nothing.
+        $tool = Tool::withoutGlobalScopes()->create([
+            'team_id' => $this->team->id,
+            'name' => 'Unreachable MCP',
+            'slug' => 'unreachable-mcp',
+            'type' => ToolType::McpHttp,
+            'status' => ToolStatus::Active,
+            'transport_config' => ['url' => 'http://127.0.0.1:1/unreachable'],
+            'tool_definitions' => [],
+        ]);
+        $agent->tools()->attach($tool->id, ['priority' => 0]);
+
+        // Force the "resolved to empty" condition deterministically.
+        $resolver = Mockery::mock(ResolveAgentToolsAction::class);
+        $resolver->shouldReceive('execute')->andReturn([]);
+        $this->app->instance(ResolveAgentToolsAction::class, $resolver);
+
+        $result = app(ExecuteAgentAction::class)->execute(
+            agent: $agent,
+            input: ['task' => 'What is the capital of France?'],
+            teamId: $this->team->id,
+            userId: $this->user->id,
+        );
+
+        $this->assertEquals('completed', $result['execution']->status);
+        $this->assertNotEmpty($result['output']);
+        $this->assertStringNotContainsString(
+            'no skills or tools assigned',
+            $result['execution']->error_message ?? '',
+        );
+    }
+}

--- a/tests/Unit/Domain/Memory/Actions/RetrieveRelevantMemoriesTagFilterTest.php
+++ b/tests/Unit/Domain/Memory/Actions/RetrieveRelevantMemoriesTagFilterTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit\Domain\Memory\Actions;
+
+use App\Domain\Memory\Actions\RetrieveRelevantMemoriesAction;
+use App\Domain\Memory\Models\Memory;
+use Prism\Prism\Embeddings\Response as EmbeddingResponse;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Testing\PrismFake;
+use Prism\Prism\ValueObjects\Embedding;
+use Prism\Prism\ValueObjects\EmbeddingsUsage;
+use Prism\Prism\ValueObjects\Meta;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * The JSONB tag filter must not emit the bare `?|` operator on PostgreSQL: the `?`
+ * collides with PDO placeholders and raises SQLSTATE[42601] ("syntax error at or
+ * near ... tags $11| $12"). The fix uses the placeholder-safe jsonb_exists_any()
+ * function form. Memory retrieval must also skip the embeddings call (and the
+ * semantic clauses that depend on it) when the query is blank — otherwise OpenAI
+ * rejects the empty input with a 400 "Invalid 'input[0]'".
+ */
+class RetrieveRelevantMemoriesTagFilterTest extends TestCase
+{
+    private function fakeEmbeddings(): PrismFake
+    {
+        $vector = array_fill(0, 1536, 0.1);
+
+        return Prism::fake([
+            new EmbeddingResponse(
+                embeddings: [new Embedding($vector)],
+                usage: new EmbeddingsUsage(tokens: 10),
+                meta: new Meta(id: 'test', model: 'text-embedding-3-small'),
+            ),
+        ]);
+    }
+
+    public function test_pgsql_tag_filter_uses_placeholder_safe_function_not_bare_operator(): void
+    {
+        config(['database.default' => 'pgsql']);
+
+        $action = new RetrieveRelevantMemoriesAction;
+        $method = new ReflectionMethod($action, 'applyTagFilter');
+        $method->setAccessible(true);
+
+        $builder = Memory::query();
+        $method->invoke($action, $builder, ['billing', 'auth']);
+
+        $sql = $builder->toSql();
+        $bindings = $builder->getBindings();
+
+        // The bare `?|` operator (which collides with PDO `?` placeholders and
+        // raises SQLSTATE[42601]) must be gone.
+        $this->assertStringNotContainsString('?|', $sql);
+        $this->assertStringContainsString('jsonb_exists_any', $sql);
+        $this->assertStringContainsString('::text[]', $sql);
+
+        // Tags are bound as plain values, not wrapped in a `{...}` array literal.
+        $this->assertSame(['billing', 'auth'], $bindings);
+    }
+
+    public function test_tags_filtered_query_runs_without_sql_syntax_error(): void
+    {
+        // SQLite (test DB) takes the json_each fallback; this asserts a tag-filtered
+        // retrieval executes end-to-end without raising a SQL syntax error.
+        $this->fakeEmbeddings();
+
+        $action = new RetrieveRelevantMemoriesAction;
+
+        $results = $action->execute(
+            agentId: 'agent-1',
+            query: 'how do refunds work',
+            tags: ['billing', 'auth'],
+        );
+
+        $this->assertCount(0, $results);
+    }
+
+    public function test_empty_query_skips_embedding_call(): void
+    {
+        $fake = $this->fakeEmbeddings();
+
+        $action = new RetrieveRelevantMemoriesAction;
+
+        $results = $action->execute(
+            agentId: 'agent-1',
+            query: '   ',
+        );
+
+        $this->assertCount(0, $results);
+        // No embeddings request must have been issued for a blank query.
+        $fake->assertRequest(function (array $recorded) {
+            $this->assertEmpty($recorded);
+        });
+    }
+
+    public function test_oversized_query_is_truncated_before_embedding(): void
+    {
+        config(['memory.embedding_max_input_tokens' => 8192]);
+        $fake = $this->fakeEmbeddings();
+
+        $action = new RetrieveRelevantMemoriesAction;
+
+        $action->execute(
+            agentId: 'agent-1',
+            query: str_repeat('word ', 12_000),
+        );
+
+        $fake->assertRequest(function (array $recorded) {
+            $this->assertNotEmpty($recorded);
+            // floor(8192 * 4 * 0.95) = 31129
+            $this->assertLessThanOrEqual(31129, mb_strlen($recorded[0]->inputs()[0]));
+        });
+    }
+}


### PR DESCRIPTION
## Two pipeline-hardening fixes

### FIX #2 — graceful tool degradation (`ExecuteAgentAction`)
An agent **with** a tool attached but whose tools resolve to **empty**
(unreachable/misconfigured `mcp_http`, empty `tool_definitions`) fell through to
the skill chain, which fails hard with `Agent has no skills or tools assigned`
for a tool-only agent — bricking every reply. When the input carries a `task`,
we now degrade gracefully to a plain LLM completion (`executeDirectPrompt`)
instead. The skill chain is kept only when there is no task input.

### FIX #3 — memory retrieval (`RetrieveRelevantMemoriesAction`)
- **(a) SQLSTATE[42601]:** the JSONB tag filter used the bare `?|` operator,
  whose `?` collides with PDO placeholders (`syntax error at or near ... tags
  $11| $12`). Switched to the placeholder-safe
  `jsonb_exists_any(tags, ARRAY[...]::text[])` function form.
- **(b) OpenAI 400 `Invalid 'input[0]'`:** skip the embedding call and the
  semantic SQL clauses when the query is blank (score by recency + importance
  only). Oversized-input truncation already existed via
  `truncateToEmbeddingLimit`.

## Tests
- `GracefulToolDegradationTest` — tool-only agent + unresolvable tool + task
  input → status `completed`, not failed.
- `RetrieveRelevantMemoriesTagFilterTest` — pgsql tag filter emits
  `jsonb_exists_any` (no bare `?|`); tag-filtered query runs; blank query skips
  embedding; oversized query truncated.

New tests: 5 passing. (Pre-existing unrelated `AgentAsToolTest` API-validation
failures exist on `develop` independent of this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)