### PR TITLE
feat(ui): UI-gap backlog Waves 1–3 — 21 previously-UI-less features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@
 
 ## Project Structure
 
-Domain-driven design with 16 bounded contexts:
+Domain-driven design with 45 bounded contexts (full map: `base/docs/capabilities.md` and `docs/feature-inventory-full_2026-06-09.md` in the parent repo). The tree below is illustrative, not exhaustive:
 
 ```
 app/
@@ -149,7 +149,7 @@ app/
       Services/                  # CircuitBreaker, ProviderResolver, LocalAgentDiscovery
   Mcp/                           # MCP Server (Model Context Protocol)
     Concerns/                    # BootstrapsMcpAuth (stdio auth bootstrap)
-    Servers/                     # AgentFleetServer (200+ tools across 31 domains)
+    Servers/                     # AgentFleetServer (675 tool files across 62 domains)
     Tools/                       # MCP tool implementations
       Agent/                     # agent_list, agent_get, agent_create, agent_update, agent_toggle_status, agent_delete, agent_config_history, agent_rollback, agent_runtime_state, agent_skill_sync, agent_tool_sync, agent_templates_list
       Experiment/                # experiment_list, experiment_get, experiment_create, experiment_start, experiment_pause, experiment_resume, experiment_retry, experiment_kill, experiment_valid_transitions, experiment_retry_from_step, experiment_steps, experiment_cost, experiment_share
@@ -303,7 +303,7 @@ app/
 | HTTP/SSE | `/mcp` | AgentFleetServer | Sanctum bearer token | Remote MCP clients (Cursor, etc.) |
 | stdio | `agent-fleet` | AgentFleetServer | Auto (default team owner) | Local CLI agents (Codex, Claude Code) |
 
-200+ MCP tools across 31 domains. Start local server: `php artisan mcp:start agent-fleet`
+675 MCP tool files across 62 domains. Start local server: `php artisan mcp:start agent-fleet`
 
 ### Legacy API Routes (`/api/`)
 
@@ -329,7 +329,7 @@ The community edition uses an "implicit single team" pattern:
 The platform exposes a Model Context Protocol (MCP) server via `laravel/mcp`, giving LLMs and agents full programmatic access.
 
 ### Architecture
-- **Server:** `app/Mcp/Servers/AgentFleetServer.php` — registers 121 tools across 23 domains
+- **Server:** `app/Mcp/Servers/AgentFleetServer.php` — registers 675 tool files across 62 domains
 - **Auth (stdio):** `BootstrapsMcpAuth` trait auto-resolves default team owner, sets `mcp.active` flag
 - **Auth (HTTP):** Sanctum bearer token via `auth:sanctum` middleware
 - **TeamScope:** Console mode bypasses `TeamScope` unless `mcp.active` is bound in the container
@@ -383,7 +383,7 @@ Reusable form components in `resources/views/components/`:
 - JSONB columns with GIN indexes (PostgreSQL).
 - Partial indexes for frequently filtered statuses.
 - Budget operations use `lockForUpdate()` for pessimistic locking.
-- 74 migrations.
+- 424 migrations.
 
 ### State Machine
 - Custom implementation (NOT spatie/laravel-model-states).

--- a/app/Domain/Outbound/Enums/OutboundChannel.php
+++ b/app/Domain/Outbound/Enums/OutboundChannel.php
@@ -4,15 +4,11 @@ namespace App\Domain\Outbound\Enums;
 
 enum OutboundChannel: string
 {
-    // Core channels — always available, managed by OutboundConnectorManager
+    // Core channels — always available, each backed by a built-in connector
+    // registered as a driver on OutboundConnectorManager.
     case Email = 'email';
     case Webhook = 'webhook';
     case Notification = 'notification';
-
-    // Legacy channels — kept for backward compatibility with existing data.
-    // These are no longer registered as core connectors but can be added
-    // by plugins via OutboundConnectorManager::extend() or handled by
-    // agents via MCP tools (browser automation, API calls).
     case Telegram = 'telegram';
     case Slack = 'slack';
     case WhatsApp = 'whatsapp';
@@ -29,6 +25,9 @@ enum OutboundChannel: string
      */
     public function isCore(): bool
     {
-        return in_array($this, [self::Email, self::Webhook, self::Notification]);
+        // signal_protocol, matrix, supabase_realtime have connectors that do not yet
+        // read resolved config credentials — deferred from core until wired to
+        // OutboundCredentialResolver.
+        return ! in_array($this, [self::SignalProtocol, self::Matrix, self::SupabaseRealtime], true);
     }
 }

--- a/app/Domain/Outbound/Managers/OutboundConnectorManager.php
+++ b/app/Domain/Outbound/Managers/OutboundConnectorManager.php
@@ -2,10 +2,15 @@
 
 namespace App\Domain\Outbound\Managers;
 
+use App\Domain\Outbound\Connectors\DiscordConnector;
 use App\Domain\Outbound\Connectors\DummyConnector;
 use App\Domain\Outbound\Connectors\EmailConnectorDispatcher;
+use App\Domain\Outbound\Connectors\GoogleChatConnector;
 use App\Domain\Outbound\Connectors\NotificationConnector;
 use App\Domain\Outbound\Connectors\NtfyConnector;
+use App\Domain\Outbound\Connectors\SlackConnector;
+use App\Domain\Outbound\Connectors\TeamsConnector;
+use App\Domain\Outbound\Connectors\TelegramConnector;
 use App\Domain\Outbound\Connectors\WebhookOutboundConnector;
 use App\Domain\Outbound\Connectors\WhatsAppConnector;
 use App\Domain\Outbound\Contracts\OutboundConnectorInterface;
@@ -14,8 +19,11 @@ use Illuminate\Support\Manager;
 /**
  * Laravel Manager for outbound connector resolution.
  *
- * Core drivers: email, webhook, notification, dummy.
- * Plugins extend via: $manager->extend('telegram', fn ($app) => new TelegramConnector);
+ * Core drivers: email, webhook, notification, whatsapp, ntfy, telegram, slack,
+ * discord, teams, google_chat, dummy.
+ * Deferred (connector ignores resolved config — needs OutboundCredentialResolver
+ * wiring before going core): signal_protocol, matrix, supabase_realtime.
+ * Plugins extend via: $manager->extend('custom', fn ($app) => new CustomConnector);
  *
  * Usage:
  *   $connector = app(OutboundConnectorManager::class)->connectorFor('email');
@@ -52,6 +60,31 @@ class OutboundConnectorManager extends Manager
     protected function createNtfyDriver(): OutboundConnectorInterface
     {
         return $this->container->make(NtfyConnector::class);
+    }
+
+    protected function createTelegramDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(TelegramConnector::class);
+    }
+
+    protected function createSlackDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(SlackConnector::class);
+    }
+
+    protected function createDiscordDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(DiscordConnector::class);
+    }
+
+    protected function createTeamsDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(TeamsConnector::class);
+    }
+
+    protected function createGoogleChatDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(GoogleChatConnector::class);
     }
 
     protected function createDummyDriver(): OutboundConnectorInterface

--- a/app/Livewire/AgentSessions/AgentSessionDetailPage.php
+++ b/app/Livewire/AgentSessions/AgentSessionDetailPage.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Livewire\AgentSessions;
+
+use App\Domain\AgentSession\Actions\CancelAgentSessionAction;
+use App\Domain\AgentSession\Actions\ReplayAgentSessionAction;
+use App\Domain\AgentSession\Actions\WakeAgentSessionAction;
+use App\Domain\AgentSession\Models\AgentSession;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+class AgentSessionDetailPage extends Component
+{
+    public string $sessionId;
+
+    public bool $showCancelConfirm = false;
+
+    public function mount(string $agentSession): void
+    {
+        // Route-model binding is avoided on purpose: a `public AgentSession`
+        // property bound via `mount(AgentSession)` triggers a 22P02 cast error
+        // when Livewire rehydrates the UUID. Resolve through a computed prop.
+        $this->sessionId = $agentSession;
+
+        // 404 if the session is outside the current team (TeamScope applies).
+        abort_unless(AgentSession::whereKey($agentSession)->exists(), 404);
+    }
+
+    #[Computed]
+    public function session(): AgentSession
+    {
+        return AgentSession::query()
+            ->with('agent')
+            ->withCount('events')
+            ->findOrFail($this->sessionId);
+    }
+
+    public function wake(): void
+    {
+        Gate::authorize('edit-content');
+
+        app(WakeAgentSessionAction::class)->execute(session: $this->session);
+
+        unset($this->session);
+        session()->flash('message', 'Session woken — recent context rehydrated.');
+    }
+
+    public function cancel(): void
+    {
+        Gate::authorize('edit-content');
+
+        app(CancelAgentSessionAction::class)->execute(
+            session: $this->session,
+            reason: 'Cancelled from admin panel',
+        );
+
+        unset($this->session);
+        $this->showCancelConfirm = false;
+        session()->flash('message', 'Session cancelled.');
+    }
+
+    public function render()
+    {
+        $replay = app(ReplayAgentSessionAction::class)->execute($this->session);
+
+        $events = $this->session->events()
+            ->orderByDesc('seq')
+            ->limit(500)
+            ->get(['seq', 'kind', 'payload', 'created_at']);
+
+        return view('livewire.agent-sessions.agent-session-detail-page', [
+            'replay' => $replay,
+            'events' => $events,
+        ])->layout('layouts.app', ['header' => 'Agent Session']);
+    }
+}

--- a/app/Livewire/AgentSessions/AgentSessionListPage.php
+++ b/app/Livewire/AgentSessions/AgentSessionListPage.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Livewire\AgentSessions;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class AgentSessionListPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $statusFilter = '';
+
+    #[Url]
+    public string $agentFilter = '';
+
+    public function updatedStatusFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedAgentFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $query = AgentSession::query()
+            ->with('agent')
+            ->withCount('events');
+
+        if ($this->statusFilter !== '') {
+            $query->where('status', $this->statusFilter);
+        }
+
+        if ($this->agentFilter !== '') {
+            $query->where('agent_id', $this->agentFilter);
+        }
+
+        $query->orderByDesc('last_heartbeat_at')->orderByDesc('created_at');
+
+        return view('livewire.agent-sessions.agent-session-list-page', [
+            'sessions' => $query->paginate(20),
+            'statuses' => AgentSessionStatus::cases(),
+            'agents' => Agent::query()->orderBy('name')->get(['id', 'name']),
+        ])->layout('layouts.app', ['header' => 'Agent Sessions']);
+    }
+}

--- a/app/Livewire/Broadcast/BroadcastListPage.php
+++ b/app/Livewire/Broadcast/BroadcastListPage.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\Broadcast;
+
+use App\Domain\Broadcast\Models\Broadcast;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class BroadcastListPage extends Component
+{
+    use WithPagination;
+
+    public function render()
+    {
+        return view('livewire.broadcast.broadcast-list-page', [
+            'broadcasts' => Broadcast::query()
+                ->with('audience:id,name')
+                ->latest()
+                ->paginate(20),
+        ])->layout('layouts.app', ['header' => 'Broadcasts']);
+    }
+}

--- a/app/Livewire/Broadcast/CreateBroadcastForm.php
+++ b/app/Livewire/Broadcast/CreateBroadcastForm.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Livewire\Broadcast;
+
+use App\Domain\Audience\Enums\AudienceMemberStatus;
+use App\Domain\Audience\Models\Audience;
+use App\Domain\Audience\Models\AudienceMember;
+use App\Domain\Broadcast\Actions\CreateBroadcast;
+use App\Domain\Broadcast\Services\BroadcastBudgetGuard;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+use Livewire\Component;
+
+class CreateBroadcastForm extends Component
+{
+    public string $audienceId = '';
+
+    public string $name = '';
+
+    public string $subject = '';
+
+    public string $body = '';
+
+    public function create(): void
+    {
+        Gate::authorize('edit-content');
+
+        $teamId = auth()->user()->currentTeam->id;
+
+        $this->validate([
+            'audienceId' => ['required', 'uuid',
+                Rule::exists('audiences', 'id')->where('team_id', $teamId)],
+            'name' => 'required|string|max:255',
+            'subject' => 'required|string|max:255',
+            'body' => 'required|string',
+        ]);
+
+        $audience = Audience::query()->findOrFail($this->audienceId);
+
+        $broadcast = app(CreateBroadcast::class)->execute(
+            audience: $audience,
+            name: $this->name,
+            subject: $this->subject,
+            body: $this->body,
+        );
+
+        session()->flash('message', 'Broadcast created as a draft. Submit it for approval to send.');
+        $this->redirect(route('broadcasts.show', $broadcast));
+    }
+
+    public function render()
+    {
+        $estimate = null;
+
+        if ($this->audienceId !== '') {
+            $recipientCount = AudienceMember::query()
+                ->where('audience_id', $this->audienceId)
+                ->where('status', AudienceMemberStatus::Subscribed->value)
+                ->count();
+
+            $estimate = [
+                'recipients' => $recipientCount,
+                'max_recipients' => BroadcastBudgetGuard::MAX_RECIPIENTS,
+                'estimated_credits' => $recipientCount,
+            ];
+        }
+
+        return view('livewire.broadcast.create-broadcast-form', [
+            'audiences' => Audience::query()->orderBy('name')->get(['id', 'name']),
+            'estimate' => $estimate,
+        ])->layout('layouts.app', ['header' => 'New Broadcast']);
+    }
+}

--- a/app/Livewire/Credentials/CredentialScanPage.php
+++ b/app/Livewire/Credentials/CredentialScanPage.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Livewire\Credentials;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Audit\Models\AuditEntry;
+use App\Domain\Credential\Jobs\CredentialScanJob;
+use App\Domain\Skill\Models\Skill;
+use App\Domain\Workflow\Models\WorkflowNode;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+/**
+ * Surfaces secret-scan findings produced by SecretScanObserver / CredentialScanJob.
+ *
+ * Findings are persisted as AuditEntry rows (event = 'secret_detected') with the
+ * matched pattern stored in the `properties` JSONB column. This page lists those
+ * findings team-scoped, lets a user re-scan the originating model, and acknowledge
+ * (dismiss) a finding.
+ */
+class CredentialScanPage extends Component
+{
+    use WithPagination;
+
+    /** Map of scannable subject types -> their model class + scannable fields. */
+    private const SUBJECT_MAP = [
+        'agent' => [Agent::class, ['role', 'goal', 'backstory']],
+        'skill' => [Skill::class, ['description', 'system_prompt']],
+        'workflow_node' => [WorkflowNode::class, ['label', 'expression']],
+    ];
+
+    #[Url]
+    public string $subjectTypeFilter = '';
+
+    #[Url]
+    public bool $showAcknowledged = false;
+
+    public function updatedSubjectTypeFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedShowAcknowledged(): void
+    {
+        $this->resetPage();
+    }
+
+    /**
+     * Re-run the secret scanner against the model that produced a finding.
+     */
+    public function rescan(string $auditEntryId): void
+    {
+        Gate::authorize('edit-content');
+
+        $entry = AuditEntry::where('event', 'secret_detected')->findOrFail($auditEntryId);
+
+        [$model, $fields] = $this->resolveSubject($entry->subject_type, $entry->subject_id);
+
+        if ($model === null) {
+            $this->dispatch('scan-rescan-missing');
+
+            return;
+        }
+
+        $textFields = [];
+        foreach ($fields as $field) {
+            $value = $model->getAttribute($field);
+            if (is_string($value) && $value !== '') {
+                $textFields[$field] = $value;
+            }
+        }
+
+        if ($textFields === []) {
+            $this->dispatch('scan-rescan-empty');
+
+            return;
+        }
+
+        $contentHash = sha1(implode('|', $textFields));
+
+        // Clear the 24h dedup key so the job actually re-evaluates and re-records.
+        Cache::forget("secret_scan:{$entry->subject_type}:{$entry->subject_id}:{$contentHash}");
+
+        CredentialScanJob::dispatch(
+            $entry->team_id,
+            $entry->subject_type,
+            $entry->subject_id,
+            $textFields,
+            $contentHash,
+        );
+
+        $this->dispatch('scan-rescan-queued');
+    }
+
+    /**
+     * Acknowledge (dismiss) a finding by stamping its properties and removing it from the active view.
+     */
+    public function acknowledge(string $auditEntryId): void
+    {
+        Gate::authorize('edit-content');
+
+        $entry = AuditEntry::where('event', 'secret_detected')->findOrFail($auditEntryId);
+
+        $properties = $entry->properties ?? [];
+        $properties['acknowledged_at'] = now()->toIso8601String();
+        $properties['acknowledged_by'] = auth()->id();
+
+        $entry->properties = $properties;
+        $entry->save();
+
+        $this->dispatch('scan-finding-acknowledged');
+    }
+
+    /**
+     * Resolve the originating model and its scannable fields for a finding.
+     *
+     * @return array{0: Model|null, 1: array<int, string>}
+     */
+    private function resolveSubject(string $subjectType, string $subjectId): array
+    {
+        $config = self::SUBJECT_MAP[$subjectType]
+            ?? collect(self::SUBJECT_MAP)->first(
+                fn (array $c) => $c[0] === $subjectType,
+            );
+
+        if ($config === null) {
+            return [null, []];
+        }
+
+        [$class, $fields] = $config;
+
+        return [$class::find($subjectId), $fields];
+    }
+
+    public function render()
+    {
+        $query = AuditEntry::query()->where('event', 'secret_detected');
+
+        if ($this->subjectTypeFilter !== '') {
+            $query->where('subject_type', $this->subjectTypeFilter);
+        }
+
+        if (! $this->showAcknowledged) {
+            $query->whereNull('properties->acknowledged_at');
+        }
+
+        $findings = $query->orderByDesc('created_at')->paginate(25);
+
+        $openCount = AuditEntry::query()
+            ->where('event', 'secret_detected')
+            ->whereNull('properties->acknowledged_at')
+            ->count();
+
+        return view('livewire.credentials.credential-scan-page', [
+            'findings' => $findings,
+            'openCount' => $openCount,
+            'subjectTypes' => array_keys(self::SUBJECT_MAP),
+        ])->layout('layouts.app', ['header' => 'Secret Scan Findings']);
+    }
+}

--- a/app/Livewire/Crews/CrewChatRoomPage.php
+++ b/app/Livewire/Crews/CrewChatRoomPage.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Livewire\Crews;
+
+use App\Domain\Crew\Models\CrewAgentMessage;
+use App\Domain\Crew\Models\CrewChatMessage;
+use App\Domain\Crew\Models\CrewExecution;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Redis;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+/**
+ * Read-only view of inter-agent communication for a single crew execution:
+ * the directed/broadcast CrewAgentMessage timeline, the chat-room CrewChatMessage
+ * transcript, and the ephemeral Redis blackboard posts.
+ *
+ * Uses `public string $executionId` + a computed resolver (NOT route-model
+ * binding) to avoid the Postgres 22P02 invalid-uuid trap on a bad route param,
+ * and relies on the global TeamScope for tenant isolation: a cross-team id
+ * resolves to null and the page 404s.
+ */
+class CrewChatRoomPage extends Component
+{
+    public string $executionId;
+
+    public function mount(string $execution): void
+    {
+        $this->executionId = $execution;
+
+        abort_unless($this->execution !== null, 404);
+    }
+
+    #[Computed]
+    public function execution(): ?CrewExecution
+    {
+        // TeamScope is applied via the global scope on CrewExecution, so an id
+        // belonging to another team resolves to null here.
+        return CrewExecution::query()
+            ->with('crew')
+            ->find($this->executionId);
+    }
+
+    /**
+     * Inter-agent messages (directed + broadcast). CrewAgentMessage carries its
+     * own team_id, so scope it explicitly and unconditionally — never via when().
+     *
+     * @return Collection<int, CrewAgentMessage>
+     */
+    #[Computed]
+    public function agentMessages(): Collection
+    {
+        $execution = $this->execution;
+
+        if ($execution === null) {
+            return collect();
+        }
+
+        return CrewAgentMessage::query()
+            ->where('team_id', $execution->team_id)
+            ->where('crew_execution_id', $execution->id)
+            ->with(['sender', 'recipient'])
+            ->orderBy('round')
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    /**
+     * Chat-room transcript. CrewChatMessage has no team_id of its own; it is
+     * scoped transitively through the already-team-scoped CrewExecution relation.
+     *
+     * @return Collection<int, CrewChatMessage>
+     */
+    #[Computed]
+    public function chatMessages(): Collection
+    {
+        $execution = $this->execution;
+
+        if ($execution === null) {
+            return collect();
+        }
+
+        return $execution->chatMessages()->with('agent')->get();
+    }
+
+    /**
+     * Blackboard posts live in a Redis sorted set with a 24h TTL — ephemeral,
+     * not a queryable DB model. After expiry this list is simply empty. Access
+     * is gated by the team-scoped execution resolved above.
+     *
+     * @return array<int, array{type: string, agent_name: ?string, message: string, ts: ?string}>
+     */
+    #[Computed]
+    public function blackboardPosts(): array
+    {
+        $execution = $this->execution;
+
+        if ($execution === null) {
+            return [];
+        }
+
+        $raw = Redis::zrange('crew:blackboard:'.$execution->id, 0, -1);
+
+        return collect($raw)
+            ->map(fn ($entry) => json_decode((string) $entry, true))
+            ->filter(fn ($decoded) => is_array($decoded))
+            ->values()
+            ->all();
+    }
+
+    public function render()
+    {
+        return view('livewire.crews.crew-chat-room-page')
+            ->layout('layouts.app', ['header' => 'Crew Chat Room']);
+    }
+}

--- a/app/Livewire/ErrorModes/ErrorModeCatalogPage.php
+++ b/app/Livewire/ErrorModes/ErrorModeCatalogPage.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Livewire\ErrorModes;
+
+use App\Domain\ErrorMode\Actions\AssignErrorModeLeverAction;
+use App\Domain\ErrorMode\Enums\ErrorModeLever;
+use App\Domain\ErrorMode\Models\ErrorMode;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class ErrorModeCatalogPage extends Component
+{
+    use WithPagination;
+
+    public string $search = '';
+
+    public string $leverFilter = '';
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedLeverFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function assignLever(string $errorModeId, string $lever): void
+    {
+        Gate::authorize('edit-content');
+
+        $teamId = auth()->user()->current_team_id;
+
+        app(AssignErrorModeLeverAction::class)->execute(
+            teamId: $teamId,
+            errorModeId: $errorModeId,
+            lever: ErrorModeLever::from($lever),
+        );
+
+        session()->flash('message', 'Lever assigned.');
+    }
+
+    public function render()
+    {
+        // Relies on the TeamScope global scope for tenant isolation.
+        $query = ErrorMode::query()
+            ->orderByDesc('occurrence_count')
+            ->orderByDesc('last_seen_at');
+
+        if ($this->search !== '') {
+            $query->whereRaw('lower(name) like ?', ['%'.mb_strtolower($this->search).'%']);
+        }
+
+        if ($this->leverFilter !== '') {
+            $query->where('lever', $this->leverFilter);
+        }
+
+        return view('livewire.error-modes.error-mode-catalog-page', [
+            'errorModes' => $query->paginate(20),
+            'levers' => ErrorModeLever::cases(),
+        ])->layout('layouts.app', ['header' => 'Error Mode Catalog']);
+    }
+}

--- a/app/Livewire/Evaluation/DriftSignalsPage.php
+++ b/app/Livewire/Evaluation/DriftSignalsPage.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Livewire\Evaluation;
+
+use App\Domain\Evaluation\Enums\DriftSignalType;
+use App\Domain\Evaluation\Models\DriftSignal;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class DriftSignalsPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $typeFilter = '';
+
+    #[Url]
+    public string $breachFilter = '';
+
+    public function updatedTypeFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedBreachFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $query = DriftSignal::query()->latest('detected_at');
+
+        if ($this->typeFilter) {
+            $query->where('signal_type', $this->typeFilter);
+        }
+
+        if ($this->breachFilter === 'breached') {
+            $query->where('breached', true);
+        } elseif ($this->breachFilter === 'ok') {
+            $query->where('breached', false);
+        }
+
+        return view('livewire.evaluation.drift-signals-page', [
+            'signals' => $query->paginate(50),
+            'signalTypes' => DriftSignalType::cases(),
+        ])->layout('layouts.app', ['header' => 'Drift Signals']);
+    }
+}

--- a/app/Livewire/Evaluation/EvalMonitorPage.php
+++ b/app/Livewire/Evaluation/EvalMonitorPage.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Livewire\Evaluation;
+
+use App\Domain\Evaluation\Models\EvaluationMonitorSnapshot;
+use Illuminate\Support\Carbon;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class EvalMonitorPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $period = '30d';
+
+    public function updatedPeriod(): void
+    {
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $query = EvaluationMonitorSnapshot::with('dataset')->latest('created_at');
+
+        $since = match ($this->period) {
+            '24h' => Carbon::now()->subDay(),
+            '7d' => Carbon::now()->subDays(7),
+            '30d' => Carbon::now()->subDays(30),
+            default => null,
+        };
+
+        if ($since) {
+            $query->where('created_at', '>=', $since);
+        }
+
+        return view('livewire.evaluation.eval-monitor-page', [
+            'snapshots' => $query->paginate(50),
+        ])->layout('layouts.app', ['header' => 'Eval Monitor']);
+    }
+}

--- a/app/Livewire/Experiments/ExperimentCheckpointsPage.php
+++ b/app/Livewire/Experiments/ExperimentCheckpointsPage.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Livewire\Experiments;
+
+use App\Domain\Experiment\Actions\ResumeFromCheckpointAction;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+/**
+ * Standalone read-mostly page that surfaces an experiment's playbook-step
+ * checkpoints (checkpoint_data / worker_id / idempotency_key / version /
+ * heartbeat) and offers a single "resume from checkpoint" action.
+ *
+ * Resume delegates to ResumeFromCheckpointAction, which always resumes from the
+ * MOST RECENT checkpoint — the backend has no notion of restoring an arbitrary
+ * historical checkpoint, so the per-row data is informational and there is one
+ * page-level restore button rather than a per-row one.
+ *
+ * Uses `public string $experimentId` + a computed property (NOT route-model
+ * binding) to avoid the Postgres 22P02 cast error on a missing/foreign UUID.
+ */
+class ExperimentCheckpointsPage extends Component
+{
+    public string $experimentId;
+
+    public bool $showResumeConfirm = false;
+
+    public function mount(string $experiment): void
+    {
+        $this->experimentId = $experiment;
+
+        // Resolve once so an out-of-team / missing id 404s on first load
+        // rather than rendering an empty page.
+        $this->experiment();
+    }
+
+    #[Computed]
+    public function experiment(): Experiment
+    {
+        $teamId = auth()->user()?->current_team_id;
+
+        $experiment = Experiment::query()
+            ->when($teamId, fn ($q) => $q->where('team_id', $teamId))
+            ->find($this->experimentId);
+
+        abort_if($experiment === null, 404);
+
+        return $experiment;
+    }
+
+    /**
+     * Steps that carry checkpoint data, most-recently-updated first.
+     *
+     * @return Collection<int, PlaybookStep>
+     */
+    #[Computed]
+    public function checkpoints(): Collection
+    {
+        return PlaybookStep::query()
+            ->where('experiment_id', $this->experiment()->id)
+            ->whereNotNull('checkpoint_data')
+            ->orderByDesc('updated_at')
+            ->get();
+    }
+
+    public function resumeFromCheckpoint(): void
+    {
+        Gate::authorize('edit-content');
+
+        $result = app(ResumeFromCheckpointAction::class)->execute($this->experiment());
+
+        unset($this->experiment, $this->checkpoints);
+        $this->showResumeConfirm = false;
+
+        session()->flash($result['resumed'] ? 'message' : 'error', $result['message']);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.experiments.experiment-checkpoints-page')
+            ->layout('layouts.app', ['header' => 'Checkpoints — '.$this->experiment()->title]);
+    }
+}

--- a/app/Livewire/Experiments/ExperimentCheckpointsPage.php
+++ b/app/Livewire/Experiments/ExperimentCheckpointsPage.php
@@ -44,8 +44,10 @@ class ExperimentCheckpointsPage extends Component
     {
         $teamId = auth()->user()?->current_team_id;
 
+        abort_if($teamId === null, 403);
+
         $experiment = Experiment::query()
-            ->when($teamId, fn ($q) => $q->where('team_id', $teamId))
+            ->where('team_id', $teamId)
             ->find($this->experimentId);
 
         abort_if($experiment === null, 404);

--- a/app/Livewire/Experiments/ReasoningBankPage.php
+++ b/app/Livewire/Experiments/ReasoningBankPage.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Livewire\Experiments;
+
+use App\Domain\Experiment\Models\ReasoningBankEntry;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class ReasoningBankPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $search = '';
+
+    public ?string $expandedId = null;
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function toggleExpand(string $id): void
+    {
+        $this->expandedId = $this->expandedId === $id ? null : $id;
+    }
+
+    public function render(): View
+    {
+        // Team isolation relies on ReasoningBankEntry's TeamScope global scope
+        // (BelongsToTeam). Do NOT swap to withoutGlobalScopes()->when($teamId),
+        // which leaks cross-tenant rows when the team is null.
+        $query = ReasoningBankEntry::query()
+            ->with('experiment:id,title')
+            ->latest('created_at');
+
+        if ($this->search) {
+            $term = '%'.mb_strtolower($this->search).'%';
+            $query->where(function ($q) use ($term) {
+                $q->whereRaw('lower(goal_text) like ?', [$term])
+                    ->orWhereRaw('lower(outcome_summary) like ?', [$term]);
+            });
+        }
+
+        return view('livewire.experiments.reasoning-bank-page', [
+            'entries' => $query->paginate(30),
+        ])->layout('layouts.app', ['header' => 'Reasoning Bank']);
+    }
+}

--- a/app/Livewire/KnowledgeGraph/KgCommunitiesPage.php
+++ b/app/Livewire/KnowledgeGraph/KgCommunitiesPage.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\KnowledgeGraph;
+
+use App\Domain\KnowledgeGraph\Actions\BuildKgCommunitiesAction;
+use App\Domain\KnowledgeGraph\Models\KgCommunity;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class KgCommunitiesPage extends Component
+{
+    use AuthorizesRequests;
+    use WithPagination;
+
+    #[Url]
+    public string $search = '';
+
+    public ?string $expandedId = null;
+
+    public ?string $error = null;
+
+    public ?string $success = null;
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function toggleExpanded(string $id): void
+    {
+        $this->expandedId = $this->expandedId === $id ? null : $id;
+    }
+
+    public function rebuild(): void
+    {
+        $this->authorize('edit-content');
+
+        $teamId = auth()->user()->current_team_id;
+
+        try {
+            app(BuildKgCommunitiesAction::class)->execute($teamId);
+            $this->success = 'Communities rebuilt.';
+            $this->error = null;
+            $this->resetPage();
+        } catch (\Throwable $e) {
+            $this->error = $e->getMessage();
+            $this->success = null;
+        }
+    }
+
+    public function render()
+    {
+        $teamId = auth()->user()->current_team_id;
+
+        $query = KgCommunity::query()
+            ->where('team_id', $teamId);
+
+        if ($this->search !== '') {
+            $query->whereRaw('lower(label) like ?', ['%'.mb_strtolower($this->search).'%']);
+        }
+
+        $communities = $query
+            ->orderByDesc('size')
+            ->paginate(20);
+
+        $stats = [
+            'total' => KgCommunity::where('team_id', $teamId)->count(),
+            'largest' => (int) KgCommunity::where('team_id', $teamId)->max('size'),
+            'entities' => (int) KgCommunity::where('team_id', $teamId)->sum('size'),
+        ];
+
+        return view('livewire.knowledge-graph.kg-communities-page', [
+            'communities' => $communities,
+            'stats' => $stats,
+        ])->layout('layouts.app', ['header' => 'KG Communities']);
+    }
+}

--- a/app/Livewire/Memory/MemoryProposalsPage.php
+++ b/app/Livewire/Memory/MemoryProposalsPage.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Livewire\Memory;
+
+use App\Domain\Memory\Enums\MemoryTier;
+use App\Domain\Memory\Models\Memory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+/**
+ * Focused review queue for agent-proposed memories.
+ *
+ * Surfaces only memories in the Proposed tier with no decision yet
+ * (proposal_status IS NULL) so an admin can approve (promote to a curated
+ * tier) or reject each one. The broader MemoryBrowserPage shows all tiers;
+ * this page is the dedicated approve/reject inbox.
+ */
+class MemoryProposalsPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $search = '';
+
+    public ?string $expandedId = null;
+
+    /**
+     * Selected approve-target tier per memory id. Defaults to canonical when
+     * a row has not been touched.
+     *
+     * @var array<string, string>
+     */
+    public array $approveTier = [];
+
+    /** Memory id currently showing its reject-reason input. */
+    public ?string $rejectingId = null;
+
+    public string $rejectReason = '';
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function toggleExpand(string $id): void
+    {
+        $this->expandedId = $this->expandedId === $id ? null : $id;
+    }
+
+    /**
+     * Approve a proposal by promoting it to the given curated tier. Mirrors
+     * the canonical approve path used by MemoryPromoteTool and the heuristic
+     * AuditMemoryProposalsAction: bump tier + stamp proposal_status='approved'.
+     */
+    public function approve(string $memoryId): void
+    {
+        Gate::authorize('edit-content');
+
+        $tier = MemoryTier::tryFrom($this->approveTier[$memoryId] ?? MemoryTier::Canonical->value);
+        if (! $tier || ! $tier->isCurated()) {
+            session()->flash('error', 'Invalid target tier.');
+
+            return;
+        }
+
+        $memory = Memory::where('id', $memoryId)
+            ->where('tier', MemoryTier::Proposed->value)
+            ->whereNull('proposal_status')
+            ->first();
+
+        if (! $memory) {
+            session()->flash('error', 'Proposal not found or already decided.');
+
+            return;
+        }
+
+        $memory->update([
+            'tier' => $tier->value,
+            'proposal_status' => 'approved',
+            'reviewed_at' => now(),
+            'reviewed_by' => 'user:'.(auth()->user()?->email ?? 'anonymous'),
+        ]);
+
+        if ($this->expandedId === $memoryId) {
+            $this->expandedId = null;
+        }
+
+        session()->flash('message', "Proposal approved and promoted to {$tier->value}.");
+    }
+
+    /** Reveal the reject-reason input for a given proposal. */
+    public function startReject(string $memoryId): void
+    {
+        $this->rejectingId = $memoryId;
+        $this->rejectReason = '';
+    }
+
+    public function cancelReject(): void
+    {
+        $this->rejectingId = null;
+        $this->rejectReason = '';
+    }
+
+    /**
+     * Reject a proposal: stamp proposal_status='rejected' with a reason so it
+     * stops surfacing in retrieval and drops out of this queue.
+     */
+    public function reject(string $memoryId): void
+    {
+        Gate::authorize('edit-content');
+
+        $reason = trim($this->rejectReason);
+        if ($reason === '') {
+            session()->flash('error', 'A rejection reason is required.');
+
+            return;
+        }
+
+        $memory = Memory::where('id', $memoryId)
+            ->where('tier', MemoryTier::Proposed->value)
+            ->whereNull('proposal_status')
+            ->first();
+
+        if (! $memory) {
+            session()->flash('error', 'Proposal not found or already decided.');
+
+            return;
+        }
+
+        $memory->update([
+            'proposal_status' => 'rejected',
+            'reviewed_at' => now(),
+            'rejection_reason' => mb_substr($reason, 0, 1000),
+            'reviewed_by' => 'user:'.(auth()->user()?->email ?? 'anonymous'),
+        ]);
+
+        $this->rejectingId = null;
+        $this->rejectReason = '';
+        if ($this->expandedId === $memoryId) {
+            $this->expandedId = null;
+        }
+
+        session()->flash('message', 'Proposal rejected.');
+    }
+
+    public function render(): View
+    {
+        $query = Memory::query()
+            ->with(['agent', 'project'])
+            ->where('tier', MemoryTier::Proposed->value)
+            ->whereNull('proposal_status')
+            ->orderBy('created_at', 'desc');
+
+        if ($this->search !== '') {
+            $query->where('content', 'ilike', "%{$this->search}%");
+        }
+
+        $curatedTiers = array_values(array_filter(
+            MemoryTier::cases(),
+            fn (MemoryTier $tier) => $tier->isCurated(),
+        ));
+
+        return view('livewire.memory.memory-proposals-page', [
+            'proposals' => $query->paginate(25),
+            'curatedTiers' => $curatedTiers,
+        ])->layout('layouts.app', ['header' => 'Memory Proposals']);
+    }
+}

--- a/app/Livewire/Migration/ImportWizardPage.php
+++ b/app/Livewire/Migration/ImportWizardPage.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Livewire\Migration;
+
+use App\Domain\Migration\Actions\DetectSchemaAction;
+use App\Domain\Migration\Actions\ExecuteMigrationAction;
+use App\Domain\Migration\Enums\MigrationEntityType;
+use App\Domain\Migration\Enums\MigrationSource;
+use App\Domain\Migration\Models\MigrationRun;
+use App\Domain\Migration\Services\Importers\ImporterRegistry;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
+
+class ImportWizardPage extends Component
+{
+    use WithFileUploads;
+
+    /** Wizard step: 1 = upload, 2 = mapping, 3 = result. */
+    public int $step = 1;
+
+    /** @var TemporaryUploadedFile|null */
+    public $file;
+
+    public string $entityType = 'contact';
+
+    public ?string $runId = null;
+
+    /** @var array<string, ?string> column header → confirmed target attribute (null/'' = unmapped) */
+    public array $mapping = [];
+
+    public ?string $error = null;
+
+    public function mount(): void
+    {
+        Gate::authorize('edit-content');
+    }
+
+    /**
+     * Step 1 → 2: validate the upload, read its text, call DetectSchemaAction.
+     */
+    public function detect(DetectSchemaAction $action): void
+    {
+        Gate::authorize('edit-content');
+
+        $this->validate([
+            'file' => 'required|file|mimes:csv,txt|mimetypes:text/csv,text/plain,application/csv,application/vnd.ms-excel|max:5120',
+            'entityType' => 'required|in:'.implode(',', array_map(fn ($c) => $c->value, MigrationEntityType::cases())),
+        ]);
+
+        $this->error = null;
+
+        // Read the CSV text directly — the action stores the full payload itself.
+        // We never touch getClientOriginalName(); the temp file path is opaque.
+        $payload = file_get_contents($this->file->getRealPath());
+        if ($payload === false || trim($payload) === '') {
+            $this->addError('file', 'The uploaded file is empty or unreadable.');
+
+            return;
+        }
+
+        try {
+            $run = $action->execute(
+                user: auth()->user(),
+                payload: $payload,
+                source: MigrationSource::Csv,
+                entityType: MigrationEntityType::from($this->entityType),
+            );
+        } catch (\Throwable $e) {
+            $this->error = 'Schema detection failed: '.$e->getMessage();
+
+            return;
+        }
+
+        $this->runId = $run->id;
+        $this->mapping = $run->proposed_mapping ?? [];
+        $this->step = 2;
+    }
+
+    /**
+     * Step 2 → 3: submit the confirmed (possibly user-adjusted) mapping.
+     */
+    public function import(ExecuteMigrationAction $action): void
+    {
+        Gate::authorize('edit-content');
+
+        if ($this->runId === null) {
+            $this->error = 'No migration run in progress.';
+
+            return;
+        }
+
+        $run = MigrationRun::query()
+            ->where('team_id', auth()->user()->current_team_id)
+            ->findOrFail($this->runId);
+
+        try {
+            $run = $action->execute($run, $this->mapping);
+        } catch (\Throwable $e) {
+            $this->error = 'Import failed: '.$e->getMessage();
+
+            return;
+        }
+
+        $this->runId = $run->id;
+        $this->step = 3;
+    }
+
+    public function backToUpload(): void
+    {
+        $this->reset(['step', 'file', 'runId', 'mapping', 'error']);
+    }
+
+    public function render()
+    {
+        $run = $this->runId !== null
+            ? MigrationRun::query()
+                ->where('team_id', auth()->user()->current_team_id)
+                ->find($this->runId)
+            : null;
+
+        $importer = app(ImporterRegistry::class)->resolve(MigrationEntityType::from($this->entityType));
+
+        return view('livewire.migration.import-wizard-page', [
+            'run' => $run,
+            'entityTypes' => MigrationEntityType::cases(),
+            'supportedAttributes' => $importer->supportedAttributes(),
+        ])->layout('layouts.app', ['header' => 'Import Data']);
+    }
+}

--- a/app/Livewire/Outbound/BlacklistPage.php
+++ b/app/Livewire/Outbound/BlacklistPage.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Livewire\Outbound;
+
+use App\Models\Blacklist;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class BlacklistPage extends Component
+{
+    use WithPagination;
+
+    public string $type = 'email';
+
+    public string $value = '';
+
+    public string $reason = '';
+
+    public function add(): void
+    {
+        Gate::authorize('edit-content');
+
+        $validated = $this->validate([
+            'type' => 'required|string|in:email,domain,company,keyword',
+            'value' => 'required|string|max:255',
+            'reason' => 'nullable|string|max:255',
+        ]);
+
+        Blacklist::create([
+            'type' => $validated['type'],
+            'value' => strtolower(trim($validated['value'])),
+            'reason' => $validated['reason'] ?: null,
+            'added_by' => auth()->id(),
+        ]);
+
+        $this->reset(['value', 'reason']);
+        session()->flash('message', 'Blacklist entry added.');
+    }
+
+    public function remove(string $id): void
+    {
+        Gate::authorize('edit-content');
+
+        $entry = Blacklist::findOrFail($id);
+        $entry->delete();
+
+        session()->flash('message', 'Blacklist entry removed.');
+    }
+
+    public function render()
+    {
+        return view('livewire.outbound.blacklist-page', [
+            'entries' => Blacklist::query()
+                ->orderBy('type')
+                ->orderBy('value')
+                ->paginate(25),
+        ])->layout('layouts.app', ['header' => 'Outbound Blacklist']);
+    }
+}

--- a/app/Livewire/Outbound/OutboundProposalsPage.php
+++ b/app/Livewire/Outbound/OutboundProposalsPage.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Livewire\Outbound;
+
+use App\Domain\Outbound\Enums\OutboundProposalStatus;
+use App\Domain\Outbound\Models\OutboundProposal;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class OutboundProposalsPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $statusFilter = '';
+
+    public ?string $expandedId = null;
+
+    public function updatedStatusFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function toggle(string $id): void
+    {
+        $this->expandedId = $this->expandedId === $id ? null : $id;
+    }
+
+    public function render()
+    {
+        $query = OutboundProposal::query()
+            ->with('experiment')
+            ->latest();
+
+        if ($this->statusFilter !== '') {
+            $query->where('status', $this->statusFilter);
+        }
+
+        $counts = [];
+        foreach (OutboundProposalStatus::cases() as $case) {
+            $counts[$case->value] = OutboundProposal::query()
+                ->where('status', $case)
+                ->count();
+        }
+
+        return view('livewire.outbound.outbound-proposals-page', [
+            'proposals' => $query->paginate(25),
+            'counts' => $counts,
+            'statuses' => OutboundProposalStatus::cases(),
+        ])->layout('layouts.app', ['header' => 'Outbound Proposals']);
+    }
+}

--- a/app/Livewire/OutboundConnectors/DiscordOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/DiscordOutboundPage.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Discord Webhook outbound connector.
+ *
+ * Credentials are stored encrypted in OutboundConnectorConfig (channel=discord)
+ * and resolved at send time by OutboundCredentialResolver. The webhook_url field
+ * is write-only: it is preserved on save when left blank.
+ */
+class DiscordOutboundPage extends Component
+{
+    /** Discord webhook URL (write-only). */
+    public string $webhookUrl = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'discord')
+            ->first();
+
+        if ($config) {
+            // webhook_url is never pre-filled (write-only)
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'webhookUrl' => 'nullable|url|max:1024',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $existing = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'discord')
+            ->first();
+
+        $credentials = [];
+
+        if ($this->webhookUrl) {
+            $credentials['webhook_url'] = $this->webhookUrl;
+        } elseif ($existing) {
+            $credentials['webhook_url'] = $existing->credentials['webhook_url'] ?? '';
+        } else {
+            $credentials['webhook_url'] = '';
+        }
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'discord'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->webhookUrl = '';
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Discord connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'discord')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $url = $config->credentials['webhook_url'] ?? '';
+        if (! $url) {
+            $this->testError = 'Webhook URL is not configured.';
+
+            return;
+        }
+
+        $response = null;
+
+        try {
+            $response = Http::timeout(10)->post($url.'?wait=true', ['content' => '[Test] FleetQ connectivity check']);
+            $status = $response->successful() ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success') {
+            $this->testMessage = 'Test message sent successfully.';
+            $this->testError = null;
+        } else {
+            $this->testError = 'Discord returned '.($response?->status() ?? 'an error').'.';
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.discord-outbound-page')
+            ->layout('layouts.app', ['header' => 'Discord Delivery']);
+    }
+}

--- a/app/Livewire/OutboundConnectors/GoogleChatOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/GoogleChatOutboundPage.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Google Chat outbound connector.
+ *
+ * Credentials are stored encrypted in OutboundConnectorConfig (channel=google_chat)
+ * and resolved at send time by OutboundCredentialResolver. The webhook_url field
+ * is write-only: it is preserved on save when left blank.
+ */
+class GoogleChatOutboundPage extends Component
+{
+    /** Google Chat space webhook URL (write-only). */
+    public string $webhookUrl = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'google_chat')
+            ->first();
+
+        if ($config) {
+            // webhook_url is never pre-filled (write-only)
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'webhookUrl' => 'nullable|url|max:1024',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $existing = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'google_chat')
+            ->first();
+
+        $credentials = [];
+
+        if ($this->webhookUrl) {
+            $credentials['webhook_url'] = $this->webhookUrl;
+        } elseif ($existing) {
+            $credentials['webhook_url'] = $existing->credentials['webhook_url'] ?? '';
+        } else {
+            $credentials['webhook_url'] = '';
+        }
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'google_chat'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->webhookUrl = '';
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Google Chat connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'google_chat')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $url = $config->credentials['webhook_url'] ?? '';
+        if (! $url) {
+            $this->testError = 'Webhook URL is not configured.';
+
+            return;
+        }
+
+        $response = null;
+
+        try {
+            $response = Http::timeout(10)->post($url, ['text' => '[Test] FleetQ connectivity check']);
+            $status = $response->successful() ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success') {
+            $this->testMessage = 'Test message sent successfully.';
+            $this->testError = null;
+        } else {
+            $this->testError = 'Google Chat returned '.($response?->status() ?? 'an error').'.';
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.google-chat-outbound-page')
+            ->layout('layouts.app', ['header' => 'Google Chat Delivery']);
+    }
+}

--- a/app/Livewire/OutboundConnectors/SlackOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/SlackOutboundPage.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Slack Incoming Webhook outbound connector.
+ *
+ * Credentials are stored encrypted in OutboundConnectorConfig (channel=slack)
+ * and resolved at send time by OutboundCredentialResolver. The webhook_url field
+ * is write-only: it is preserved on save when left blank.
+ */
+class SlackOutboundPage extends Component
+{
+    /** Slack incoming webhook URL (write-only). */
+    public string $webhookUrl = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'slack')
+            ->first();
+
+        if ($config) {
+            // webhook_url is never pre-filled (write-only)
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'webhookUrl' => 'nullable|url|max:1024',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $existing = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'slack')
+            ->first();
+
+        $credentials = [];
+
+        if ($this->webhookUrl) {
+            $credentials['webhook_url'] = $this->webhookUrl;
+        } elseif ($existing) {
+            $credentials['webhook_url'] = $existing->credentials['webhook_url'] ?? '';
+        } else {
+            $credentials['webhook_url'] = '';
+        }
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'slack'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->webhookUrl = '';
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Slack connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'slack')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $url = $config->credentials['webhook_url'] ?? '';
+        if (! $url) {
+            $this->testError = 'Webhook URL is not configured.';
+
+            return;
+        }
+
+        $response = null;
+
+        try {
+            $response = Http::timeout(10)->post($url, ['text' => '[Test] FleetQ connectivity check']);
+            $status = $response->successful() ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success') {
+            $this->testMessage = 'Test message sent successfully.';
+            $this->testError = null;
+        } else {
+            $this->testError = 'Slack returned '.($response?->status() ?? 'an error').'.';
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.slack-outbound-page')
+            ->layout('layouts.app', ['header' => 'Slack Delivery']);
+    }
+}

--- a/app/Livewire/OutboundConnectors/TeamsOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/TeamsOutboundPage.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Microsoft Teams outbound connector
+ * (Power Automate Workflows webhook).
+ *
+ * Credentials are stored encrypted in OutboundConnectorConfig (channel=teams)
+ * and resolved at send time by OutboundCredentialResolver. The webhook_url field
+ * is write-only: it is preserved on save when left blank.
+ */
+class TeamsOutboundPage extends Component
+{
+    /** Teams Power Automate Workflows webhook URL (write-only). */
+    public string $webhookUrl = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'teams')
+            ->first();
+
+        if ($config) {
+            // webhook_url is never pre-filled (write-only)
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'webhookUrl' => 'nullable|url|max:1024',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $existing = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'teams')
+            ->first();
+
+        $credentials = [];
+
+        if ($this->webhookUrl) {
+            $credentials['webhook_url'] = $this->webhookUrl;
+        } elseif ($existing) {
+            $credentials['webhook_url'] = $existing->credentials['webhook_url'] ?? '';
+        } else {
+            $credentials['webhook_url'] = '';
+        }
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'teams'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->webhookUrl = '';
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Microsoft Teams connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'teams')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $url = $config->credentials['webhook_url'] ?? '';
+        if (! $url) {
+            $this->testError = 'Webhook URL is not configured.';
+
+            return;
+        }
+
+        $payload = [
+            'type' => 'message',
+            'attachments' => [[
+                'contentType' => 'application/vnd.microsoft.card.adaptive',
+                'contentUrl' => null,
+                'content' => [
+                    '$schema' => 'http://adaptivecards.io/schemas/adaptive-card.json',
+                    'type' => 'AdaptiveCard',
+                    'version' => '1.4',
+                    'body' => [[
+                        'type' => 'TextBlock',
+                        'text' => '[Test] FleetQ connectivity check',
+                        'wrap' => true,
+                    ]],
+                ],
+            ]],
+        ];
+
+        $response = null;
+
+        try {
+            $response = Http::timeout(10)->post($url, $payload);
+            $status = $response->successful() ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success') {
+            $this->testMessage = 'Test card sent successfully.';
+            $this->testError = null;
+        } else {
+            $this->testError = 'Teams returned '.($response?->status() ?? 'an error').'.';
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.teams-outbound-page')
+            ->layout('layouts.app', ['header' => 'Microsoft Teams Delivery']);
+    }
+}

--- a/app/Livewire/OutboundConnectors/TelegramOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/TelegramOutboundPage.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Telegram Bot API outbound connector.
+ *
+ * Credentials are stored encrypted in OutboundConnectorConfig (channel=telegram)
+ * and resolved at send time by OutboundCredentialResolver. The bot_token field is
+ * write-only: it is preserved on save when left blank.
+ */
+class TelegramOutboundPage extends Component
+{
+    /** Default chat ID used when a proposal target omits one. */
+    public string $chatId = '';
+
+    /** Telegram bot token (write-only). */
+    public string $botToken = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'telegram')
+            ->first();
+
+        if ($config) {
+            $creds = $config->credentials ?? [];
+            $this->chatId = $creds['chat_id'] ?? '';
+            // bot_token is never pre-filled (write-only)
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'chatId' => 'nullable|string|max:64',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $existing = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'telegram')
+            ->first();
+
+        $credentials = [
+            'chat_id' => $this->chatId ?: null,
+        ];
+
+        if ($this->botToken) {
+            $credentials['bot_token'] = $this->botToken;
+        } elseif ($existing) {
+            $credentials['bot_token'] = $existing->credentials['bot_token'] ?? '';
+        } else {
+            $credentials['bot_token'] = '';
+        }
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'telegram'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->botToken = '';
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Telegram connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'telegram')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $token = $config->credentials['bot_token'] ?? '';
+        if (! $token) {
+            $this->testError = 'Bot token is not configured.';
+
+            return;
+        }
+
+        $response = null;
+
+        try {
+            $response = Http::timeout(10)->get("https://api.telegram.org/bot{$token}/getMe");
+            $status = ($response->successful() && $response->json('ok')) ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success' && $response !== null) {
+            $this->testMessage = 'Connected as @'.$response->json('result.username');
+            $this->testError = null;
+        } else {
+            $this->testError = 'Telegram API error: '.($response?->json('description') ?? 'Invalid bot token');
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.telegram-outbound-page')
+            ->layout('layouts.app', ['header' => 'Telegram Delivery']);
+    }
+}

--- a/app/Livewire/Releases/SigningKeysPage.php
+++ b/app/Livewire/Releases/SigningKeysPage.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Releases;
+
+use App\Domain\Release\Crypto\Actions\GenerateSigningKeyAction;
+use App\Domain\Release\Crypto\Actions\RevokeSigningKeyAction;
+use App\Domain\Release\Crypto\Actions\RotateSigningKeyAction;
+use App\Domain\Release\Crypto\Enums\SigningKeyStatus;
+use App\Domain\Release\Crypto\Models\ReleaseSigningKey;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+class SigningKeysPage extends Component
+{
+    /**
+     * UUID of the key the user has armed for revocation (two-step confirm).
+     */
+    public ?string $confirmingRevokeId = null;
+
+    public function generate(GenerateSigningKeyAction $action): void
+    {
+        Gate::authorize('manage-team');
+
+        $action->execute(auth()->user()->current_team_id);
+
+        session()->flash('message', 'Signing key generated.');
+    }
+
+    public function rotate(RotateSigningKeyAction $action): void
+    {
+        Gate::authorize('manage-team');
+
+        $action->execute(auth()->user()->current_team_id);
+
+        session()->flash('message', 'Signing key rotated. The previous key entered a 90-day grace period.');
+    }
+
+    public function confirmRevoke(string $id): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->confirmingRevokeId = $id;
+    }
+
+    public function cancelRevoke(): void
+    {
+        $this->confirmingRevokeId = null;
+    }
+
+    public function revoke(string $id, RevokeSigningKeyAction $action): void
+    {
+        Gate::authorize('manage-team');
+
+        $key = ReleaseSigningKey::where('id', $id)->first();
+
+        if ($key) {
+            $action->execute($key);
+            session()->flash('message', 'Signing key revoked. Releases signed by it will no longer verify.');
+        }
+
+        $this->confirmingRevokeId = null;
+    }
+
+    public function render()
+    {
+        $keys = ReleaseSigningKey::orderByDesc('created_at')->get();
+
+        return view('livewire.releases.signing-keys-page', [
+            'keys' => $keys,
+            'hasActive' => $keys->contains(fn (ReleaseSigningKey $k) => $k->status === SigningKeyStatus::Active),
+        ])->layout('layouts.app', ['header' => 'Signing Keys']);
+    }
+}

--- a/app/Livewire/Skills/SkillOpsPage.php
+++ b/app/Livewire/Skills/SkillOpsPage.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Livewire\Skills;
+
+use App\Domain\Skill\Actions\AnnotateSkillResponseAction;
+use App\Domain\Skill\Actions\CancelSkillBenchmarkAction;
+use App\Domain\Skill\Actions\StartSkillBenchmarkAction;
+use App\Domain\Skill\Enums\AnnotationRating;
+use App\Domain\Skill\Enums\BenchmarkStatus;
+use App\Domain\Skill\Exceptions\BenchmarkAlreadyRunningException;
+use App\Domain\Skill\Models\Skill;
+use App\Domain\Skill\Models\SkillAnnotation;
+use App\Domain\Skill\Models\SkillBenchmark;
+use App\Domain\Skill\Models\SkillVersion;
+use App\Domain\Skill\Services\MetricGatedImprovementLoopService;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+/**
+ * Cross-skill operations console surfacing three Skill self-improvement backends
+ * that previously had no first-class UI:
+ *   1. Improvement Loop — metric-gated loop via MetricGatedImprovementLoopService.
+ *   2. Benchmarks       — SkillBenchmark runs (start via StartSkillBenchmarkAction, cancel).
+ *   3. Annotations      — RLHF ratings via AnnotateSkillResponseAction.
+ */
+class SkillOpsPage extends Component
+{
+    #[Url]
+    public string $tab = 'loop';
+
+    /** Selected skill for the active tab's controls. */
+    public string $skillId = '';
+
+    // --- Improvement Loop form ---
+    public string $loopMetric = 'accuracy';
+
+    public int $loopMaxIterations = 5;
+
+    // --- Benchmark form ---
+    public string $benchSkillId = '';
+
+    public string $benchMetricName = 'latency_ms';
+
+    public string $benchMetricDirection = 'maximize';
+
+    public string $benchTestInputs = '[]';
+
+    public int $benchTimeBudget = 3600;
+
+    public int $benchMaxIterations = 50;
+
+    public float $benchComplexityPenalty = 0.01;
+
+    public float $benchImprovementThreshold = 0.0;
+
+    // --- Annotation form ---
+    public string $annotateVersionId = '';
+
+    public string $annotateModelId = '';
+
+    public string $annotateInput = '';
+
+    public string $annotateOutput = '';
+
+    public string $annotateRating = 'good';
+
+    public string $annotateNote = '';
+
+    public function mount(): void
+    {
+        $first = Skill::query()->orderBy('name')->value('id');
+        $this->skillId = (string) $first;
+        $this->benchSkillId = (string) $first;
+    }
+
+    public function startLoop(): void
+    {
+        Gate::authorize('edit-content');
+
+        $this->validate([
+            'skillId' => 'required|uuid',
+            'loopMetric' => 'required|string|max:100',
+            'loopMaxIterations' => 'required|integer|min:1|max:50',
+        ]);
+
+        $skill = Skill::query()->findOrFail($this->skillId);
+
+        app(MetricGatedImprovementLoopService::class)->run(
+            skill: $skill,
+            maxIterations: $this->loopMaxIterations,
+            metric: $this->loopMetric,
+        );
+
+        session()->flash('message', 'Improvement loop started (or already running) for '.$skill->name.'.');
+    }
+
+    public function startBenchmark(): void
+    {
+        Gate::authorize('edit-content');
+
+        $this->validate([
+            'benchSkillId' => 'required|uuid',
+            'benchMetricName' => 'required|string|max:100',
+            'benchMetricDirection' => 'required|in:maximize,minimize',
+            'benchTestInputs' => 'required|json',
+            'benchTimeBudget' => 'required|integer|min:60',
+            'benchMaxIterations' => 'required|integer|min:1|max:500',
+            'benchComplexityPenalty' => 'required|numeric|min:0',
+            'benchImprovementThreshold' => 'required|numeric',
+        ]);
+
+        $skill = Skill::query()->findOrFail($this->benchSkillId);
+
+        /** @var array<int, mixed> $testInputs */
+        $testInputs = json_decode($this->benchTestInputs, true);
+
+        try {
+            app(StartSkillBenchmarkAction::class)->execute(
+                skill: $skill,
+                userId: (string) auth()->id(),
+                metricName: $this->benchMetricName,
+                testInputs: $testInputs,
+                metricDirection: $this->benchMetricDirection,
+                timeBudgetSeconds: $this->benchTimeBudget,
+                maxIterations: $this->benchMaxIterations,
+                complexityPenalty: $this->benchComplexityPenalty,
+                improvementThreshold: $this->benchImprovementThreshold,
+            );
+        } catch (BenchmarkAlreadyRunningException $e) {
+            session()->flash('benchmark_error', $e->getMessage());
+
+            return;
+        }
+
+        session()->flash('message', 'Benchmark started for '.$skill->name.'.');
+    }
+
+    public function cancelBenchmark(string $benchmarkId): void
+    {
+        Gate::authorize('edit-content');
+
+        $benchmark = SkillBenchmark::query()->findOrFail($benchmarkId);
+
+        app(CancelSkillBenchmarkAction::class)->execute($benchmark);
+
+        session()->flash('message', 'Benchmark cancellation requested.');
+    }
+
+    public function submitAnnotation(): void
+    {
+        Gate::authorize('edit-content');
+
+        $this->validate([
+            'annotateVersionId' => 'required|uuid',
+            'annotateModelId' => 'required|string|max:255',
+            'annotateInput' => 'required|string|max:20000',
+            'annotateOutput' => 'required|string|max:50000',
+            'annotateRating' => 'required|in:good,bad',
+            'annotateNote' => 'nullable|string|max:2000',
+        ]);
+
+        $teamId = (string) auth()->user()->currentTeam->id;
+
+        // Ownership check — the version must belong to a skill in the current team.
+        SkillVersion::query()
+            ->whereHas('skill', fn ($q) => $q->where('team_id', $teamId))
+            ->findOrFail($this->annotateVersionId);
+
+        app(AnnotateSkillResponseAction::class)->execute(
+            teamId: $teamId,
+            userId: (string) auth()->id(),
+            skillVersionId: $this->annotateVersionId,
+            modelId: $this->annotateModelId,
+            input: $this->annotateInput,
+            output: $this->annotateOutput,
+            rating: AnnotationRating::from($this->annotateRating),
+            note: $this->annotateNote ?: null,
+        );
+
+        $this->reset(['annotateInput', 'annotateOutput', 'annotateNote']);
+
+        session()->flash('message', 'Annotation saved.');
+    }
+
+    public function render()
+    {
+        $skills = Skill::query()->orderBy('name')->get(['id', 'name']);
+
+        $benchmarks = SkillBenchmark::query()
+            ->with(['skill:id,name', 'iterationLogs'])
+            ->orderByDesc('created_at')
+            ->limit(50)
+            ->get();
+
+        $annotations = SkillAnnotation::query()
+            ->with(['skillVersion:id,skill_id,version', 'skillVersion.skill:id,name', 'user:id,name'])
+            ->orderByDesc('created_at')
+            ->limit(50)
+            ->get();
+
+        $versions = SkillVersion::query()
+            ->whereHas('skill', fn ($q) => $q->where('team_id', auth()->user()->currentTeam->id))
+            ->with('skill:id,name')
+            ->orderByDesc('created_at')
+            ->limit(100)
+            ->get();
+
+        return view('livewire.skills.skill-ops-page', [
+            'skills' => $skills,
+            'benchmarks' => $benchmarks,
+            'annotations' => $annotations,
+            'versions' => $versions,
+            'runningBenchmarks' => $benchmarks->where('status', BenchmarkStatus::Running),
+        ])->layout('layouts.app', ['header' => 'Skill Ops']);
+    }
+}

--- a/app/Livewire/Testing/TestSuiteDetailPage.php
+++ b/app/Livewire/Testing/TestSuiteDetailPage.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Livewire\Testing;
+
+use App\Domain\Testing\Models\TestRun;
+use App\Domain\Testing\Models\TestSuite;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class TestSuiteDetailPage extends Component
+{
+    use WithPagination;
+
+    public string $suiteId;
+
+    public function mount(string $suite): void
+    {
+        // TeamScope refuses cross-tenant ids; abort 404 (HttpException) on a
+        // foreign/missing suite so Livewire renders a 404 rather than throwing.
+        $model = TestSuite::query()->find($suite);
+        abort_if($model === null, 404);
+        $this->suiteId = $model->id;
+    }
+
+    public function render()
+    {
+        $suite = TestSuite::query()->with('project')->findOrFail($this->suiteId);
+
+        // TestRun has no team_id of its own; constrain through the team-scoped
+        // suite relation so a foreign suite's runs can never surface here.
+        $runs = TestRun::query()
+            ->where('test_suite_id', $suite->id)
+            ->with('experiment')
+            ->orderByDesc('created_at')
+            ->paginate(20);
+
+        return view('livewire.testing.test-suite-detail-page', [
+            'suite' => $suite,
+            'runs' => $runs,
+        ])->layout('layouts.app', ['header' => 'Test Suite']);
+    }
+}

--- a/app/Livewire/Testing/TestSuitesPage.php
+++ b/app/Livewire/Testing/TestSuitesPage.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Livewire\Testing;
+
+use App\Domain\Testing\Enums\TestStrategy;
+use App\Domain\Testing\Models\TestSuite;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class TestSuitesPage extends Component
+{
+    use WithPagination;
+
+    #[Url]
+    public string $search = '';
+
+    #[Url]
+    public string $strategyFilter = '';
+
+    #[Url]
+    public string $activeFilter = '';
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedStrategyFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedActiveFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        // Rely on the TeamScope global scope for tenant isolation — do NOT
+        // use withoutGlobalScopes()->when($teamId, ...), which leaks across
+        // tenants when the team id is null.
+        $query = TestSuite::query()
+            ->with('project')
+            ->withCount('testRuns');
+
+        if ($this->search !== '') {
+            $query->whereRaw('lower(name) like ?', ['%'.mb_strtolower($this->search).'%']);
+        }
+
+        if ($this->strategyFilter !== '') {
+            $query->where('test_strategy', $this->strategyFilter);
+        }
+
+        if ($this->activeFilter !== '') {
+            $query->where('is_active', $this->activeFilter === 'active');
+        }
+
+        $suites = $query->orderByDesc('created_at')->paginate(20);
+
+        return view('livewire.testing.test-suites-page', [
+            'suites' => $suites,
+            'strategies' => TestStrategy::cases(),
+        ])->layout('layouts.app', ['header' => 'Test Suites']);
+    }
+}

--- a/app/Livewire/Workflows/WorkflowOpsPage.php
+++ b/app/Livewire/Workflows/WorkflowOpsPage.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Livewire\Workflows;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use App\Domain\Workflow\Models\WorkflowNode;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+/**
+ * Compensation (saga) ops view.
+ *
+ * Compensation runs are NOT persisted as their own queryable records — the
+ * RunCompensationChainAction only fires CompensationStarted/CompensationCompleted
+ * events and dispatches ExecuteCompensationJob (which logs but writes no row).
+ *
+ * This page therefore reconstructs compensation activity from durable data:
+ * failed workflow-run experiments whose completed steps had a compensation node
+ * defined (i.e. steps that would have been rolled back). It is strictly read-only.
+ */
+class WorkflowOpsPage extends Component
+{
+    use WithPagination;
+
+    /**
+     * For each failed workflow experiment, count completed steps whose workflow
+     * node has a compensation_node_id (the steps eligible for saga rollback).
+     *
+     * @return Collection<int, array{experiment: Experiment, compensated_count: int}>
+     */
+    private function compensationRuns(): Collection
+    {
+        // Only failed workflow-run experiments can trigger compensation.
+        $experiments = Experiment::query()
+            ->whereNotNull('workflow_id')
+            ->whereIn('status', ['execution_failed', 'building_failed', 'planning_failed', 'scoring_failed'])
+            ->with('workflow:id,name')
+            ->orderByDesc('updated_at')
+            ->limit(50)
+            ->get();
+
+        if ($experiments->isEmpty()) {
+            return collect();
+        }
+
+        return $experiments
+            ->map(function (Experiment $experiment): array {
+                $completedNodeIds = PlaybookStep::query()
+                    ->where('experiment_id', $experiment->id)
+                    ->where('status', 'completed')
+                    ->whereNotNull('workflow_node_id')
+                    ->pluck('workflow_node_id');
+
+                if ($completedNodeIds->isEmpty()) {
+                    return ['experiment' => $experiment, 'compensated_count' => 0];
+                }
+
+                $compensatedCount = WorkflowNode::withoutGlobalScopes()
+                    ->whereHas('workflow', fn ($q) => $q->where('team_id', $experiment->team_id))
+                    ->whereIn('id', $completedNodeIds)
+                    ->whereNotNull('compensation_node_id')
+                    ->count();
+
+                return ['experiment' => $experiment, 'compensated_count' => $compensatedCount];
+            })
+            ->filter(fn (array $row): bool => $row['compensated_count'] > 0)
+            ->values();
+    }
+
+    public function render()
+    {
+        return view('livewire.workflows.workflow-ops-page', [
+            'runs' => $this->compensationRuns(),
+        ])->layout('layouts.app', ['header' => 'Workflow Compensation']);
+    }
+}

--- a/app/Livewire/Workflows/WorkflowSimulationPanel.php
+++ b/app/Livewire/Workflows/WorkflowSimulationPanel.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Livewire\Workflows;
+
+use App\Domain\Workflow\DTOs\SimulationResult;
+use App\Domain\Workflow\Enums\WorkflowNodeType;
+use App\Domain\Workflow\Models\Workflow;
+use App\Domain\Workflow\Models\WorkflowNode;
+use App\Domain\Workflow\Services\WorkflowSimulator;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+/**
+ * Dry-run a workflow graph through WorkflowSimulator (no real execution, no LLM
+ * calls, no cost, no DB writes). Renders the predicted execution path.
+ *
+ * Execution nodes are auto-stubbed with empty output so the simulator can walk
+ * the whole graph from the UI without asking the user for per-node stubs.
+ */
+class WorkflowSimulationPanel extends Component
+{
+    use AuthorizesRequests;
+
+    public Workflow $workflow;
+
+    /** @var array<int, array{id: string, label: string, type: string}> */
+    public array $executedPath = [];
+
+    public ?string $terminationStatus = null;
+
+    public ?string $terminationNodeId = null;
+
+    public bool $hasRun = false;
+
+    public ?string $error = null;
+
+    public function mount(Workflow $workflow): void
+    {
+        $this->workflow = $workflow;
+    }
+
+    public function simulate(): void
+    {
+        // Compute trigger — guard even though simulation is side-effect-free.
+        $this->authorize('edit-content');
+
+        $this->reset(['executedPath', 'terminationStatus', 'terminationNodeId', 'error']);
+        $this->hasRun = true;
+
+        $nodes = $this->workflow->nodes()->get()->keyBy('id');
+
+        // Auto-stub every execution (non-control-flow) node with empty output.
+        $simulator = new WorkflowSimulator;
+        foreach ($nodes as $node) {
+            if (! $node->type->isControlFlow() && $node->type !== WorkflowNodeType::End) {
+                $simulator = $simulator->stub($node->id, []);
+            }
+        }
+
+        $result = $simulator->run($this->workflow);
+
+        $this->renderResult($result, $nodes);
+    }
+
+    /**
+     * @param  Collection<string, WorkflowNode>  $nodes
+     */
+    private function renderResult(SimulationResult $result, $nodes): void
+    {
+        $this->terminationStatus = $result->terminationStatus;
+        $this->terminationNodeId = $result->terminationNodeId;
+
+        $this->executedPath = collect($result->executedPath)
+            ->map(function (string $nodeId) use ($nodes): array {
+                $node = $nodes->get($nodeId);
+
+                return [
+                    'id' => $nodeId,
+                    'label' => $node?->label ?? $nodeId,
+                    'type' => $node?->type->value ?? 'unknown',
+                ];
+            })
+            ->all();
+
+        if ($result->terminationStatus === 'error') {
+            $this->error = 'Simulation could not start — the workflow has no Start node.';
+        }
+    }
+
+    public function render()
+    {
+        return view('livewire.workflows.workflow-simulation-panel');
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -512,6 +512,7 @@ use App\Mcp\Tools\Skill\SkillUpdateTool;
 use App\Mcp\Tools\Skill\SkillVersionsTool;
 use App\Mcp\Tools\Skill\SupabaseEdgeFunctionSkillTool;
 use App\Mcp\Tools\System\AuditLogTool;
+use App\Mcp\Tools\System\SecretScanFindingsTool;
 use App\Mcp\Tools\System\BlacklistManageTool;
 use App\Mcp\Tools\System\DashboardKpisTool;
 use App\Mcp\Tools\System\GlobalSettingsUpdateTool;
@@ -1341,6 +1342,7 @@ class AgentFleetServer extends Server
         SystemVersionCheckTool::class,
         SystemDiscoveryGetTool::class,
         AuditLogTool::class,
+        SecretScanFindingsTool::class,
         GlobalSettingsUpdateTool::class,
         BlacklistManageTool::class,
         SecurityPolicyManageTool::class,

--- a/app/Mcp/Tools/System/SecretScanFindingsTool.php
+++ b/app/Mcp/Tools/System/SecretScanFindingsTool.php
@@ -38,9 +38,13 @@ class SecretScanFindingsTool extends Tool
     {
         $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
 
+        if (! $teamId) {
+            return Response::text(json_encode(['count' => 0, 'findings' => []]));
+        }
+
         $query = AuditEntry::withoutGlobalScopes()
             ->where('event', 'secret_detected')
-            ->when($teamId, fn ($q) => $q->where('team_id', $teamId))
+            ->where('team_id', $teamId)
             ->orderByDesc('created_at');
 
         if ($subjectType = $request->get('subject_type')) {

--- a/app/Mcp/Tools/System/SecretScanFindingsTool.php
+++ b/app/Mcp/Tools/System/SecretScanFindingsTool.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Mcp\Tools\System;
+
+use App\Domain\Audit\Models\AuditEntry;
+use App\Mcp\Attributes\AssistantTool;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class SecretScanFindingsTool extends Tool
+{
+    protected string $name = 'secret_scan_findings';
+
+    protected string $description = 'List secret-scan findings — accidentally embedded API keys/secrets detected in agent, skill, and workflow free-text fields. Returns id, subject_type, subject_id, pattern_id, pattern_name, field, acknowledged, created_at.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'subject_type' => $schema->string()
+                ->description('Filter by source type: agent, skill, or workflow_node'),
+            'include_acknowledged' => $schema->boolean()
+                ->description('Include findings already acknowledged (default false)')
+                ->default(false),
+            'limit' => $schema->integer()
+                ->description('Max results to return (default 20, max 100)')
+                ->default(20),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app('mcp.team_id') ?? auth()->user()?->current_team_id;
+
+        $query = AuditEntry::withoutGlobalScopes()
+            ->where('event', 'secret_detected')
+            ->when($teamId, fn ($q) => $q->where('team_id', $teamId))
+            ->orderByDesc('created_at');
+
+        if ($subjectType = $request->get('subject_type')) {
+            $query->where('subject_type', $subjectType);
+        }
+
+        if (! $request->get('include_acknowledged', false)) {
+            $query->whereNull('properties->acknowledged_at');
+        }
+
+        $limit = min((int) ($request->get('limit', 20)), 100);
+
+        $entries = $query->limit($limit)->get();
+
+        return Response::text(json_encode([
+            'count' => $entries->count(),
+            'findings' => $entries->map(fn ($e) => [
+                'id' => $e->id,
+                'subject_type' => $e->subject_type,
+                'subject_id' => $e->subject_id,
+                'pattern_id' => $e->properties['pattern_id'] ?? null,
+                'pattern_name' => $e->properties['pattern_name'] ?? null,
+                'field' => $e->properties['field'] ?? null,
+                'acknowledged' => ! empty($e->properties['acknowledged_at']),
+                'created_at' => $e->created_at?->diffForHumans(),
+            ])->toArray(),
+        ]));
+    }
+}

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -1,7 +1,7 @@
 @php
     $activeRailGroup = match(true) {
         request()->routeIs('dashboard', 'projects.*', 'experiments.*', 'agents.*', 'agent-sessions.*', 'crews.*', 'approvals.*', 'chatbots.*') => 'fleet',
-        request()->routeIs('workflows.*', 'skills.*', 'memory.*', 'knowledge.*', 'knowledge-graph.*', 'evaluation.*', 'evaluations.*', 'triggers.*', 'evolution.*', 'websites.*') => 'build',
+        request()->routeIs('workflows.*', 'skills.*', 'memory.*', 'knowledge.*', 'knowledge-graph.*', 'evaluation.*', 'evaluations.*', 'triggers.*', 'evolution.*', 'websites.*', 'reasoning-bank.*', 'error-modes.*', 'testing.*') => 'build',
         request()->routeIs('signals.*', 'bug-reports.*', 'contacts.*', 'imports.*', 'email.*', 'outbound.*', 'audiences.*', 'broadcasts.*', 'health', 'audit', 'audit-console.*', 'metrics.*') => 'monitor',
         request()->routeIs('app.marketplace.*', 'marketplace.*', 'plugins', 'telegram.*') => 'marketplace',
         request()->routeIs('tools.*', 'credentials.*', 'releases.*', 'integrations.*', 'git-repositories.*', 'team.*', 'settings', 'settings.git-sync', 'profile', 'notifications.*') => 'settings',
@@ -145,12 +145,16 @@
                 <x-sidebar-link href="{{ route('memory.proposals') }}" :active="request()->routeIs('memory.proposals')" icon="check-circle">Memory Proposals</x-sidebar-link>
                 <x-sidebar-link href="{{ route('world-model.index') }}" :active="request()->routeIs('world-model.*')" icon="globe-alt">World Model</x-sidebar-link>
                 <x-sidebar-link href="{{ route('knowledge.index') }}" :active="request()->routeIs('knowledge.*') && !request()->routeIs('knowledge-graph.*')" icon="book-open">Knowledge</x-sidebar-link>
-                <x-sidebar-link href="{{ route('knowledge-graph.index') }}" :active="request()->routeIs('knowledge-graph.*')" icon="share">Knowledge Graph</x-sidebar-link>
+                <x-sidebar-link href="{{ route('knowledge-graph.index') }}" :active="request()->routeIs('knowledge-graph.index')" icon="share">Knowledge Graph</x-sidebar-link>
+                <x-sidebar-link href="{{ route('knowledge-graph.communities') }}" :active="request()->routeIs('knowledge-graph.communities')" icon="share">KG Communities</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluation.index') }}" :active="request()->routeIs('evaluation.index')" icon="scale">Evaluation</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluation.drift') }}" :active="request()->routeIs('evaluation.drift')" icon="scale">Drift Signals</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluation.monitor') }}" :active="request()->routeIs('evaluation.monitor')" icon="chart-bar">Eval Monitor</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluations.index') }}" :active="request()->routeIs('evaluations.*')" icon="beaker">Flow Evals</x-sidebar-link>
                 <x-sidebar-link href="{{ route('triggers.index') }}" :active="request()->routeIs('triggers.*')" icon="bolt">Triggers</x-sidebar-link>
+                <x-sidebar-link href="{{ route('reasoning-bank.index') }}" :active="request()->routeIs('reasoning-bank.*')" icon="light-bulb">Reasoning Bank</x-sidebar-link>
+                <x-sidebar-link href="{{ route('error-modes.index') }}" :active="request()->routeIs('error-modes.*')" icon="bug-ant">Error Modes</x-sidebar-link>
+                <x-sidebar-link href="{{ route('testing.index') }}" :active="request()->routeIs('testing.*')" icon="beaker">Test Suites</x-sidebar-link>
                 @if(Route::has('evolution.index'))
                     <x-sidebar-link href="{{ route('evolution.index') }}" :active="request()->routeIs('evolution.*')" icon="sparkles">
                         Evolution

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -1,10 +1,10 @@
 @php
     $activeRailGroup = match(true) {
-        request()->routeIs('dashboard', 'projects.*', 'experiments.*', 'agents.*', 'crews.*', 'approvals.*', 'chatbots.*') => 'fleet',
+        request()->routeIs('dashboard', 'projects.*', 'experiments.*', 'agents.*', 'agent-sessions.*', 'crews.*', 'approvals.*', 'chatbots.*') => 'fleet',
         request()->routeIs('workflows.*', 'skills.*', 'memory.*', 'knowledge.*', 'knowledge-graph.*', 'evaluation.*', 'evaluations.*', 'triggers.*', 'evolution.*', 'websites.*') => 'build',
-        request()->routeIs('signals.*', 'bug-reports.*', 'contacts.*', 'email.*', 'outbound.*', 'audiences.*', 'broadcasts.*', 'health', 'audit', 'audit-console.*', 'metrics.*') => 'monitor',
+        request()->routeIs('signals.*', 'bug-reports.*', 'contacts.*', 'imports.*', 'email.*', 'outbound.*', 'audiences.*', 'broadcasts.*', 'health', 'audit', 'audit-console.*', 'metrics.*') => 'monitor',
         request()->routeIs('app.marketplace.*', 'marketplace.*', 'plugins', 'telegram.*') => 'marketplace',
-        request()->routeIs('tools.*', 'credentials.*', 'integrations.*', 'git-repositories.*', 'team.*', 'settings', 'settings.git-sync', 'profile', 'notifications.*') => 'settings',
+        request()->routeIs('tools.*', 'credentials.*', 'releases.*', 'integrations.*', 'git-repositories.*', 'team.*', 'settings', 'settings.git-sync', 'profile', 'notifications.*') => 'settings',
         default => null,
     };
     $pendingCount = \App\Domain\Approval\Models\ApprovalRequest::where('status', 'pending')->count();
@@ -118,6 +118,7 @@
                 <x-sidebar-link href="{{ route('agents.index') }}" :active="request()->routeIs('agents.*')" icon="cpu-chip">Agents</x-sidebar-link>
                 <x-sidebar-link href="{{ route('external-agents.index') }}" :active="request()->routeIs('external-agents.*')" icon="link">External Agents</x-sidebar-link>
                 <x-sidebar-link href="{{ route('crews.index') }}" :active="request()->routeIs('crews.*')" icon="user-group">Crews</x-sidebar-link>
+                <x-sidebar-link href="{{ route('agent-sessions.index') }}" :active="request()->routeIs('agent-sessions.*')" icon="clock">Agent Sessions</x-sidebar-link>
                 <x-sidebar-link href="{{ route('approvals.index') }}" :active="request()->routeIs('approvals.*')" icon="check-circle">
                     Approvals
                     @if($pendingCount > 0)
@@ -143,6 +144,8 @@
                 <x-sidebar-link href="{{ route('knowledge.index') }}" :active="request()->routeIs('knowledge.*') && !request()->routeIs('knowledge-graph.*')" icon="book-open">Knowledge</x-sidebar-link>
                 <x-sidebar-link href="{{ route('knowledge-graph.index') }}" :active="request()->routeIs('knowledge-graph.*')" icon="share">Knowledge Graph</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluation.index') }}" :active="request()->routeIs('evaluation.index')" icon="scale">Evaluation</x-sidebar-link>
+                <x-sidebar-link href="{{ route('evaluation.drift') }}" :active="request()->routeIs('evaluation.drift')" icon="scale">Drift Signals</x-sidebar-link>
+                <x-sidebar-link href="{{ route('evaluation.monitor') }}" :active="request()->routeIs('evaluation.monitor')" icon="chart-bar">Eval Monitor</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluations.index') }}" :active="request()->routeIs('evaluations.*')" icon="beaker">Flow Evals</x-sidebar-link>
                 <x-sidebar-link href="{{ route('triggers.index') }}" :active="request()->routeIs('triggers.*')" icon="bolt">Triggers</x-sidebar-link>
                 @if(Route::has('evolution.index'))
@@ -167,6 +170,7 @@
                 <x-sidebar-link href="{{ route('signals.bindings') }}" :active="request()->routeIs('signals.bindings')" icon="link">Bindings</x-sidebar-link>
                 <x-sidebar-link href="{{ route('bug-reports.index') }}" :active="request()->routeIs('bug-reports.*')" icon="bug-ant">Bug Reports</x-sidebar-link>
                 <x-sidebar-link href="{{ route('contacts.index') }}" :active="request()->routeIs('contacts.*')" icon="identification">Contacts</x-sidebar-link>
+                <x-sidebar-link href="{{ route('imports.create') }}" :active="request()->routeIs('imports.*')" icon="document-text">Import Data</x-sidebar-link>
                 <x-sidebar-link href="{{ route('email.templates.index') }}" :active="request()->routeIs('email.templates.*')" icon="document-text">Email Templates</x-sidebar-link>
                 <x-sidebar-link href="{{ route('email.themes.index') }}" :active="request()->routeIs('email.themes.*')" icon="envelope">Email Themes</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.email') }}" :active="request()->routeIs('outbound.email')" icon="envelope">Email Delivery</x-sidebar-link>
@@ -210,6 +214,7 @@
             <nav class="flex-1 overflow-y-auto px-2">
                 <x-sidebar-link href="{{ route('tools.index') }}" :active="request()->routeIs('tools.*')" icon="wrench-screwdriver">Tools</x-sidebar-link>
                 <x-sidebar-link href="{{ route('credentials.index') }}" :active="request()->routeIs('credentials.*')" icon="key">Credentials</x-sidebar-link>
+                <x-sidebar-link href="{{ route('releases.signing-keys') }}" :active="request()->routeIs('releases.signing-keys')" icon="key">Signing Keys</x-sidebar-link>
                 <x-sidebar-link href="{{ route('integrations.index') }}" :active="request()->routeIs('integrations.*')" icon="link">Integrations</x-sidebar-link>
                 <x-sidebar-link href="{{ route('git-repositories.index') }}" :active="request()->routeIs('git-repositories.*')" icon="code-branch">Git Repos</x-sidebar-link>
                 <x-sidebar-link href="{{ route('settings.git-sync') }}" :active="request()->routeIs('settings.git-sync')" icon="arrow-path">Git Sync</x-sidebar-link>

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -135,11 +135,14 @@
         <div x-show="nav === 'build'" class="flex h-full flex-col py-3" style="display: none;">
             <p class="mb-1 px-4 text-xs font-semibold uppercase tracking-wider text-gray-500">Build</p>
             <nav class="flex-1 overflow-y-auto px-2">
-                <x-sidebar-link href="{{ route('workflows.index') }}" :active="request()->routeIs('workflows.*')" icon="arrow-path">Workflows</x-sidebar-link>
+                <x-sidebar-link href="{{ route('workflows.index') }}" :active="request()->routeIs('workflows.*') && !request()->routeIs('workflows.ops')" icon="arrow-path">Workflows</x-sidebar-link>
+                <x-sidebar-link href="{{ route('workflows.ops') }}" :active="request()->routeIs('workflows.ops')" icon="arrow-path">Compensation</x-sidebar-link>
                 <x-sidebar-link href="{{ route('websites.index') }}" :active="request()->routeIs('websites.*')" icon="globe-alt">Websites</x-sidebar-link>
-                <x-sidebar-link href="{{ route('skills.index') }}" :active="request()->routeIs('skills.*')" icon="puzzle-piece">Skills</x-sidebar-link>
+                <x-sidebar-link href="{{ route('skills.index') }}" :active="request()->routeIs('skills.*') && !request()->routeIs('skills.ops')" icon="puzzle-piece">Skills</x-sidebar-link>
+                <x-sidebar-link href="{{ route('skills.ops') }}" :active="request()->routeIs('skills.ops')" icon="wrench-screwdriver">Skill Ops</x-sidebar-link>
                 <x-sidebar-link href="{{ route('frameworks.index') }}" :active="request()->routeIs('frameworks.*')" icon="academic-cap">Frameworks</x-sidebar-link>
-                <x-sidebar-link href="{{ route('memory.index') }}" :active="request()->routeIs('memory.*') && !request()->routeIs('knowledge.*')" icon="circle-stack">Memory</x-sidebar-link>
+                <x-sidebar-link href="{{ route('memory.index') }}" :active="request()->routeIs('memory.*') && !request()->routeIs('knowledge.*') && !request()->routeIs('memory.proposals')" icon="circle-stack">Memory</x-sidebar-link>
+                <x-sidebar-link href="{{ route('memory.proposals') }}" :active="request()->routeIs('memory.proposals')" icon="check-circle">Memory Proposals</x-sidebar-link>
                 <x-sidebar-link href="{{ route('world-model.index') }}" :active="request()->routeIs('world-model.*')" icon="globe-alt">World Model</x-sidebar-link>
                 <x-sidebar-link href="{{ route('knowledge.index') }}" :active="request()->routeIs('knowledge.*') && !request()->routeIs('knowledge-graph.*')" icon="book-open">Knowledge</x-sidebar-link>
                 <x-sidebar-link href="{{ route('knowledge-graph.index') }}" :active="request()->routeIs('knowledge-graph.*')" icon="share">Knowledge Graph</x-sidebar-link>
@@ -182,6 +185,8 @@
                 <x-sidebar-link href="{{ route('outbound.discord') }}" :active="request()->routeIs('outbound.discord')" icon="chat-bubble-left-right">Discord</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.teams') }}" :active="request()->routeIs('outbound.teams')" icon="chat-bubble-left-right">Teams</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.google_chat') }}" :active="request()->routeIs('outbound.google_chat')" icon="chat-bubble-left-right">Google Chat</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.proposals') }}" :active="request()->routeIs('outbound.proposals')" icon="paper-airplane">Outbound Proposals</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.blacklist') }}" :active="request()->routeIs('outbound.blacklist')" icon="shield-check">Blacklist</x-sidebar-link>
                 <x-sidebar-link href="{{ route('audiences.index') }}" :active="request()->routeIs('audiences.*', 'broadcasts.*')" icon="identification">Audiences</x-sidebar-link>
                 <x-sidebar-link href="{{ route('health') }}" :active="request()->routeIs('health')" icon="heart">Health</x-sidebar-link>
                 <x-sidebar-link href="{{ route('audit') }}" :active="request()->routeIs('audit')" icon="document-text">Audit Log</x-sidebar-link>
@@ -220,6 +225,7 @@
                 <x-sidebar-link href="{{ route('tools.index') }}" :active="request()->routeIs('tools.*')" icon="wrench-screwdriver">Tools</x-sidebar-link>
                 <x-sidebar-link href="{{ route('credentials.index') }}" :active="request()->routeIs('credentials.*')" icon="key">Credentials</x-sidebar-link>
                 <x-sidebar-link href="{{ route('releases.signing-keys') }}" :active="request()->routeIs('releases.signing-keys')" icon="key">Signing Keys</x-sidebar-link>
+                <x-sidebar-link href="{{ route('credentials.scan') }}" :active="request()->routeIs('credentials.scan')" icon="shield-check">Secret Scan</x-sidebar-link>
                 <x-sidebar-link href="{{ route('integrations.index') }}" :active="request()->routeIs('integrations.*')" icon="link">Integrations</x-sidebar-link>
                 <x-sidebar-link href="{{ route('git-repositories.index') }}" :active="request()->routeIs('git-repositories.*')" icon="code-branch">Git Repos</x-sidebar-link>
                 <x-sidebar-link href="{{ route('settings.git-sync') }}" :active="request()->routeIs('settings.git-sync')" icon="arrow-path">Git Sync</x-sidebar-link>

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -177,6 +177,11 @@
                 <x-sidebar-link href="{{ route('outbound.webhooks') }}" :active="request()->routeIs('outbound.webhooks')" icon="link">Webhooks</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.notifications') }}" :active="request()->routeIs('outbound.notifications')" icon="bell">Notifications</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.whatsapp') }}" :active="request()->routeIs('outbound.whatsapp')" icon="chat-bubble-left-right">WhatsApp</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.telegram') }}" :active="request()->routeIs('outbound.telegram')" icon="chat-bubble-left-right">Telegram</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.slack') }}" :active="request()->routeIs('outbound.slack')" icon="chat-bubble-left-right">Slack</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.discord') }}" :active="request()->routeIs('outbound.discord')" icon="chat-bubble-left-right">Discord</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.teams') }}" :active="request()->routeIs('outbound.teams')" icon="chat-bubble-left-right">Teams</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.google_chat') }}" :active="request()->routeIs('outbound.google_chat')" icon="chat-bubble-left-right">Google Chat</x-sidebar-link>
                 <x-sidebar-link href="{{ route('audiences.index') }}" :active="request()->routeIs('audiences.*', 'broadcasts.*')" icon="identification">Audiences</x-sidebar-link>
                 <x-sidebar-link href="{{ route('health') }}" :active="request()->routeIs('health')" icon="heart">Health</x-sidebar-link>
                 <x-sidebar-link href="{{ route('audit') }}" :active="request()->routeIs('audit')" icon="document-text">Audit Log</x-sidebar-link>

--- a/resources/views/livewire/agent-sessions/agent-session-detail-page.blade.php
+++ b/resources/views/livewire/agent-sessions/agent-session-detail-page.blade.php
@@ -1,0 +1,125 @@
+<div>
+    @php
+        $session = $this->session;
+        $statusClasses = [
+            'pending' => 'bg-gray-100 text-gray-700',
+            'active' => 'bg-green-100 text-green-700',
+            'sleeping' => 'bg-blue-100 text-blue-700',
+            'completed' => 'bg-gray-100 text-gray-700',
+            'cancelled' => 'bg-amber-100 text-amber-700',
+            'failed' => 'bg-red-100 text-red-700',
+        ];
+        $isTerminal = $session->status?->isTerminal() ?? false;
+    @endphp
+
+    @if (session('message'))
+        <div class="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-800">
+            {{ session('message') }}
+        </div>
+    @endif
+
+    {{-- Header / state + actions --}}
+    <div class="mb-6 flex flex-wrap items-start justify-between gap-4 rounded-lg border border-gray-200 bg-white p-5">
+        <div>
+            <div class="flex items-center gap-3">
+                <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium {{ $statusClasses[$session->status?->value] ?? 'bg-gray-100 text-gray-700' }}">
+                    {{ $session->status?->label() ?? '—' }}
+                </span>
+                <span class="text-sm text-gray-500">{{ $session->agent?->name ?? 'No agent' }}</span>
+            </div>
+            <p class="mt-2 font-mono text-xs text-gray-400">{{ $session->id }}</p>
+            <p class="mt-1 text-xs text-gray-500">
+                Started {{ $session->started_at?->diffForHumans() ?? '—' }}
+                &middot; Last heartbeat {{ $session->last_heartbeat_at?->diffForHumans() ?? '—' }}
+                @if($session->last_known_sandbox_id)
+                    &middot; Sandbox <span class="font-mono">{{ $session->last_known_sandbox_id }}</span>
+                @endif
+            </p>
+        </div>
+
+        <div class="flex items-center gap-2">
+            @unless($isTerminal)
+                <button wire:click="wake"
+                    class="rounded-lg border border-primary-300 bg-primary-50 px-4 py-2 text-sm font-medium text-primary-700 hover:bg-primary-100">
+                    Wake
+                </button>
+                <button wire:click="$set('showCancelConfirm', true)"
+                    class="rounded-lg border border-red-300 bg-red-50 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-100">
+                    Cancel
+                </button>
+            @else
+                <span class="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-400">
+                    Session is {{ $session->status?->label() }}
+                </span>
+            @endunless
+        </div>
+    </div>
+
+    {{-- Cancel confirm --}}
+    @if($showCancelConfirm)
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" wire:click.self="$set('showCancelConfirm', false)">
+            <div class="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+                <h3 class="mb-2 text-lg font-semibold text-gray-900">Cancel session?</h3>
+                <p class="mb-5 text-sm text-gray-600">This marks the session terminal. It cannot be woken again.</p>
+                <div class="flex justify-end gap-2">
+                    <button wire:click="$set('showCancelConfirm', false)"
+                        class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                        Keep
+                    </button>
+                    <button wire:click="cancel"
+                        class="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700">
+                        Cancel Session
+                    </button>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    {{-- Replay stats --}}
+    <div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs uppercase tracking-wider text-gray-500">Total Events</p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900">{{ $replay->totalEvents }}</p>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs uppercase tracking-wider text-gray-500">Tool Calls</p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900">{{ $replay->toolCallCount }}</p>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs uppercase tracking-wider text-gray-500">LLM Tokens</p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900">{{ number_format($replay->llmTotalTokens) }}</p>
+        </div>
+        <div class="rounded-lg border border-gray-200 bg-white p-4">
+            <p class="text-xs uppercase tracking-wider text-gray-500">Handoffs</p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900">{{ $replay->handoffCount }}</p>
+        </div>
+    </div>
+
+    {{-- Append-only event timeline --}}
+    <div class="rounded-lg border border-gray-200 bg-white">
+        <div class="border-b border-gray-200 px-5 py-3">
+            <h2 class="text-sm font-semibold text-gray-900">Event Timeline</h2>
+            <p class="text-xs text-gray-500">Newest first &middot; showing up to 500 events</p>
+        </div>
+        <ul class="divide-y divide-gray-100">
+            @forelse($events as $event)
+                <li class="flex items-start gap-4 px-5 py-3">
+                    <span class="mt-0.5 w-10 shrink-0 font-mono text-xs text-gray-400">#{{ $event->seq }}</span>
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2">
+                            <span class="inline-flex rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                                {{ $event->kind?->value ?? 'unknown' }}
+                            </span>
+                            <span class="text-xs text-gray-400">{{ $event->created_at?->diffForHumans() }}</span>
+                        </div>
+                        @if(!empty($event->payload))
+                            <pre class="mt-1 overflow-x-auto whitespace-pre-wrap break-words rounded bg-gray-50 p-2 text-xs text-gray-600">{{ json_encode($event->payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                        @endif
+                    </div>
+                </li>
+            @empty
+                <li class="px-5 py-10 text-center text-sm text-gray-500">No events recorded.</li>
+            @endforelse
+        </ul>
+    </div>
+</div>

--- a/resources/views/livewire/agent-sessions/agent-session-list-page.blade.php
+++ b/resources/views/livewire/agent-sessions/agent-session-list-page.blade.php
@@ -1,0 +1,82 @@
+<div>
+    @php
+        $statusClasses = [
+            'pending' => 'bg-gray-100 text-gray-700',
+            'active' => 'bg-green-100 text-green-700',
+            'sleeping' => 'bg-blue-100 text-blue-700',
+            'completed' => 'bg-gray-100 text-gray-700',
+            'cancelled' => 'bg-amber-100 text-amber-700',
+            'failed' => 'bg-red-100 text-red-700',
+        ];
+    @endphp
+
+    {{-- Toolbar --}}
+    <form class="mb-6 flex flex-wrap items-center gap-4" onsubmit="return false">
+        <x-form-select wire:model.live="statusFilter">
+            <option value="">All Statuses</option>
+            @foreach($statuses as $status)
+                <option value="{{ $status->value }}">{{ $status->label() }}</option>
+            @endforeach
+        </x-form-select>
+
+        <x-form-select wire:model.live="agentFilter">
+            <option value="">All Agents</option>
+            @foreach($agents as $agent)
+                <option value="{{ $agent->id }}">{{ $agent->name }}</option>
+            @endforeach
+        </x-form-select>
+    </form>
+
+    {{-- Table --}}
+    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Agent</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Events</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Started</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Last Heartbeat</th>
+                    <th class="px-4 py-3"></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+                @forelse($sessions as $session)
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-4 py-3">
+                            <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium {{ $statusClasses[$session->status?->value] ?? 'bg-gray-100 text-gray-700' }}">
+                                {{ $session->status?->label() ?? '—' }}
+                            </span>
+                        </td>
+                        <td class="px-4 py-3 text-sm text-gray-900">
+                            {{ $session->agent?->name ?? '—' }}
+                        </td>
+                        <td class="px-4 py-3 text-sm text-gray-700">{{ $session->events_count }}</td>
+                        <td class="px-4 py-3 text-sm text-gray-500">
+                            {{ $session->started_at?->diffForHumans() ?? '—' }}
+                        </td>
+                        <td class="px-4 py-3 text-sm text-gray-500">
+                            {{ $session->last_heartbeat_at?->diffForHumans() ?? '—' }}
+                        </td>
+                        <td class="px-4 py-3 text-right">
+                            <a href="{{ route('agent-sessions.show', $session->id) }}"
+                                class="text-sm font-medium text-primary-600 hover:text-primary-700">
+                                View
+                            </a>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="6" class="px-4 py-10 text-center text-sm text-gray-500">
+                            No agent sessions yet.
+                        </td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ $sessions->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/broadcast/broadcast-list-page.blade.php
+++ b/resources/views/livewire/broadcast/broadcast-list-page.blade.php
@@ -1,0 +1,67 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @php
+        $statusStyles = [
+            'draft' => 'bg-gray-100 text-gray-600',
+            'pending_approval' => 'bg-amber-100 text-amber-700',
+            'approved' => 'bg-blue-100 text-blue-700',
+            'sending' => 'bg-blue-100 text-blue-700',
+            'sent' => 'bg-green-100 text-green-700',
+            'failed' => 'bg-red-100 text-red-700',
+            'cancelled' => 'bg-gray-100 text-gray-500',
+        ];
+    @endphp
+
+    <div class="space-y-6">
+        <div class="flex justify-end">
+            <a href="{{ route('broadcasts.create') }}" wire:navigate
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700">
+                New Broadcast
+            </a>
+        </div>
+
+        {{-- List --}}
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+                <thead>
+                    <tr class="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                        <th class="px-6 py-3">Name</th>
+                        <th class="px-6 py-3">Status</th>
+                        <th class="px-6 py-3">Audience</th>
+                        <th class="px-6 py-3">Recipients</th>
+                        <th class="px-6 py-3">Sent</th>
+                        <th class="px-6 py-3">Created</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @forelse ($broadcasts as $broadcast)
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-6 py-3">
+                                <a href="{{ route('broadcasts.show', $broadcast) }}" wire:navigate
+                                    class="font-medium text-primary-600 hover:text-primary-800">{{ $broadcast->name }}</a>
+                            </td>
+                            <td class="px-6 py-3">
+                                <span class="rounded-full px-2.5 py-0.5 text-xs font-medium {{ $statusStyles[$broadcast->status->value] ?? 'bg-gray-100 text-gray-600' }}">
+                                    {{ str_replace('_', ' ', $broadcast->status->value) }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-3 text-gray-700">{{ $broadcast->audience?->name ?? '—' }}</td>
+                            <td class="px-6 py-3 text-gray-700">{{ $broadcast->recipient_count }}</td>
+                            <td class="px-6 py-3 text-gray-500">
+                                {{ $broadcast->sent_at?->diffForHumans() ?? '—' }}
+                            </td>
+                            <td class="px-6 py-3 text-gray-500">{{ $broadcast->created_at?->diffForHumans() }}</td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="6" class="px-6 py-8 text-center text-gray-400">No broadcasts yet.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <div>{{ $broadcasts->links() }}</div>
+    </div>
+</div>

--- a/resources/views/livewire/broadcast/create-broadcast-form.blade.php
+++ b/resources/views/livewire/broadcast/create-broadcast-form.blade.php
@@ -1,0 +1,41 @@
+<div>
+    <div class="space-y-6">
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">New Broadcast</h2>
+                <p class="mt-0.5 text-sm text-gray-500">A one-time mass email sent to every subscribed member of an audience.</p>
+            </div>
+
+            <div class="space-y-5 p-6">
+                <x-form-select wire:model.live="audienceId" label="Audience">
+                    <option value="">Select an audience…</option>
+                    @foreach ($audiences as $audience)
+                        <option value="{{ $audience->id }}">{{ $audience->name }}</option>
+                    @endforeach
+                </x-form-select>
+
+                @if ($estimate)
+                    <div class="rounded-lg bg-gray-50 px-4 py-3 text-sm text-gray-600">
+                        <span class="font-medium text-gray-900">{{ $estimate['recipients'] }}</span> subscribed recipient(s)
+                        · est. <span class="font-medium text-gray-900">{{ $estimate['estimated_credits'] }}</span> credit(s)
+                        <span class="text-gray-400">(cap {{ $estimate['max_recipients'] }})</span>
+                        @if ($estimate['recipients'] > $estimate['max_recipients'])
+                            <span class="ml-2 font-medium text-red-600">Exceeds recipient cap.</span>
+                        @endif
+                    </div>
+                @endif
+
+                <x-form-input wire:model="name" label="Name" placeholder="June newsletter" />
+                <x-form-input wire:model="subject" label="Subject" placeholder="What's new this month" />
+                <x-form-textarea wire:model="body" label="Body" hint="HTML is supported." rows="10" />
+            </div>
+
+            <div class="flex justify-end border-t border-gray-200 px-6 py-4">
+                <button wire:click="create" wire:loading.attr="disabled"
+                    class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                    Create Broadcast
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/credentials/credential-scan-page.blade.php
+++ b/resources/views/livewire/credentials/credential-scan-page.blade.php
@@ -1,0 +1,130 @@
+<div>
+    {{-- Intro --}}
+    <div class="mb-6 rounded-xl border border-gray-200 bg-white p-4">
+        <div class="flex items-start gap-3">
+            <div class="mt-0.5 flex-shrink-0">
+                <i class="fa-solid fa-magnifying-glass-chart text-lg text-amber-600"></i>
+            </div>
+            <div class="flex-1">
+                <h4 class="text-sm font-semibold text-gray-900">Secret Scan Findings</h4>
+                <p class="mt-0.5 text-sm text-gray-600">
+                    Automated scans of agent, skill, and workflow free-text fields for accidentally embedded
+                    API keys and secrets. Review each finding, re-scan after editing the source, or acknowledge
+                    once resolved.
+                </p>
+            </div>
+            <div class="text-right">
+                <span class="inline-flex items-center rounded-full bg-amber-100 px-3 py-1 text-sm font-semibold text-amber-800">
+                    {{ $openCount }} open
+                </span>
+            </div>
+        </div>
+    </div>
+
+    {{-- Toolbar --}}
+    <div class="mb-6 flex flex-wrap items-center gap-4">
+        <x-form-select wire:model.live="subjectTypeFilter">
+            <option value="">All Sources</option>
+            @foreach($subjectTypes as $type)
+                <option value="{{ $type }}">{{ \Illuminate\Support\Str::headline($type) }}</option>
+            @endforeach
+        </x-form-select>
+
+        <label class="flex items-center gap-2 text-sm text-gray-700">
+            <input type="checkbox" wire:model.live="showAcknowledged"
+                class="rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
+            Show acknowledged
+        </label>
+
+        <div x-data="{ msg: '' }"
+            x-on:scan-rescan-queued.window="msg = 'Re-scan queued.'; setTimeout(() => msg = '', 3000)"
+            x-on:scan-rescan-empty.window="msg = 'No scannable text remains — finding may be stale.'; setTimeout(() => msg = '', 4000)"
+            x-on:scan-rescan-missing.window="msg = 'Source record no longer exists.'; setTimeout(() => msg = '', 4000)"
+            x-on:scan-finding-acknowledged.window="msg = 'Finding acknowledged.'; setTimeout(() => msg = '', 3000)"
+            class="text-sm font-medium text-green-700" x-text="msg"></div>
+    </div>
+
+    {{-- Table --}}
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+        <div class="overflow-x-auto">
+            <table class="w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Pattern</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Source</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Field</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Detected</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                        <th class="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 bg-white">
+                    @forelse($findings as $finding)
+                        @php
+                            $props = $finding->properties ?? [];
+                            $acknowledged = ! empty($props['acknowledged_at']);
+                        @endphp
+                        <tr class="{{ $acknowledged ? 'opacity-60' : '' }}">
+                            <td class="px-6 py-4">
+                                <div class="flex items-center gap-2">
+                                    <i class="fa-solid fa-triangle-exclamation text-amber-500"></i>
+                                    <span class="text-sm font-medium text-gray-900">{{ $props['pattern_name'] ?? 'Secret' }}</span>
+                                </div>
+                                <div class="mt-0.5 font-mono text-xs text-gray-400">{{ $props['pattern_id'] ?? '' }}</div>
+                            </td>
+                            <td class="px-6 py-4">
+                                <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                                    {{ \Illuminate\Support\Str::headline(\Illuminate\Support\Str::afterLast($finding->subject_type, '\\')) }}
+                                </span>
+                                <div class="mt-0.5 font-mono text-xs text-gray-400">{{ \Illuminate\Support\Str::limit($finding->subject_id, 12, '…') }}</div>
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-700">
+                                <code class="rounded bg-gray-50 px-1.5 py-0.5 text-xs">{{ $props['field'] ?? '—' }}</code>
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-500">
+                                {{ $finding->created_at?->diffForHumans() ?? '—' }}
+                            </td>
+                            <td class="px-6 py-4">
+                                @if($acknowledged)
+                                    <span class="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                                        <i class="fa-solid fa-check mr-1"></i> Acknowledged
+                                    </span>
+                                @else
+                                    <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-700">
+                                        Open
+                                    </span>
+                                @endif
+                            </td>
+                            <td class="px-6 py-4 text-right text-sm">
+                                <div class="flex items-center justify-end gap-3">
+                                    <button wire:click="rescan('{{ $finding->id }}')"
+                                        wire:loading.attr="disabled"
+                                        class="font-medium text-primary-600 hover:text-primary-800">
+                                        Re-scan
+                                    </button>
+                                    @unless($acknowledged)
+                                        <button wire:click="acknowledge('{{ $finding->id }}')"
+                                            class="font-medium text-gray-500 hover:text-gray-700">
+                                            Acknowledge
+                                        </button>
+                                    @endunless
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="px-6 py-12 text-center text-sm text-gray-500">
+                                <i class="fa-solid fa-shield-halved mb-2 block text-2xl text-green-500"></i>
+                                No secret-scan findings. Free-text fields are clean.
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="mt-4">
+        {{ $findings->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/crews/crew-chat-room-page.blade.php
+++ b/resources/views/livewire/crews/crew-chat-room-page.blade.php
@@ -1,0 +1,140 @@
+<div class="mx-auto max-w-4xl px-4 py-6">
+    @php($execution = $this->execution)
+
+    {{-- Header --}}
+    <div class="mb-6 flex items-center justify-between">
+        <div>
+            <h1 class="text-lg font-semibold text-gray-800">Crew Chat Room</h1>
+            <p class="mt-0.5 text-sm text-gray-500">
+                Inter-agent messaging &amp; blackboard for crew execution
+                <span class="font-mono text-xs text-gray-400">{{ $execution->id }}</span>
+            </p>
+        </div>
+        <a href="{{ route('crews.show', $execution->crew_id) }}"
+            class="rounded bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-200">
+            <i class="fa-solid fa-arrow-left mr-1"></i> Back to crew
+        </a>
+    </div>
+
+    {{-- Goal --}}
+    @if($execution->goal)
+        <div class="mb-6 rounded-lg border border-gray-100 bg-gray-50 p-3 text-sm text-gray-600">
+            <span class="font-medium text-gray-700">Goal:</span> {{ $execution->goal }}
+        </div>
+    @endif
+
+    {{-- Blackboard --}}
+    <div class="mb-8">
+        <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Blackboard
+            <span class="ml-1 font-normal normal-case text-gray-400">(shared board · ephemeral, 24h)</span>
+        </h2>
+        @php($posts = $this->blackboardPosts)
+        @if(empty($posts))
+            <p class="rounded-lg border border-dashed border-gray-200 px-3 py-4 text-center text-sm text-gray-400">
+                No blackboard posts. Posts are stored in Redis with a 24-hour TTL and disappear after that window.
+            </p>
+        @else
+            <div class="space-y-2">
+                @foreach($posts as $post)
+                    <div class="flex items-start gap-2 rounded-lg border border-gray-100 bg-white p-2.5">
+                        <span class="inline-flex shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold
+                            {{ match($post['type'] ?? '') {
+                                'STATUS' => 'bg-blue-50 text-blue-700',
+                                'QUESTION' => 'bg-amber-50 text-amber-700',
+                                'FINDING' => 'bg-green-50 text-green-700',
+                                default => 'bg-gray-100 text-gray-600',
+                            } }}">
+                            {{ $post['type'] ?? '—' }}
+                        </span>
+                        <div class="min-w-0 flex-1">
+                            <div class="mb-0.5 flex items-center gap-1.5">
+                                <span class="text-[10px] font-medium text-gray-600">{{ $post['agent_name'] ?? 'unknown' }}</span>
+                                @if(!empty($post['ts']))
+                                    <span class="text-[10px] text-gray-400">{{ \Illuminate\Support\Carbon::parse($post['ts'])->diffForHumans() }}</span>
+                                @endif
+                            </div>
+                            <div class="whitespace-pre-wrap text-sm text-gray-700">{{ $post['message'] ?? '' }}</div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+
+    {{-- Chat-room transcript --}}
+    @php($chatMessages = $this->chatMessages)
+    @if($chatMessages->isNotEmpty())
+        <div class="mb-8">
+            <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Chat Room Discussion</h2>
+            <div class="space-y-2">
+                @php($currentRound = 0)
+                @foreach($chatMessages as $msg)
+                    @if($msg->round !== $currentRound)
+                        @php($currentRound = $msg->round)
+                        @if($currentRound > 0)
+                            <div class="my-2 flex items-center gap-2">
+                                <div class="h-px flex-1 bg-gray-200"></div>
+                                <span class="text-[10px] font-medium text-gray-400">Round {{ $currentRound }}</span>
+                                <div class="h-px flex-1 bg-gray-200"></div>
+                            </div>
+                        @endif
+                    @endif
+                    <div class="flex gap-2 {{ $msg->role === 'system' ? 'justify-center' : '' }}">
+                        @if($msg->role === 'system')
+                            <div class="rounded-lg bg-gray-100 px-3 py-1.5 text-xs italic text-gray-500">{{ $msg->content }}</div>
+                        @else
+                            <div class="flex-1 rounded-lg border border-gray-100 bg-white p-2.5">
+                                <div class="mb-1 flex items-center gap-1.5">
+                                    <span class="inline-flex rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-700">{{ $msg->agent_name ?? $msg->agent?->name ?? 'agent' }}</span>
+                                    <span class="text-[10px] text-gray-400">{{ $msg->created_at?->diffForHumans() }}</span>
+                                </div>
+                                <div class="whitespace-pre-wrap text-sm text-gray-700">{{ \Illuminate\Support\Str::limit($msg->content, 4000) }}</div>
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
+    {{-- Inter-agent messages --}}
+    <div>
+        <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-500">Inter-Agent Messages</h2>
+        @php($agentMessages = $this->agentMessages)
+        @if($agentMessages->isEmpty())
+            <p class="rounded-lg border border-dashed border-gray-200 px-3 py-4 text-center text-sm text-gray-400">
+                No inter-agent messages for this execution.
+            </p>
+        @else
+            <div class="space-y-2">
+                @php($currentRound = -1)
+                @foreach($agentMessages as $msg)
+                    @if($msg->round !== $currentRound)
+                        @php($currentRound = $msg->round)
+                        <div class="my-2 flex items-center gap-2">
+                            <div class="h-px flex-1 bg-gray-200"></div>
+                            <span class="text-[10px] font-medium text-gray-400">Round {{ $currentRound }}</span>
+                            <div class="h-px flex-1 bg-gray-200"></div>
+                        </div>
+                    @endif
+                    <div class="rounded-lg border border-gray-100 bg-white p-2.5">
+                        <div class="mb-1 flex flex-wrap items-center gap-1.5">
+                            <span class="inline-flex rounded-full bg-indigo-50 px-2 py-0.5 text-[10px] font-semibold text-indigo-700">
+                                {{ $msg->sender?->name ?? 'system' }}
+                            </span>
+                            <i class="fa-solid fa-arrow-right text-[9px] text-gray-300"></i>
+                            <span class="inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold
+                                {{ $msg->recipient_agent_id ? 'bg-gray-100 text-gray-600' : 'bg-purple-50 text-purple-700' }}">
+                                {{ $msg->recipient?->name ?? 'broadcast' }}
+                            </span>
+                            <span class="inline-flex rounded-full bg-gray-50 px-2 py-0.5 text-[10px] font-medium text-gray-500">{{ $msg->message_type }}</span>
+                            <span class="text-[10px] text-gray-400">{{ $msg->created_at?->diffForHumans() }}</span>
+                        </div>
+                        <div class="whitespace-pre-wrap text-sm text-gray-700">{{ \Illuminate\Support\Str::limit($msg->content, 4000) }}</div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/error-modes/error-mode-catalog-page.blade.php
+++ b/resources/views/livewire/error-modes/error-mode-catalog-page.blade.php
@@ -1,0 +1,102 @@
+<div>
+    {{-- Flash messages --}}
+    @if(session()->has('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-3 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    <p class="mb-6 text-sm text-gray-500">
+        Named, clustered production failure modes from the Diagnose stage. Each mode accumulates occurrences over time and points at a remediation lever.
+    </p>
+
+    {{-- Toolbar --}}
+    <div class="mb-6 flex flex-wrap items-center gap-4">
+        <div class="relative flex-1">
+            <x-form-input wire:model.live.debounce.300ms="search" type="text" placeholder="Search error modes...">
+                <x-slot:leadingIcon>
+                    <i class="fa-solid fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 text-base -translate-y-1/2 text-gray-400"></i>
+                </x-slot:leadingIcon>
+            </x-form-input>
+        </div>
+
+        <div class="w-56">
+            <x-form-select wire:model.live="leverFilter" compact>
+                <option value="">All levers</option>
+                @foreach($levers as $lever)
+                    <option value="{{ $lever->value }}">{{ $lever->label() }}</option>
+                @endforeach
+            </x-form-select>
+        </div>
+    </div>
+
+    {{-- Empty state --}}
+    @if($errorModes->isEmpty())
+        <div class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-300 bg-white py-16">
+            <i class="fa-solid fa-bug-slash mb-4 text-5xl text-gray-400"></i>
+            <p class="mb-1 text-sm font-medium text-gray-900">No error modes catalogued yet</p>
+            <p class="text-sm text-gray-500">Error modes appear here as the Diagnose stage clusters production failures.</p>
+        </div>
+    @else
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Error Mode</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Occurrences</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Last Seen</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Lever</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                    @foreach($errorModes as $mode)
+                        <tr class="transition hover:bg-gray-50">
+                            <td class="px-6 py-4">
+                                <p class="font-medium text-gray-900">{{ $mode->name }}</p>
+                                @if($mode->description)
+                                    <p class="mt-0.5 text-xs text-gray-400">{{ \Illuminate\Support\Str::limit($mode->description, 100) }}</p>
+                                @endif
+                            </td>
+                            <td class="px-6 py-4">
+                                <span class="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium
+                                    @class([
+                                        'bg-red-100 text-red-800' => $mode->status === \App\Domain\ErrorMode\Enums\ErrorModeStatus::Open,
+                                        'bg-yellow-100 text-yellow-800' => $mode->status === \App\Domain\ErrorMode\Enums\ErrorModeStatus::Mitigated,
+                                        'bg-gray-100 text-gray-600' => $mode->status === \App\Domain\ErrorMode\Enums\ErrorModeStatus::Closed,
+                                    ])">
+                                    {{ ucfirst($mode->status->value) }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 text-sm font-medium text-gray-700">
+                                {{ number_format($mode->occurrence_count) }}
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-500">
+                                {{ $mode->last_seen_at?->diffForHumans() ?? '—' }}
+                            </td>
+                            <td class="px-6 py-4">
+                                @can('edit-content')
+                                    <select
+                                        wire:change="assignLever('{{ $mode->id }}', $event.target.value)"
+                                        class="rounded-lg border border-gray-300 py-1.5 text-sm focus:border-primary-500 focus:ring-primary-500">
+                                        @foreach($levers as $lever)
+                                            <option value="{{ $lever->value }}" @selected($mode->lever === $lever)>{{ $lever->label() }}</option>
+                                        @endforeach
+                                    </select>
+                                @else
+                                    <span class="inline-flex items-center rounded-full bg-indigo-100 px-2.5 py-0.5 text-xs font-medium text-indigo-800">
+                                        {{ $mode->lever->label() }}
+                                    </span>
+                                @endcan
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+            </div>
+        </div>
+
+        <div class="mt-4">
+            {{ $errorModes->links() }}
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/evaluation/drift-signals-page.blade.php
+++ b/resources/views/livewire/evaluation/drift-signals-page.blade.php
@@ -1,0 +1,61 @@
+<div>
+    {{-- Filters --}}
+    <form class="mb-6 flex flex-wrap items-center gap-4" onsubmit="return false">
+        <x-form-select wire:model.live="typeFilter">
+            <option value="">All Signal Types</option>
+            @foreach($signalTypes as $type)
+                <option value="{{ $type->value }}">{{ $type->label() }}</option>
+            @endforeach
+        </x-form-select>
+
+        <x-form-select wire:model.live="breachFilter">
+            <option value="">All Statuses</option>
+            <option value="breached">Breached</option>
+            <option value="ok">Within baseline</option>
+        </x-form-select>
+    </form>
+
+    {{-- Table --}}
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+        <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Signal</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Value</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Baseline</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Window</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Detected</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse($signals as $signal)
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4 text-sm font-medium text-gray-900">{{ $signal->signal_type->label() }}</td>
+                        <td class="px-6 py-4 text-sm">
+                            @if($signal->breached)
+                                <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">Breached</span>
+                            @else
+                                <span class="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">OK</span>
+                            @endif
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-700">{{ $signal->value !== null ? number_format($signal->value, 4) : '—' }}</td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500">{{ $signal->baseline !== null ? number_format($signal->baseline, 4) : '—' }}</td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500">{{ $signal->window ?? '—' }}</td>
+                        <td class="px-6 py-4 text-sm text-gray-500" title="{{ $signal->detected_at }}">{{ $signal->detected_at->diffForHumans() }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="6" class="px-6 py-12 text-center text-sm text-gray-400">No drift signals recorded yet.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+        </div>
+    </div>
+
+    <div class="mt-4">
+        {{ $signals->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/evaluation/eval-monitor-page.blade.php
+++ b/resources/views/livewire/evaluation/eval-monitor-page.blade.php
@@ -1,0 +1,51 @@
+<div>
+    {{-- Filters --}}
+    <form class="mb-6 flex flex-wrap items-center gap-4" onsubmit="return false">
+        <x-form-select wire:model.live="period">
+            <option value="24h">Last 24 hours</option>
+            <option value="7d">Last 7 days</option>
+            <option value="30d">Last 30 days</option>
+            <option value="all">All time</option>
+        </x-form-select>
+    </form>
+
+    {{-- Table --}}
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+        <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Captured</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Dataset</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Avg Score</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Pass Rate</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Sampled</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Active</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Deferred Passed</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse($snapshots as $snapshot)
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4 text-sm text-gray-700" title="{{ $snapshot->created_at }}">{{ $snapshot->created_at->diffForHumans() }}</td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500">{{ $snapshot->dataset?->name ?? '—' }}</td>
+                        <td class="px-6 py-4 text-sm text-gray-900">{{ $snapshot->avg_score !== null ? number_format($snapshot->avg_score, 2) : '—' }}</td>
+                        <td class="px-6 py-4 text-sm text-gray-700">{{ $snapshot->pass_rate !== null ? number_format($snapshot->pass_rate, 2).'%' : '—' }}</td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500">{{ $snapshot->sampled_count }}</td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500">{{ $snapshot->active_count }}</td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500">{{ $snapshot->deferred_passed }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="7" class="px-6 py-12 text-center text-sm text-gray-400">No monitor snapshots in this period.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+        </div>
+    </div>
+
+    <div class="mt-4">
+        {{ $snapshots->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/experiments/experiment-checkpoints-page.blade.php
+++ b/resources/views/livewire/experiments/experiment-checkpoints-page.blade.php
@@ -1,0 +1,94 @@
+<div class="mx-auto max-w-5xl space-y-6 p-4 sm:p-6">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+            <a href="{{ route('experiments.show', $this->experiment) }}"
+               class="text-sm text-primary-600 hover:text-primary-700">&larr; Back to experiment</a>
+            <h1 class="mt-1 text-xl font-semibold text-gray-900">Checkpoints</h1>
+            <p class="text-sm text-gray-500">{{ $this->experiment->title }}</p>
+        </div>
+
+        @if($this->checkpoints->isNotEmpty())
+            <button type="button"
+                    wire:click="$set('showResumeConfirm', true)"
+                    class="inline-flex items-center rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700">
+                Resume from latest checkpoint
+            </button>
+        @endif
+    </div>
+
+    @if(session('message'))
+        <div class="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+            {{ session('message') }}
+        </div>
+    @endif
+    @if(session('error'))
+        <div class="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            {{ session('error') }}
+        </div>
+    @endif
+
+    <div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+        Resume re-triggers execution from the <strong>most recent</strong> checkpoint, preserving each step's
+        saved state. The list below is informational — there is no per-checkpoint rollback.
+    </div>
+
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Step</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Version</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Worker</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Idempotency key</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Last heartbeat</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Updated</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                    @forelse($this->checkpoints as $step)
+                        <tr>
+                            <td class="px-4 py-3 text-sm font-medium text-gray-900">#{{ $step->order }}</td>
+                            <td class="px-4 py-3"><x-status-badge :status="$step->status" /></td>
+                            <td class="px-4 py-3 text-sm text-gray-600">{{ $step->checkpoint_version ?? '-' }}</td>
+                            <td class="px-4 py-3 font-mono text-xs text-gray-500">{{ $step->worker_id ?? '-' }}</td>
+                            <td class="px-4 py-3 max-w-xs truncate font-mono text-xs text-gray-500">{{ $step->idempotency_key ?? '-' }}</td>
+                            <td class="px-4 py-3 text-xs text-gray-500">{{ $step->last_heartbeat_at?->diffForHumans() ?? '-' }}</td>
+                            <td class="px-4 py-3 text-xs text-gray-500">{{ $step->updated_at?->diffForHumans() ?? '-' }}</td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7" class="px-4 py-8 text-center text-sm text-gray-400">
+                                No checkpoints recorded for this experiment.
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    @if($showResumeConfirm)
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+            <div class="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+                <h2 class="text-lg font-semibold text-gray-900">Resume from checkpoint?</h2>
+                <p class="mt-2 text-sm text-gray-600">
+                    This re-triggers execution from the most recent checkpoint. Saved step state is preserved.
+                </p>
+                <div class="mt-6 flex justify-end gap-3">
+                    <button type="button"
+                            wire:click="$set('showResumeConfirm', false)"
+                            class="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                        Cancel
+                    </button>
+                    <button type="button"
+                            wire:click="resumeFromCheckpoint"
+                            class="rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700">
+                        Resume
+                    </button>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/experiments/reasoning-bank-page.blade.php
+++ b/resources/views/livewire/experiments/reasoning-bank-page.blade.php
@@ -1,0 +1,83 @@
+<div>
+    {{-- Filters --}}
+    <form class="mb-6 flex flex-wrap items-center gap-4" onsubmit="return false">
+        <div class="relative flex-1">
+            <x-form-input wire:model.live.debounce.300ms="search" type="text" placeholder="Search goal or outcome..." class="pl-10">
+                <x-slot:leadingIcon>
+                    <i class="fa-solid fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base text-gray-400"></i>
+                </x-slot:leadingIcon>
+            </x-form-input>
+        </div>
+    </form>
+
+    {{-- Table --}}
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+        <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Goal</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Outcome</th>
+                    <th class="hidden lg:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Source Experiment</th>
+                    <th class="hidden md:table-cell px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Recorded</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500"></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse($entries as $entry)
+                    <tr class="hover:bg-gray-50 cursor-pointer" wire:click="toggleExpand('{{ $entry->id }}')">
+                        <td class="px-6 py-4 text-sm text-gray-900 max-w-md truncate">{{ $entry->goal_text }}</td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500 max-w-md truncate">{{ $entry->outcome_summary }}</td>
+                        <td class="hidden lg:table-cell px-6 py-4 text-sm text-gray-500">
+                            @if($entry->experiment)
+                                <a href="{{ route('experiments.show', $entry->experiment_id) }}" class="text-primary-600 hover:underline" wire:click.stop>
+                                    {{ $entry->experiment->title }}
+                                </a>
+                            @else
+                                <span class="text-gray-400">—</span>
+                            @endif
+                        </td>
+                        <td class="hidden md:table-cell px-6 py-4 text-sm text-gray-500">{{ $entry->created_at->diffForHumans() }}</td>
+                        <td class="px-6 py-4 text-sm text-gray-400">
+                            <i class="fa-solid fa-chevron-right text-base transition {{ $expandedId === $entry->id ? 'rotate-90' : '' }}"></i>
+                        </td>
+                    </tr>
+
+                    @if($expandedId === $entry->id)
+                        <tr>
+                            <td colspan="5" class="bg-gray-50 px-6 py-4">
+                                <div class="mb-3">
+                                    <p class="text-xs font-semibold text-gray-500 uppercase">Goal</p>
+                                    <p class="mt-1 text-sm text-gray-800">{{ $entry->goal_text }}</p>
+                                </div>
+                                <div class="mb-3">
+                                    <p class="text-xs font-semibold text-gray-500 uppercase">Outcome Summary</p>
+                                    <p class="mt-1 text-sm text-gray-800">{{ $entry->outcome_summary }}</p>
+                                </div>
+                                @if(! empty($entry->tool_sequence))
+                                    <div>
+                                        <p class="text-xs font-semibold text-gray-500 uppercase">Tool Sequence</p>
+                                        <div class="mt-1 flex flex-wrap gap-1.5">
+                                            @foreach($entry->tool_sequence as $tool)
+                                                <span class="inline-flex items-center rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-800">{{ is_string($tool) ? $tool : json_encode($tool) }}</span>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                @endif
+                            </td>
+                        </tr>
+                    @endif
+                @empty
+                    <tr>
+                        <td colspan="5" class="px-6 py-12 text-center text-sm text-gray-400">No reasoning bank entries yet. Lessons are distilled automatically as experiments complete.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+        </div>
+    </div>
+
+    <div class="mt-4">
+        {{ $entries->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/knowledge-graph/kg-communities-page.blade.php
+++ b/resources/views/livewire/knowledge-graph/kg-communities-page.blade.php
@@ -1,0 +1,118 @@
+<div class="space-y-6">
+    {{-- Stats --}}
+    <div class="grid grid-cols-3 gap-4">
+        <div class="rounded-xl border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium uppercase tracking-wider text-gray-500">Communities</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900">{{ number_format($stats['total']) }}</p>
+        </div>
+        <div class="rounded-xl border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium uppercase tracking-wider text-gray-500">Largest Cluster</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900">{{ number_format($stats['largest']) }}</p>
+        </div>
+        <div class="rounded-xl border border-gray-200 bg-white p-4">
+            <p class="text-xs font-medium uppercase tracking-wider text-gray-500">Clustered Entities</p>
+            <p class="mt-1 text-2xl font-bold text-gray-900">{{ number_format($stats['entities']) }}</p>
+        </div>
+    </div>
+
+    {{-- Flash messages --}}
+    @if($success)
+        <div class="rounded-lg bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-800">{{ $success }}</div>
+    @endif
+    @if($error)
+        <div class="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-800">{{ $error }}</div>
+    @endif
+
+    {{-- Filters + Rebuild --}}
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div class="flex-1">
+            <input wire:model.live.debounce.300ms="search" type="text"
+                   placeholder="Search communities by label..."
+                   class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-500 focus:ring-primary-500" />
+        </div>
+        @can('edit-content')
+            <button wire:click="rebuild" wire:loading.attr="disabled"
+                    class="inline-flex items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-60">
+                <i class="fa-solid fa-arrows-rotate text-base" wire:loading.remove wire:target="rebuild"></i>
+                <i class="fa-solid fa-spinner fa-spin text-base" wire:loading wire:target="rebuild"></i>
+                Rebuild Communities
+            </button>
+        @endcan
+    </div>
+
+    {{-- Communities list --}}
+    <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Label</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Size</th>
+                    <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Top Entities</th>
+                    <th class="px-4 py-3"></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse($communities as $community)
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-4 py-3 align-top">
+                            <p class="text-sm font-medium text-gray-900">{{ $community->label ?: 'Unlabeled cluster' }}</p>
+                            @if($community->summary)
+                                <p class="mt-0.5 text-xs text-gray-500 line-clamp-2">{{ $community->summary }}</p>
+                            @endif
+                        </td>
+                        <td class="px-4 py-3 align-top">
+                            <span class="inline-flex items-center rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700">
+                                {{ number_format($community->size) }}
+                            </span>
+                        </td>
+                        <td class="px-4 py-3 align-top">
+                            <div class="flex flex-wrap gap-1">
+                                @foreach(array_slice($community->top_entities ?? [], 0, 5) as $entity)
+                                    <span class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-2 py-0.5 text-xs text-gray-700">
+                                        {{ $entity['name'] ?? '—' }}
+                                        @if(isset($entity['type']))
+                                            <span class="text-gray-400">{{ $entity['type'] }}</span>
+                                        @endif
+                                    </span>
+                                @endforeach
+                                @if(empty($community->top_entities))
+                                    <span class="text-xs text-gray-400">—</span>
+                                @endif
+                            </div>
+                        </td>
+                        <td class="px-4 py-3 align-top text-right">
+                            <button wire:click="toggleExpanded('{{ $community->id }}')"
+                                    class="text-xs font-medium text-primary-600 hover:text-primary-700">
+                                {{ $expandedId === $community->id ? 'Hide members' : 'View members' }}
+                            </button>
+                        </td>
+                    </tr>
+                    @if($expandedId === $community->id)
+                        <tr class="bg-gray-50">
+                            <td colspan="4" class="px-4 py-3">
+                                <p class="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500">
+                                    Member entity IDs ({{ count($community->entity_ids ?? []) }})
+                                </p>
+                                <div class="flex flex-wrap gap-1">
+                                    @foreach($community->entity_ids ?? [] as $entityId)
+                                        <span class="inline-flex items-center rounded-md bg-white border border-gray-200 px-2 py-0.5 font-mono text-[11px] text-gray-600">
+                                            {{ $entityId }}
+                                        </span>
+                                    @endforeach
+                                </div>
+                            </td>
+                        </tr>
+                    @endif
+                @empty
+                    <tr>
+                        <td colspan="4" class="px-4 py-12 text-center text-sm text-gray-500">
+                            No communities yet. Build the knowledge graph, then rebuild communities to surface clusters.
+                        </td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div>{{ $communities->links() }}</div>
+</div>

--- a/resources/views/livewire/memory/memory-proposals-page.blade.php
+++ b/resources/views/livewire/memory/memory-proposals-page.blade.php
@@ -1,0 +1,138 @@
+<div class="space-y-6">
+    @if (session('message'))
+        <div class="rounded-md bg-green-50 border border-green-200 px-4 py-3 text-sm text-green-800">
+            {{ session('message') }}
+        </div>
+    @endif
+    @if (session('error'))
+        <div class="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-800">
+            {{ session('error') }}
+        </div>
+    @endif
+
+    <div class="flex items-center justify-between gap-4">
+        <div>
+            <h2 class="text-lg font-semibold text-gray-900">Proposal Review Queue</h2>
+            <p class="text-sm text-gray-500">
+                Agent-extracted memories awaiting human review. Approve to promote into a curated tier, or reject with a reason.
+            </p>
+        </div>
+        <a href="{{ route('memory.index') }}" class="text-sm text-primary-600 hover:text-primary-700 whitespace-nowrap">
+            Browse all memories &rarr;
+        </a>
+    </div>
+
+    <div class="max-w-sm">
+        <x-form-input
+            wire:model.live.debounce.300ms="search"
+            name="search"
+            placeholder="Search proposal content..."
+            compact
+        />
+    </div>
+
+    <div class="space-y-3">
+        @forelse ($proposals as $memory)
+            <div class="rounded-lg border border-gray-200 bg-white shadow-sm" wire:key="proposal-{{ $memory->id }}">
+                <div class="p-4">
+                    <div class="flex items-start justify-between gap-4">
+                        <div class="min-w-0 flex-1">
+                            <p class="text-sm text-gray-900 {{ $expandedId === $memory->id ? '' : 'line-clamp-3' }}">
+                                {{ $memory->content }}
+                            </p>
+                            <div class="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500">
+                                <span>Proposed by <span class="font-medium text-gray-700">{{ $memory->proposed_by ?? 'unknown' }}</span></span>
+                                @if ($memory->agent)
+                                    <span>Agent: {{ $memory->agent->name }}</span>
+                                @endif
+                                @if ($memory->project)
+                                    <span>Project: {{ $memory->project->title }}</span>
+                                @endif
+                                <span>Confidence: {{ number_format((float) ($memory->confidence ?? 0), 2) }}</span>
+                                <span>{{ $memory->created_at?->diffForHumans() }}</span>
+                            </div>
+                            @if (! empty($memory->tags))
+                                <div class="mt-2 flex flex-wrap gap-1">
+                                    @foreach ($memory->tags as $tag)
+                                        <span class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">{{ $tag }}</span>
+                                    @endforeach
+                                </div>
+                            @endif
+                            <button
+                                type="button"
+                                wire:click="toggleExpand('{{ $memory->id }}')"
+                                class="mt-2 text-xs text-primary-600 hover:text-primary-700"
+                            >
+                                {{ $expandedId === $memory->id ? 'Show less' : 'Show more' }}
+                            </button>
+                        </div>
+                    </div>
+
+                    @if ($rejectingId === $memory->id)
+                        <div class="mt-4 space-y-2 rounded-md bg-red-50 border border-red-200 p-3">
+                            <x-form-textarea
+                                wire:model="rejectReason"
+                                name="rejectReason"
+                                label="Rejection reason"
+                                placeholder="Why is this proposal being rejected?"
+                                rows="2"
+                            />
+                            <div class="flex items-center gap-2">
+                                <button
+                                    type="button"
+                                    wire:click="reject('{{ $memory->id }}')"
+                                    class="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+                                >
+                                    Confirm reject
+                                </button>
+                                <button
+                                    type="button"
+                                    wire:click="cancelReject"
+                                    class="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+                    @else
+                        <div class="mt-4 flex flex-wrap items-center gap-2">
+                            <div class="flex items-center gap-2">
+                                <select
+                                    wire:model="approveTier.{{ $memory->id }}"
+                                    class="rounded-md border border-gray-300 py-1.5 text-sm focus:border-primary-500 focus:ring-primary-500"
+                                >
+                                    @foreach ($curatedTiers as $tier)
+                                        <option value="{{ $tier->value }}">{{ ucfirst($tier->value) }}</option>
+                                    @endforeach
+                                </select>
+                                <button
+                                    type="button"
+                                    wire:click="approve('{{ $memory->id }}')"
+                                    class="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700"
+                                >
+                                    Approve
+                                </button>
+                            </div>
+                            <button
+                                type="button"
+                                wire:click="startReject('{{ $memory->id }}')"
+                                class="rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50"
+                            >
+                                Reject
+                            </button>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        @empty
+            <div class="rounded-lg border border-dashed border-gray-300 bg-white p-10 text-center">
+                <p class="text-sm font-medium text-gray-900">No proposals to review</p>
+                <p class="mt-1 text-sm text-gray-500">Agent-proposed memories awaiting review will appear here.</p>
+            </div>
+        @endforelse
+    </div>
+
+    <div>
+        {{ $proposals->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/migration/import-wizard-page.blade.php
+++ b/resources/views/livewire/migration/import-wizard-page.blade.php
@@ -1,0 +1,159 @@
+<div class="mx-auto max-w-3xl space-y-6 p-4">
+    {{-- Step indicator --}}
+    <ol class="flex items-center gap-2 text-sm">
+        @foreach (['Upload', 'Map columns', 'Result'] as $i => $label)
+            <li class="flex items-center gap-2">
+                <span @class([
+                    'flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold',
+                    'bg-primary-600 text-white' => $step >= $i + 1,
+                    'bg-(--color-surface-alt) text-(--color-on-surface-muted)' => $step < $i + 1,
+                ])>{{ $i + 1 }}</span>
+                <span @class([
+                    'font-medium' => $step === $i + 1,
+                    'text-(--color-on-surface-muted)' => $step !== $i + 1,
+                ])>{{ $label }}</span>
+                @unless ($loop->last)
+                    <span class="mx-1 text-(--color-on-surface-muted)">&rarr;</span>
+                @endunless
+            </li>
+        @endforeach
+    </ol>
+
+    @if ($error)
+        <div class="rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {{ $error }}
+        </div>
+    @endif
+
+    {{-- Step 1: Upload + target importer --}}
+    @if ($step === 1)
+        <div class="space-y-4 rounded-xl border border-(--color-input-border) bg-(--color-surface) p-6">
+            <h2 class="text-lg font-semibold text-(--color-on-surface)">Upload a CSV export</h2>
+            <p class="text-sm text-(--color-on-surface-muted)">
+                Export contacts from your previous tool (Salesforce, HubSpot, Intercom&hellip;) as CSV.
+                We&rsquo;ll propose a column mapping for you to confirm.
+            </p>
+
+            <x-form-select wire:model="entityType" label="Import into" id="entityType"
+                :error="$errors->first('entityType')">
+                @foreach ($entityTypes as $type)
+                    <option value="{{ $type->value }}">{{ $type->label() }}</option>
+                @endforeach
+            </x-form-select>
+
+            <div>
+                <label class="mb-1 block text-sm font-medium text-(--color-on-surface)">CSV file</label>
+                <input type="file" wire:model="file" accept=".csv,text/csv"
+                    class="block w-full text-sm text-(--color-on-surface) file:mr-4 file:rounded-lg file:border-0 file:bg-primary-600 file:px-4 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-primary-700" />
+                @error('file')
+                    <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                @enderror
+                <div wire:loading wire:target="file" class="mt-1 text-xs text-(--color-on-surface-muted)">
+                    Uploading&hellip;
+                </div>
+            </div>
+
+            <div class="flex justify-end">
+                <button type="button" wire:click="detect" wire:loading.attr="disabled" wire:target="detect,file"
+                    class="rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="detect">Detect mapping</span>
+                    <span wire:loading wire:target="detect">Analysing&hellip;</span>
+                </button>
+            </div>
+        </div>
+    @endif
+
+    {{-- Step 2: Confirm / adjust mapping --}}
+    @if ($step === 2)
+        <div class="space-y-4 rounded-xl border border-(--color-input-border) bg-(--color-surface) p-6">
+            <h2 class="text-lg font-semibold text-(--color-on-surface)">Confirm column mapping</h2>
+            <p class="text-sm text-(--color-on-surface-muted)">
+                Each source column maps to a FleetQ attribute. Leave a column <em>Unmapped</em> to drop it
+                (text columns land in <code>metadata</code> via the importer).
+            </p>
+
+            @if ($run && ! empty($run->stats['warnings']))
+                <ul class="rounded-lg border border-amber-300 bg-amber-50 px-4 py-2 text-xs text-amber-800">
+                    @foreach ($run->stats['warnings'] as $warning)
+                        <li>&bull; {{ $warning }}</li>
+                    @endforeach
+                </ul>
+            @endif
+
+            <div class="space-y-2">
+                @forelse ($mapping as $header => $target)
+                    <div class="flex items-center gap-3" wire:key="map-{{ $loop->index }}">
+                        <div class="w-1/2 truncate font-mono text-sm text-(--color-on-surface)" title="{{ $header }}">
+                            {{ $header }}
+                        </div>
+                        <span class="text-(--color-on-surface-muted)">&rarr;</span>
+                        <div class="w-1/2">
+                            <x-form-select wire:model="mapping.{{ $header }}" compact>
+                                <option value="">— Unmapped —</option>
+                                @foreach ($supportedAttributes as $attr => $desc)
+                                    <option value="{{ $attr }}">{{ $attr }}</option>
+                                @endforeach
+                            </x-form-select>
+                        </div>
+                    </div>
+                @empty
+                    <p class="text-sm text-(--color-on-surface-muted)">No columns were detected in this file.</p>
+                @endforelse
+            </div>
+
+            <div class="flex items-center justify-between pt-2">
+                <button type="button" wire:click="backToUpload"
+                    class="rounded-lg border border-(--color-input-border) px-4 py-2.5 text-sm font-medium text-(--color-on-surface) hover:bg-(--color-surface-alt)">
+                    Start over
+                </button>
+                <button type="button" wire:click="import" wire:loading.attr="disabled" wire:target="import"
+                    class="rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="import">Run import</span>
+                    <span wire:loading wire:target="import">Importing&hellip;</span>
+                </button>
+            </div>
+        </div>
+    @endif
+
+    {{-- Step 3: Result --}}
+    @if ($step === 3)
+        <div class="space-y-4 rounded-xl border border-(--color-input-border) bg-(--color-surface) p-6">
+            <h2 class="text-lg font-semibold text-(--color-on-surface)">Import {{ $run?->status->value }}</h2>
+
+            @if ($run)
+                <div class="grid grid-cols-2 gap-3 sm:grid-cols-5">
+                    @foreach (['total' => 'Total', 'created' => 'Created', 'updated' => 'Updated', 'skipped' => 'Skipped', 'failed' => 'Failed'] as $key => $label)
+                        <div class="rounded-lg bg-(--color-surface-alt) p-3 text-center">
+                            <div class="text-2xl font-semibold text-(--color-on-surface)">{{ $run->stats[$key] ?? 0 }}</div>
+                            <div class="text-xs text-(--color-on-surface-muted)">{{ $label }}</div>
+                        </div>
+                    @endforeach
+                </div>
+
+                @if (! empty($run->errors))
+                    <details class="rounded-lg border border-(--color-input-border) p-3 text-sm">
+                        <summary class="cursor-pointer font-medium text-(--color-on-surface)">
+                            {{ count($run->errors) }} row issue(s)
+                        </summary>
+                        <ul class="mt-2 space-y-1 text-xs text-(--color-on-surface-muted)">
+                            @foreach (array_slice($run->errors, 0, 50) as $err)
+                                <li>Row {{ $err['row'] ?? '?' }}: {{ $err['message'] ?? '' }}</li>
+                            @endforeach
+                        </ul>
+                    </details>
+                @endif
+            @endif
+
+            <div class="flex justify-end gap-3 pt-2">
+                <button type="button" wire:click="backToUpload"
+                    class="rounded-lg border border-(--color-input-border) px-4 py-2.5 text-sm font-medium text-(--color-on-surface) hover:bg-(--color-surface-alt)">
+                    Import another file
+                </button>
+                <a href="{{ route('contacts.index') }}"
+                    class="rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700">
+                    View contacts
+                </a>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/outbound-connectors/discord-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/discord-outbound-page.blade.php
@@ -1,0 +1,77 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Discord Webhook</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    In a Discord channel, open <em>Edit Channel → Integrations → Webhooks</em>, create a webhook and copy
+                    its URL. Testing posts a message to that channel.
+                </p>
+            </div>
+            <div class="p-6">
+                <x-form-input
+                    wire:model="webhookUrl"
+                    type="password"
+                    label="Webhook URL"
+                    placeholder="{{ $lastTestedAt ? '(leave blank to keep existing)' : 'https://discord.com/api/webhooks/…' }}"
+                    autocomplete="new-password"
+                >
+                    <x-slot:hint>e.g. <code class="rounded bg-gray-100 px-1 text-xs">https://discord.com/api/webhooks/…/…</code></x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/outbound-connectors/google-chat-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/google-chat-outbound-page.blade.php
@@ -1,0 +1,77 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Google Chat Webhook</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    In a Google Chat space, open <em>Apps &amp; integrations → Webhooks</em>, create an incoming webhook
+                    and paste its URL. Testing posts a message to that space.
+                </p>
+            </div>
+            <div class="p-6">
+                <x-form-input
+                    wire:model="webhookUrl"
+                    type="password"
+                    label="Webhook URL"
+                    placeholder="{{ $lastTestedAt ? '(leave blank to keep existing)' : 'https://chat.googleapis.com/v1/spaces/…' }}"
+                    autocomplete="new-password"
+                >
+                    <x-slot:hint>e.g. <code class="rounded bg-gray-100 px-1 text-xs">https://chat.googleapis.com/v1/spaces/…/messages?key=…&token=…</code></x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/outbound-connectors/slack-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/slack-outbound-page.blade.php
@@ -1,0 +1,78 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Slack Incoming Webhook</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    Create an
+                    <a href="https://api.slack.com/messaging/webhooks" target="_blank" rel="noopener" class="text-primary-600 hover:text-primary-800">Incoming Webhook</a>
+                    in your Slack workspace and paste the URL below. Testing sends a message to the connected channel.
+                </p>
+            </div>
+            <div class="p-6">
+                <x-form-input
+                    wire:model="webhookUrl"
+                    type="password"
+                    label="Webhook URL"
+                    placeholder="{{ $lastTestedAt ? '(leave blank to keep existing)' : 'https://hooks.slack.com/services/…' }}"
+                    autocomplete="new-password"
+                >
+                    <x-slot:hint>e.g. <code class="rounded bg-gray-100 px-1 text-xs">https://hooks.slack.com/services/T…/B…/…</code></x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/outbound-connectors/teams-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/teams-outbound-page.blade.php
@@ -1,0 +1,77 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Microsoft Teams Webhook</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    Create a <strong>Workflows</strong> (Power Automate) "Post to a channel when a webhook request is
+                    received" flow and paste its HTTP URL below. Testing posts an Adaptive Card to that channel.
+                </p>
+            </div>
+            <div class="p-6">
+                <x-form-input
+                    wire:model="webhookUrl"
+                    type="password"
+                    label="Workflow Webhook URL"
+                    placeholder="{{ $lastTestedAt ? '(leave blank to keep existing)' : 'https://prod-….logic.azure.com/…' }}"
+                    autocomplete="new-password"
+                >
+                    <x-slot:hint>Power Automate Workflows HTTP trigger URL. Legacy Office 365 connectors are deprecated.</x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/outbound-connectors/telegram-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/telegram-outbound-page.blade.php
@@ -1,0 +1,86 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Telegram Bot API Credentials</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    Create a bot with <a href="https://t.me/BotFather" target="_blank" rel="noopener" class="text-primary-600 hover:text-primary-800">@BotFather</a>
+                    and paste the token below.
+                </p>
+            </div>
+            <div class="grid grid-cols-1 gap-5 p-6 sm:grid-cols-2">
+                <x-form-input
+                    wire:model="botToken"
+                    type="password"
+                    label="Bot Token"
+                    placeholder="{{ $lastTestedAt || $chatId ? '(leave blank to keep existing)' : '123456:ABC-DEF…' }}"
+                    autocomplete="new-password"
+                >
+                    <x-slot:hint>Token from BotFather, e.g. <code class="rounded bg-gray-100 px-1 text-xs">123456:ABC-DEF…</code></x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="chatId"
+                    label="Default Chat ID"
+                    placeholder="-1001234567890"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Optional. Used when a proposal target doesn't specify a chat_id.</x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/outbound/blacklist-page.blade.php
+++ b/resources/views/livewire/outbound/blacklist-page.blade.php
@@ -1,0 +1,70 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    <div class="space-y-6">
+        {{-- Add entry --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Block a target</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    Blocked entries prevent outbound messages from being delivered. Matching is done on the
+                    recipient email, its domain, the company, or keywords found in message content.
+                </p>
+            </div>
+            <div class="grid grid-cols-1 gap-5 p-6 sm:grid-cols-3">
+                <x-form-select wire:model="type" label="Type">
+                    <option value="email">Email</option>
+                    <option value="domain">Domain</option>
+                    <option value="company">Company</option>
+                    <option value="keyword">Keyword</option>
+                </x-form-select>
+                <x-form-input wire:model="value" label="Value" placeholder="spam@example.com" />
+                <x-form-input wire:model="reason" label="Reason" placeholder="Optional" />
+            </div>
+            <div class="flex justify-end border-t border-gray-200 px-6 py-4">
+                <button wire:click="add" wire:loading.attr="disabled"
+                    class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                    Add to Blacklist
+                </button>
+            </div>
+        </div>
+
+        {{-- List --}}
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+                <thead>
+                    <tr class="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                        <th class="px-6 py-3">Type</th>
+                        <th class="px-6 py-3">Value</th>
+                        <th class="px-6 py-3">Reason</th>
+                        <th class="px-6 py-3">Added</th>
+                        <th class="px-6 py-3 text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @forelse ($entries as $entry)
+                        <tr class="hover:bg-gray-50" wire:key="entry-{{ $entry->id }}">
+                            <td class="px-6 py-3">
+                                <span class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">{{ $entry->type }}</span>
+                            </td>
+                            <td class="px-6 py-3 font-mono text-gray-900">{{ $entry->value }}</td>
+                            <td class="px-6 py-3 text-gray-500">{{ $entry->reason ?? '—' }}</td>
+                            <td class="px-6 py-3 text-gray-500">{{ $entry->created_at?->diffForHumans() ?? '—' }}</td>
+                            <td class="px-6 py-3 text-right">
+                                <button wire:click="remove('{{ $entry->id }}')"
+                                    wire:confirm="Remove this blacklist entry?"
+                                    class="text-sm font-medium text-red-600 hover:text-red-800">Remove</button>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="5" class="px-6 py-8 text-center text-gray-400">No blacklist entries yet.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <div>{{ $entries->links() }}</div>
+    </div>
+</div>

--- a/resources/views/livewire/outbound/outbound-proposals-page.blade.php
+++ b/resources/views/livewire/outbound/outbound-proposals-page.blade.php
@@ -1,0 +1,102 @@
+<div>
+    <div class="space-y-6">
+        <div class="rounded-lg bg-blue-50 px-4 py-3 text-sm text-blue-700">
+            Proposals are reviewed and approved or rejected from the
+            <a href="{{ route('approvals.index') }}" wire:navigate class="font-medium underline">Approval Inbox</a>.
+            This page is read-only.
+        </div>
+
+        {{-- Status filter --}}
+        <div class="flex flex-wrap gap-2">
+            <button wire:click="$set('statusFilter', '')"
+                @class([
+                    'rounded-full px-3 py-1 text-sm font-medium',
+                    'bg-primary-600 text-white' => $statusFilter === '',
+                    'bg-gray-100 text-gray-600 hover:bg-gray-200' => $statusFilter !== '',
+                ])>
+                All
+            </button>
+            @foreach ($statuses as $status)
+                <button wire:click="$set('statusFilter', '{{ $status->value }}')"
+                    @class([
+                        'rounded-full px-3 py-1 text-sm font-medium',
+                        'bg-primary-600 text-white' => $statusFilter === $status->value,
+                        'bg-gray-100 text-gray-600 hover:bg-gray-200' => $statusFilter !== $status->value,
+                    ])>
+                    {{ ucwords(str_replace('_', ' ', $status->value)) }}
+                    <span class="ml-1 text-xs opacity-75">{{ $counts[$status->value] ?? 0 }}</span>
+                </button>
+            @endforeach
+        </div>
+
+        {{-- List --}}
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+                <thead>
+                    <tr class="text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                        <th class="px-6 py-3">Status</th>
+                        <th class="px-6 py-3">Channel</th>
+                        <th class="px-6 py-3">Target</th>
+                        <th class="px-6 py-3">Risk</th>
+                        <th class="px-6 py-3">Created</th>
+                        <th class="px-6 py-3 text-right">Content</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @forelse ($proposals as $proposal)
+                        <tr class="hover:bg-gray-50" wire:key="proposal-{{ $proposal->id }}">
+                            <td class="px-6 py-3">
+                                <span @class([
+                                    'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+                                    'bg-yellow-100 text-yellow-800' => $proposal->status === \App\Domain\Outbound\Enums\OutboundProposalStatus::PendingApproval,
+                                    'bg-green-100 text-green-800' => $proposal->status === \App\Domain\Outbound\Enums\OutboundProposalStatus::Approved,
+                                    'bg-red-100 text-red-800' => $proposal->status === \App\Domain\Outbound\Enums\OutboundProposalStatus::Rejected,
+                                    'bg-gray-100 text-gray-600' => in_array($proposal->status, [\App\Domain\Outbound\Enums\OutboundProposalStatus::Expired, \App\Domain\Outbound\Enums\OutboundProposalStatus::Cancelled], true),
+                                ])>{{ ucwords(str_replace('_', ' ', $proposal->status->value)) }}</span>
+                            </td>
+                            <td class="px-6 py-3 text-gray-700">{{ $proposal->channel->value }}</td>
+                            <td class="px-6 py-3 font-mono text-gray-700">
+                                {{ $proposal->target['email'] ?? $proposal->target['company'] ?? '—' }}
+                            </td>
+                            <td class="px-6 py-3 text-gray-500">{{ number_format((float) $proposal->risk_score, 2) }}</td>
+                            <td class="px-6 py-3 text-gray-500">{{ $proposal->created_at?->diffForHumans() ?? '—' }}</td>
+                            <td class="px-6 py-3 text-right">
+                                <button wire:click="toggle('{{ $proposal->id }}')"
+                                    class="text-sm font-medium text-primary-600 hover:text-primary-800">
+                                    {{ $expandedId === $proposal->id ? 'Hide' : 'View' }}
+                                </button>
+                            </td>
+                        </tr>
+                        @if ($expandedId === $proposal->id)
+                            <tr wire:key="proposal-detail-{{ $proposal->id }}">
+                                <td colspan="6" class="bg-gray-50 px-6 py-4">
+                                    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                                        <div>
+                                            <h3 class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">Target</h3>
+                                            <pre class="overflow-x-auto rounded-lg bg-white p-3 text-xs text-gray-700">{{ json_encode($proposal->target, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                                        </div>
+                                        <div>
+                                            <h3 class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">Content</h3>
+                                            <pre class="overflow-x-auto rounded-lg bg-white p-3 text-xs text-gray-700">{{ json_encode($proposal->content, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                                        </div>
+                                    </div>
+                                    @if ($proposal->experiment)
+                                        <p class="mt-3 text-xs text-gray-500">
+                                            From experiment:
+                                            <a href="{{ route('experiments.show', $proposal->experiment) }}" wire:navigate
+                                                class="font-medium text-primary-600 hover:text-primary-800">{{ $proposal->experiment->title ?? $proposal->experiment->id }}</a>
+                                        </p>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endif
+                    @empty
+                        <tr><td colspan="6" class="px-6 py-8 text-center text-gray-400">No outbound proposals.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <div>{{ $proposals->links() }}</div>
+    </div>
+</div>

--- a/resources/views/livewire/releases/signing-keys-page.blade.php
+++ b/resources/views/livewire/releases/signing-keys-page.blade.php
@@ -1,0 +1,119 @@
+@php
+    use App\Domain\Release\Crypto\Enums\SigningKeyStatus;
+
+    $statusStyles = [
+        'active' => ['bg-green-100', 'text-green-700'],
+        'grace' => ['bg-amber-100', 'text-amber-700'],
+        'revoked' => ['bg-red-100', 'text-red-700'],
+    ];
+
+    // SHA-256 fingerprint of the raw Ed25519 public key, shown as a short hex
+    // prefix so operators can eyeball-match keys without exposing key material.
+    $fingerprint = function (string $publicKey): string {
+        $raw = base64_decode($publicKey, true);
+        $hash = hash('sha256', $raw !== false ? $raw : $publicKey);
+
+        return implode(':', str_split(substr($hash, 0, 32), 4));
+    };
+@endphp
+
+<div>
+    @if(session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-3 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    <div class="mb-6 flex items-start justify-between gap-4">
+        <p class="max-w-2xl text-sm text-gray-500">
+            Ed25519 keys used to sign your team's releases. Verifiers fetch the matching public key
+            from the public JWKS endpoint. Private key material is never displayed and never leaves the server.
+        </p>
+        @if(! $hasActive)
+            <button wire:click="generate"
+                class="shrink-0 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700">
+                <i class="fa-solid fa-key mr-1"></i>Generate signing key
+            </button>
+        @else
+            <button wire:click="rotate"
+                wire:confirm="Rotate the active signing key? The current key moves to a 90-day grace period (releases signed by it still verify until it expires), and a new active key is generated."
+                class="shrink-0 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                <i class="fa-solid fa-rotate mr-1"></i>Rotate key
+            </button>
+        @endif
+    </div>
+
+    <div class="rounded-xl border border-gray-200 bg-white">
+        @forelse($keys as $key)
+            @php([$badgeBg, $badgeText] = $statusStyles[$key->status->value] ?? ['bg-gray-100', 'text-gray-700'])
+            <div class="border-b border-gray-100 px-6 py-4 last:border-0">
+                <div class="flex items-center justify-between gap-4">
+                    <div class="min-w-0">
+                        <div class="flex flex-wrap items-center gap-3">
+                            <span class="inline-flex items-center rounded-full {{ $badgeBg }} px-2 py-0.5 text-xs font-medium {{ $badgeText }}">
+                                {{ $key->status->label() }}
+                            </span>
+                            <span class="font-mono text-xs text-gray-500" title="Key ID (kid)">{{ $key->id }}</span>
+                        </div>
+                        <div class="mt-2 flex flex-wrap gap-x-6 gap-y-1 text-xs text-gray-500">
+                            <span title="SHA-256 of the public key">
+                                <span class="text-gray-400">Fingerprint</span>
+                                <span class="font-mono text-gray-700">{{ $fingerprint($key->public_key) }}</span>
+                            </span>
+                            <span>
+                                <span class="text-gray-400">Created</span> {{ $key->created_at?->diffForHumans() }}
+                            </span>
+                            @if($key->rotated_at)
+                                <span>
+                                    <span class="text-gray-400">Rotated</span> {{ $key->rotated_at->diffForHumans() }}
+                                </span>
+                            @endif
+                            @if($key->status === SigningKeyStatus::Grace && $key->grace_expires_at)
+                                <span>
+                                    <span class="text-gray-400">Grace expires</span> {{ $key->grace_expires_at->diffForHumans() }}
+                                </span>
+                            @endif
+                            @if($key->revoked_at)
+                                <span>
+                                    <span class="text-gray-400">Revoked</span> {{ $key->revoked_at->diffForHumans() }}
+                                </span>
+                            @endif
+                        </div>
+                    </div>
+
+                    @if($key->status !== SigningKeyStatus::Revoked)
+                        <div class="shrink-0">
+                            @if($confirmingRevokeId === $key->id)
+                                <div class="flex items-center gap-2">
+                                    <button wire:click="revoke('{{ $key->id }}')"
+                                        class="rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700">
+                                        Confirm revoke
+                                    </button>
+                                    <button wire:click="cancelRevoke"
+                                        class="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50">
+                                        Cancel
+                                    </button>
+                                </div>
+                            @else
+                                <button wire:click="confirmRevoke('{{ $key->id }}')"
+                                    class="rounded-lg border border-red-300 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50">
+                                    <i class="fa-solid fa-ban mr-1"></i>Revoke
+                                </button>
+                            @endif
+                        </div>
+                    @endif
+                </div>
+
+                @if($confirmingRevokeId === $key->id)
+                    <div class="mt-3 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-700">
+                        <i class="fa-solid fa-triangle-exclamation mr-1"></i>
+                        Revoking is immediate and irreversible. Every release signed by this key will
+                        <strong>fail verification</strong> — there is no grace period. Use rotation instead unless this key is compromised.
+                    </div>
+                @endif
+            </div>
+        @empty
+            <div class="px-6 py-12 text-center text-sm text-gray-400">
+                No signing keys yet. Generate one to start signing your releases.
+            </div>
+        @endforelse
+    </div>
+</div>

--- a/resources/views/livewire/skills/skill-ops-page.blade.php
+++ b/resources/views/livewire/skills/skill-ops-page.blade.php
@@ -1,0 +1,225 @@
+<div class="space-y-6" wire:poll.10s>
+    @if (session('message'))
+        <div class="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+            {{ session('message') }}
+        </div>
+    @endif
+    @if (session('benchmark_error'))
+        <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+            {{ session('benchmark_error') }}
+        </div>
+    @endif
+
+    {{-- Tabs --}}
+    <div class="border-b border-gray-200">
+        <nav class="-mb-px flex gap-6">
+            @php($tabs = ['loop' => 'Improvement Loop', 'benchmarks' => 'Benchmarks', 'annotations' => 'Annotations'])
+            @foreach ($tabs as $key => $label)
+                <button type="button" wire:click="$set('tab', '{{ $key }}')"
+                    class="border-b-2 px-1 py-3 text-sm font-medium {{ $tab === $key ? 'border-primary-500 text-primary-600' : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700' }}">
+                    {{ $label }}
+                </button>
+            @endforeach
+        </nav>
+    </div>
+
+    {{-- ============ IMPROVEMENT LOOP ============ --}}
+    @if ($tab === 'loop')
+        <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div class="rounded-lg border border-gray-200 bg-white p-5 lg:col-span-1">
+                <h3 class="mb-1 text-sm font-semibold text-gray-900">Start metric-gated loop</h3>
+                <p class="mb-4 text-xs text-gray-500">
+                    Generates candidate skill versions and keeps only those that improve the metric.
+                    Runs in the background; refresh the Benchmarks tab to track progress.
+                </p>
+                <div class="space-y-3">
+                    <x-form-select wire:model="skillId" label="Skill">
+                        @foreach ($skills as $s)
+                            <option value="{{ $s->id }}">{{ $s->name }}</option>
+                        @endforeach
+                    </x-form-select>
+                    <x-form-input wire:model="loopMetric" label="Metric" />
+                    <x-form-input wire:model="loopMaxIterations" type="number" label="Max iterations" />
+                    <button type="button" wire:click="startLoop"
+                        class="w-full rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700">
+                        Start improvement loop
+                    </button>
+                </div>
+            </div>
+
+            <div class="rounded-lg border border-gray-200 bg-white p-5 lg:col-span-2">
+                <h3 class="mb-3 text-sm font-semibold text-gray-900">Running loops &amp; benchmarks</h3>
+                @if ($runningBenchmarks->isEmpty())
+                    <p class="text-sm text-gray-500">No loops currently running.</p>
+                @else
+                    <div class="space-y-3">
+                        @foreach ($runningBenchmarks as $b)
+                            <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <p class="text-sm font-medium text-gray-900">{{ $b->skill?->name ?? '—' }}</p>
+                                        <p class="text-xs text-gray-500">
+                                            {{ $b->metric_name }} · iteration {{ $b->iteration_count }}/{{ $b->max_iterations }}
+                                            · best {{ $b->best_value !== null ? number_format($b->best_value, 4) : '—' }}
+                                            ({{ $b->improvementPercent() }}%)
+                                        </p>
+                                    </div>
+                                    <button type="button" wire:click="cancelBenchmark('{{ $b->id }}')"
+                                        class="rounded-lg border border-red-300 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50">
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        </div>
+    @endif
+
+    {{-- ============ BENCHMARKS ============ --}}
+    @if ($tab === 'benchmarks')
+        <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div class="rounded-lg border border-gray-200 bg-white p-5 lg:col-span-1">
+                <h3 class="mb-4 text-sm font-semibold text-gray-900">Start benchmark</h3>
+                <div class="space-y-3">
+                    <x-form-select wire:model="benchSkillId" label="Skill">
+                        @foreach ($skills as $s)
+                            <option value="{{ $s->id }}">{{ $s->name }}</option>
+                        @endforeach
+                    </x-form-select>
+                    <x-form-input wire:model="benchMetricName" label="Metric name" />
+                    <x-form-select wire:model="benchMetricDirection" label="Direction">
+                        <option value="maximize">Maximize</option>
+                        <option value="minimize">Minimize</option>
+                    </x-form-select>
+                    <x-form-textarea wire:model="benchTestInputs" label="Test inputs (JSON array)" mono rows="4" />
+                    <div class="grid grid-cols-2 gap-3">
+                        <x-form-input wire:model="benchMaxIterations" type="number" label="Max iterations" />
+                        <x-form-input wire:model="benchTimeBudget" type="number" label="Time budget (s)" />
+                    </div>
+                    <div class="grid grid-cols-2 gap-3">
+                        <x-form-input wire:model="benchComplexityPenalty" type="number" step="0.01" label="Complexity penalty" />
+                        <x-form-input wire:model="benchImprovementThreshold" type="number" step="0.01" label="Improvement threshold" />
+                    </div>
+                    <button type="button" wire:click="startBenchmark"
+                        class="w-full rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700">
+                        Start benchmark
+                    </button>
+                </div>
+            </div>
+
+            <div class="lg:col-span-2">
+                <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+                    <table class="min-w-full divide-y divide-gray-200 text-sm">
+                        <thead class="bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                            <tr>
+                                <th class="px-4 py-3">Skill</th>
+                                <th class="px-4 py-3">Metric</th>
+                                <th class="px-4 py-3">Status</th>
+                                <th class="px-4 py-3">Iters</th>
+                                <th class="px-4 py-3">Best</th>
+                                <th class="px-4 py-3"></th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100">
+                            @forelse ($benchmarks as $b)
+                                <tr>
+                                    <td class="px-4 py-3 font-medium text-gray-900">{{ $b->skill?->name ?? '—' }}</td>
+                                    <td class="px-4 py-3 text-gray-600">{{ $b->metric_name }} ({{ $b->metric_direction }})</td>
+                                    <td class="px-4 py-3">
+                                        @php($colors = ['running' => 'bg-blue-100 text-blue-700', 'completed' => 'bg-green-100 text-green-700', 'cancelled' => 'bg-gray-100 text-gray-600', 'failed' => 'bg-red-100 text-red-700', 'pending' => 'bg-amber-100 text-amber-700'])
+                                        <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ $colors[$b->status->value] ?? 'bg-gray-100 text-gray-600' }}">
+                                            {{ $b->status->label() }}
+                                        </span>
+                                    </td>
+                                    <td class="px-4 py-3 text-gray-600">{{ $b->iteration_count }}/{{ $b->max_iterations }}</td>
+                                    <td class="px-4 py-3 text-gray-600">{{ $b->best_value !== null ? number_format($b->best_value, 4) : '—' }}</td>
+                                    <td class="px-4 py-3 text-right">
+                                        @if ($b->status === \App\Domain\Skill\Enums\BenchmarkStatus::Running)
+                                            <button type="button" wire:click="cancelBenchmark('{{ $b->id }}')"
+                                                class="rounded-lg border border-red-300 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-50">
+                                                Cancel
+                                            </button>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr><td colspan="6" class="px-4 py-8 text-center text-gray-500">No benchmarks yet.</td></tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    @endif
+
+    {{-- ============ ANNOTATIONS ============ --}}
+    @if ($tab === 'annotations')
+        <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div class="rounded-lg border border-gray-200 bg-white p-5 lg:col-span-1">
+                <h3 class="mb-1 text-sm font-semibold text-gray-900">Annotate a response</h3>
+                <p class="mb-4 text-xs text-gray-500">
+                    Rate a skill version's output. Annotations feed
+                    GenerateImprovedSkillVersionAction's few-shot meta-prompting.
+                </p>
+                <div class="space-y-3">
+                    <x-form-select wire:model="annotateVersionId" label="Skill version">
+                        <option value="">Select a version…</option>
+                        @foreach ($versions as $v)
+                            <option value="{{ $v->id }}">{{ $v->skill?->name ?? '—' }} · v{{ $v->version }}</option>
+                        @endforeach
+                    </x-form-select>
+                    <x-form-input wire:model="annotateModelId" label="Model" placeholder="anthropic/claude-sonnet-4-5" />
+                    <x-form-textarea wire:model="annotateInput" label="Input" mono rows="3" />
+                    <x-form-textarea wire:model="annotateOutput" label="Output" mono rows="4" />
+                    <x-form-select wire:model="annotateRating" label="Rating">
+                        <option value="good">Good</option>
+                        <option value="bad">Bad</option>
+                    </x-form-select>
+                    <x-form-input wire:model="annotateNote" label="Note (optional)" />
+                    <button type="button" wire:click="submitAnnotation"
+                        class="w-full rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700">
+                        Submit annotation
+                    </button>
+                </div>
+            </div>
+
+            <div class="lg:col-span-2">
+                <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+                    <table class="min-w-full divide-y divide-gray-200 text-sm">
+                        <thead class="bg-gray-50 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                            <tr>
+                                <th class="px-4 py-3">Skill / Version</th>
+                                <th class="px-4 py-3">Model</th>
+                                <th class="px-4 py-3">Rating</th>
+                                <th class="px-4 py-3">By</th>
+                                <th class="px-4 py-3">When</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100">
+                            @forelse ($annotations as $a)
+                                <tr>
+                                    <td class="px-4 py-3 font-medium text-gray-900">
+                                        {{ $a->skillVersion?->skill?->name ?? '—' }}
+                                        <span class="text-gray-400">· v{{ $a->skillVersion?->version ?? '?' }}</span>
+                                    </td>
+                                    <td class="px-4 py-3 text-gray-600">{{ $a->model_id }}</td>
+                                    <td class="px-4 py-3">
+                                        <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ $a->rating === \App\Domain\Skill\Enums\AnnotationRating::Good ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                                            {{ ucfirst($a->rating->value) }}
+                                        </span>
+                                    </td>
+                                    <td class="px-4 py-3 text-gray-600">{{ $a->user?->name ?? '—' }}</td>
+                                    <td class="px-4 py-3 text-gray-500">{{ $a->created_at?->diffForHumans() }}</td>
+                                </tr>
+                            @empty
+                                <tr><td colspan="5" class="px-4 py-8 text-center text-gray-500">No annotations yet.</td></tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/testing/test-suite-detail-page.blade.php
+++ b/resources/views/livewire/testing/test-suite-detail-page.blade.php
@@ -1,0 +1,90 @@
+<div>
+    <div class="mb-6">
+        <a href="{{ route('testing.index') }}" class="text-sm text-primary-600 hover:text-primary-800">&larr; Back to test suites</a>
+    </div>
+
+    {{-- Suite summary --}}
+    <div class="mb-6 rounded-xl border border-gray-200 bg-white p-6">
+        <div class="flex items-start justify-between">
+            <div>
+                <h2 class="text-lg font-semibold text-gray-900">{{ $suite->name }}</h2>
+                <p class="mt-1 text-sm text-gray-500">{{ $suite->project?->name ?? 'No project' }}</p>
+            </div>
+            @if($suite->is_active)
+                <span class="inline-flex rounded-full bg-green-100 px-2.5 py-1 text-xs font-medium text-green-700">Active</span>
+            @else
+                <span class="inline-flex rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-500">Inactive</span>
+            @endif
+        </div>
+
+        <dl class="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-400">Strategy</dt>
+                <dd class="mt-1 text-sm font-medium text-gray-700">{{ $suite->test_strategy->label() }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-400">Pass Rate</dt>
+                <dd class="mt-1 text-sm font-medium text-gray-700">{{ $suite->pass_rate !== null ? round($suite->pass_rate * 100).'%' : '—' }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-400">Quality Threshold</dt>
+                <dd class="mt-1 text-sm font-medium text-gray-700">{{ $suite->quality_threshold !== null ? round($suite->quality_threshold * 100).'%' : '—' }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs uppercase tracking-wide text-gray-400">Test Agents</dt>
+                <dd class="mt-1 text-sm font-medium text-gray-700">{{ $suite->test_agent_count }}</dd>
+            </div>
+        </dl>
+    </div>
+
+    {{-- Runs --}}
+    <h3 class="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">Test Runs</h3>
+
+    @if($runs->isEmpty())
+        <div class="rounded-xl border border-gray-200 bg-white px-6 py-12 text-center">
+            <p class="text-sm text-gray-400">No runs recorded for this suite yet.</p>
+        </div>
+    @else
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Status</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Score</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Experiment</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Duration</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Started</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach($runs as $run)
+                        @php
+                            $statusColor = match($run->status->value) {
+                                'passed' => 'bg-green-100 text-green-700',
+                                'failed' => 'bg-red-100 text-red-700',
+                                'running' => 'bg-blue-100 text-blue-700',
+                                'skipped' => 'bg-gray-100 text-gray-500',
+                                default => 'bg-amber-100 text-amber-700',
+                            };
+                        @endphp
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-4 py-3">
+                                <span class="inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium {{ $statusColor }}">{{ $run->status->label() }}</span>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-600">{{ $run->score !== null ? round($run->score * 100).'%' : '—' }}</td>
+                            <td class="px-4 py-3 text-sm text-gray-600">
+                                {{ $run->experiment?->title ?? '—' }}
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-600">{{ $run->duration_ms !== null ? round($run->duration_ms / 1000, 1).'s' : '—' }}</td>
+                            <td class="px-4 py-3 text-sm text-gray-400" title="{{ $run->started_at?->toDateTimeString() }}">{{ $run->started_at?->diffForHumans() ?? '—' }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+
+    <div class="mt-4">
+        {{ $runs->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/testing/test-suites-page.blade.php
+++ b/resources/views/livewire/testing/test-suites-page.blade.php
@@ -1,0 +1,87 @@
+<div>
+    {{-- Toolbar --}}
+    <form class="mb-6 flex flex-wrap items-center gap-4" onsubmit="return false">
+        <div class="relative flex-1">
+            <x-form-input wire:model.live.debounce.300ms="search" type="text" placeholder="Search test suites..." class="pl-10">
+                <x-slot:leadingIcon>
+                    <i class="fa-solid fa-magnifying-glass pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-base text-gray-400"></i>
+                </x-slot:leadingIcon>
+            </x-form-input>
+        </div>
+
+        <x-form-select wire:model.live="strategyFilter">
+            <option value="">All Strategies</option>
+            @foreach($strategies as $strategy)
+                <option value="{{ $strategy->value }}">{{ $strategy->label() }}</option>
+            @endforeach
+        </x-form-select>
+
+        <x-form-select wire:model.live="activeFilter">
+            <option value="">All States</option>
+            <option value="active">Active</option>
+            <option value="inactive">Inactive</option>
+        </x-form-select>
+    </form>
+
+    {{-- List --}}
+    @if($suites->isEmpty())
+        <div class="rounded-xl border border-gray-200 bg-white px-6 py-12 text-center">
+            @if($search || $strategyFilter || $activeFilter)
+                <p class="text-sm text-gray-400">No test suites match your filters.</p>
+            @else
+                <i class="fa-solid fa-vial mx-auto mb-3 text-4xl text-gray-300"></i>
+                <p class="text-sm font-medium text-gray-600">No test suites yet</p>
+                <p class="mt-1 text-xs text-gray-400">
+                    Test suites are created per project and run automatically against experiment output.
+                </p>
+            @endif
+        </div>
+    @else
+        <div class="overflow-hidden rounded-xl border border-gray-200 bg-white">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Name</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Project</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Strategy</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Pass Rate</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Runs</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Last Run</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">State</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100">
+                    @foreach($suites as $suite)
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-4 py-3">
+                                <a href="{{ route('testing.show', $suite) }}" class="font-medium text-primary-600 hover:text-primary-800">{{ $suite->name }}</a>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-600">{{ $suite->project?->name ?? '—' }}</td>
+                            <td class="px-4 py-3">
+                                <span class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-600">{{ $suite->test_strategy->label() }}</span>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-600">
+                                {{ $suite->pass_rate !== null ? round($suite->pass_rate * 100).'%' : '—' }}
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-600">{{ $suite->test_runs_count }}</td>
+                            <td class="px-4 py-3 text-sm text-gray-400" title="{{ $suite->last_run_at?->toDateTimeString() }}">
+                                {{ $suite->last_run_at?->diffForHumans() ?? 'never' }}
+                            </td>
+                            <td class="px-4 py-3">
+                                @if($suite->is_active)
+                                    <span class="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-[11px] font-medium text-green-700">Active</span>
+                                @else
+                                    <span class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">Inactive</span>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
+
+    <div class="mt-4">
+        {{ $suites->links() }}
+    </div>
+</div>

--- a/resources/views/livewire/workflows/workflow-ops-page.blade.php
+++ b/resources/views/livewire/workflows/workflow-ops-page.blade.php
@@ -1,0 +1,66 @@
+<div>
+    <div class="mb-6">
+        <h2 class="text-lg font-semibold text-gray-900">Workflow Compensation</h2>
+        <p class="mt-1 text-sm text-gray-500">
+            Failed workflow runs whose completed steps had compensation (saga rollback) nodes defined.
+        </p>
+    </div>
+
+    @if($runs->isEmpty())
+        <div class="rounded-lg border border-dashed border-gray-300 bg-white p-12 text-center">
+            <i class="fa-solid fa-rotate-left mb-3 text-3xl text-gray-300"></i>
+            <p class="text-sm text-gray-500">No compensation activity.</p>
+            <p class="mt-1 text-xs text-gray-400">
+                Compensation triggers only on failed workflow runs that have completed steps with a compensation node.
+            </p>
+        </div>
+    @else
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Experiment</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Workflow</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Compensated steps</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Failed at</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200">
+                    @foreach($runs as $run)
+                        @php($experiment = $run['experiment'])
+                        <tr class="hover:bg-gray-50">
+                            <td class="px-4 py-3 text-sm">
+                                <a href="{{ route('experiments.show', $experiment) }}" wire:navigate
+                                   class="font-medium text-primary-600 hover:text-primary-700">
+                                    {{ $experiment->title }}
+                                </a>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-700">
+                                {{ $experiment->workflow?->name ?? '—' }}
+                            </td>
+                            <td class="px-4 py-3 text-sm">
+                                <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">
+                                    {{ str($experiment->status->value)->replace('_', ' ')->title() }}
+                                </span>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-700">
+                                <span class="inline-flex items-center gap-1.5">
+                                    <i class="fa-solid fa-rotate-left text-amber-500"></i>
+                                    {{ $run['compensated_count'] }}
+                                </span>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-gray-500">
+                                {{ $experiment->updated_at?->diffForHumans() }}
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        <p class="mt-3 text-xs text-gray-400">
+            Compensation runs are reconstructed from experiment + step data — they are not stored as standalone records.
+        </p>
+    @endif
+</div>

--- a/resources/views/livewire/workflows/workflow-simulation-panel.blade.php
+++ b/resources/views/livewire/workflows/workflow-simulation-panel.blade.php
@@ -1,0 +1,62 @@
+<div>
+    <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div class="flex min-w-0 flex-1 items-center gap-3">
+            <a href="{{ route('workflows.show', $workflow) }}" wire:navigate class="shrink-0 text-gray-500 hover:text-gray-700">
+                <i class="fa-solid fa-arrow-left text-lg"></i>
+            </a>
+            <div class="min-w-0 flex-1">
+                <h2 class="text-lg font-semibold text-gray-900">Simulate: {{ $workflow->name }}</h2>
+                <p class="mt-1 text-sm text-gray-500">
+                    Dry-run the workflow graph. No agents run, no LLM calls, no cost.
+                </p>
+            </div>
+        </div>
+
+        <button type="button" wire:click="simulate" wire:loading.attr="disabled"
+                class="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+            <i class="fa-solid fa-play" wire:loading.remove wire:target="simulate"></i>
+            <i class="fa-solid fa-spinner fa-spin" wire:loading wire:target="simulate"></i>
+            <span>Run simulation</span>
+        </button>
+    </div>
+
+    @if($error)
+        <div class="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {{ $error }}
+        </div>
+    @endif
+
+    @if($hasRun && ! $error)
+        <div class="mb-4 flex items-center gap-3">
+            <span class="text-sm font-medium text-gray-700">Predicted outcome:</span>
+            @php($statusColor = match($terminationStatus) {
+                'completed' => 'green',
+                'loop_limit' => 'amber',
+                default => 'red',
+            })
+            <span class="inline-flex items-center rounded-full bg-{{ $statusColor }}-100 px-2.5 py-0.5 text-xs font-medium text-{{ $statusColor }}-800">
+                {{ str($terminationStatus)->replace('_', ' ')->title() }}
+            </span>
+            <span class="text-xs text-gray-400">{{ count($executedPath) }} nodes visited</span>
+        </div>
+
+        <div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+            <ol class="divide-y divide-gray-100">
+                @foreach($executedPath as $i => $step)
+                    <li class="flex items-center gap-3 px-4 py-3 {{ $step['id'] === $terminationNodeId ? 'bg-gray-50' : '' }}">
+                        <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary-100 text-xs font-semibold text-primary-700">
+                            {{ $i + 1 }}
+                        </span>
+                        <span class="flex-1 text-sm font-medium text-gray-900">{{ $step['label'] }}</span>
+                        <span class="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-500">{{ $step['type'] }}</span>
+                    </li>
+                @endforeach
+            </ol>
+        </div>
+    @elseif(! $hasRun)
+        <div class="rounded-lg border border-dashed border-gray-300 bg-white p-12 text-center">
+            <i class="fa-solid fa-diagram-project mb-3 text-3xl text-gray-300"></i>
+            <p class="text-sm text-gray-500">Run a simulation to preview the predicted execution path.</p>
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,7 +44,12 @@ use App\Livewire\AuditConsole\AuditConsoleDetailPage;
 use App\Livewire\AuditConsole\AuditConsoleListPage;
 use App\Livewire\AuditConsole\AuditConsoleSettingsPage;
 use App\Livewire\Auth\AcceptTermsPage;
+use App\Livewire\AgentSessions\AgentSessionDetailPage;
+use App\Livewire\AgentSessions\AgentSessionListPage;
 use App\Livewire\Broadcast\BroadcastDetailPage;
+use App\Livewire\Broadcast\BroadcastListPage;
+use App\Livewire\Broadcast\CreateBroadcastForm;
+use App\Livewire\Migration\ImportWizardPage;
 use App\Livewire\Changelog\ChangelogPage;
 use App\Livewire\Chatbots\ChatbotAnalyticsPage;
 use App\Livewire\Chatbots\ChatbotConversationListPage;
@@ -65,6 +70,8 @@ use App\Livewire\Email\EmailTemplateListPage;
 use App\Livewire\Email\EmailThemeDetailPage;
 use App\Livewire\Email\EmailThemeListPage;
 use App\Livewire\Evaluation\EvaluationCompareRunsPage;
+use App\Livewire\Evaluation\DriftSignalsPage;
+use App\Livewire\Evaluation\EvalMonitorPage;
 use App\Livewire\Evaluation\EvaluationPage;
 use App\Livewire\Evolution\EvolutionListPage;
 use App\Livewire\Experiments\ExperimentDetailPage;
@@ -105,6 +112,7 @@ use App\Livewire\Projects\ProjectListPage;
 use App\Livewire\Releases\ReleaseDetailPage;
 use App\Livewire\Releases\ReleaseDiffPage;
 use App\Livewire\Releases\ReleaseListPage;
+use App\Livewire\Releases\SigningKeysPage;
 use App\Livewire\Settings\GitSyncPage;
 use App\Livewire\Settings\GlobalSettingsPage;
 use App\Livewire\Settings\PluginsPage;
@@ -393,8 +401,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/crews/{crew}', CrewDetailPage::class)->name('crews.show');
 
     Route::get('/releases', ReleaseListPage::class)->name('releases.index');
+    Route::get('/releases/signing-keys', SigningKeysPage::class)->name('releases.signing-keys');
     Route::get('/releases/{release}/diff', ReleaseDiffPage::class)->name('releases.diff');
     Route::get('/releases/{release}', ReleaseDetailPage::class)->name('releases.show');
+
+    Route::get('/agent-sessions', AgentSessionListPage::class)->name('agent-sessions.index');
+    Route::get('/agent-sessions/{agentSession}', AgentSessionDetailPage::class)->name('agent-sessions.show');
 
     Route::get('/inbox', InboxPage::class)->name('inbox.index');
 
@@ -430,6 +442,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/contacts', ContactsPage::class)->name('contacts.index');
     Route::get('/contacts/{contact}', ContactDetailPage::class)->name('contacts.show');
 
+    Route::get('/imports/create', ImportWizardPage::class)->name('imports.create');
+
     Route::get('/metrics/models', ModelComparisonPage::class)->name('metrics.models');
     Route::get('/metrics/rocs', RocsPage::class)->name('metrics.rocs');
     Route::get('/metrics/ai-routing', AiRoutingPage::class)->name('metrics.ai-routing');
@@ -438,6 +452,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/approvals', ApprovalInboxPage::class)->name('approvals.index');
     Route::get('/evaluation', EvaluationPage::class)->name('evaluation.index');
     Route::get('/evaluation/compare', EvaluationCompareRunsPage::class)->name('evaluation.compare');
+    Route::get('/evaluation/drift', DriftSignalsPage::class)->name('evaluation.drift');
+    Route::get('/evaluation/monitor', EvalMonitorPage::class)->name('evaluation.monitor');
     Route::get('/evaluations', WorkflowEvaluationListPage::class)->name('evaluations.index');
     Route::get('/evolution', EvolutionListPage::class)->name('evolution.index');
     Route::get('/telegram/bots', TelegramBotsPage::class)->name('telegram.bots');
@@ -469,6 +485,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Audiences & broadcasts
     Route::get('/audiences', AudienceListPage::class)->name('audiences.index');
     Route::get('/audiences/{audience}', AudienceDetailPage::class)->name('audiences.show');
+    Route::get('/broadcasts', BroadcastListPage::class)->name('broadcasts.index');
+    Route::get('/broadcasts/create', CreateBroadcastForm::class)->name('broadcasts.create');
     Route::get('/broadcasts/{broadcast}', BroadcastDetailPage::class)->name('broadcasts.show');
 
     // Email themes

--- a/routes/web.php
+++ b/routes/web.php
@@ -481,6 +481,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/outbound/webhooks', WebhookOutboundPage::class)->name('outbound.webhooks');
     Route::get('/outbound/notifications', NotificationOutboundPage::class)->name('outbound.notifications');
     Route::get('/outbound/whatsapp', WhatsAppOutboundPage::class)->name('outbound.whatsapp');
+    Route::get('/outbound/telegram', \App\Livewire\OutboundConnectors\TelegramOutboundPage::class)->name('outbound.telegram');
+    Route::get('/outbound/slack', \App\Livewire\OutboundConnectors\SlackOutboundPage::class)->name('outbound.slack');
+    Route::get('/outbound/discord', \App\Livewire\OutboundConnectors\DiscordOutboundPage::class)->name('outbound.discord');
+    Route::get('/outbound/teams', \App\Livewire\OutboundConnectors\TeamsOutboundPage::class)->name('outbound.teams');
+    Route::get('/outbound/google-chat', \App\Livewire\OutboundConnectors\GoogleChatOutboundPage::class)->name('outbound.google_chat');
 
     // Audiences & broadcasts
     Route::get('/audiences', AudienceListPage::class)->name('audiences.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -337,10 +337,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('/experiments', ExperimentListPage::class)->name('experiments.index');
     Route::get('/experiments/{experiment}', ExperimentDetailPage::class)->name('experiments.show');
+    Route::get('/experiments/{experiment}/checkpoints', \App\Livewire\Experiments\ExperimentCheckpointsPage::class)->name('experiments.checkpoints');
 
     Route::get('/skills', SkillListPage::class)->name('skills.index');
     Route::get('/skills/create', CreateSkillForm::class)->name('skills.create');
     Route::get('/skills/import', ImportSkillForm::class)->name('skills.import');
+    Route::get('/skills/ops', \App\Livewire\Skills\SkillOpsPage::class)->name('skills.ops');
     Route::get('/skills/{skill}', SkillDetailPage::class)->name('skills.show');
     Route::get('/skills/{skill}/export', SkillExportController::class)->name('skills.export');
 
@@ -387,6 +389,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('/credentials', CredentialListPage::class)->name('credentials.index');
     Route::get('/credentials/create', CreateCredentialForm::class)->name('credentials.create');
+    Route::get('/credentials/scan', \App\Livewire\Credentials\CredentialScanPage::class)->name('credentials.scan');
     Route::get('/credentials/{credential}', CredentialDetailPage::class)->name('credentials.show');
 
     Route::get('/integrations', IntegrationListPage::class)->name('integrations.index');
@@ -420,11 +423,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/workflows/create', WorkflowBuilderPage::class)->name('workflows.create');
     Route::get('/workflows/{workflow}/schedule', ScheduleWorkflowForm::class)->name('workflows.schedule');
     Route::get('/workflows/{workflow}/edit', WorkflowBuilderPage::class)->name('workflows.edit');
+    Route::get('/workflows/ops', \App\Livewire\Workflows\WorkflowOpsPage::class)->name('workflows.ops');
+    Route::get('/workflows/{workflow}/simulate', \App\Livewire\Workflows\WorkflowSimulationPanel::class)->name('workflows.simulate');
     Route::get('/workflows/{workflow}', WorkflowDetailPage::class)->name('workflows.show');
 
     Route::get('/artifacts/{artifact}/render/{version?}', [ArtifactPreviewController::class, 'render'])->name('artifacts.render');
 
     Route::get('/memory', MemoryBrowserPage::class)->name('memory.index');
+    Route::get('/memory/proposals', \App\Livewire\Memory\MemoryProposalsPage::class)->name('memory.proposals');
     Route::get('/world-model', WorldModelPage::class)->name('world-model.index');
     Route::get('/knowledge', KnowledgeSourcesPage::class)->name('knowledge.index');
     Route::get('/knowledge-graph', KnowledgeGraphBrowserPage::class)->name('knowledge-graph.index');
@@ -486,6 +492,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/outbound/discord', \App\Livewire\OutboundConnectors\DiscordOutboundPage::class)->name('outbound.discord');
     Route::get('/outbound/teams', \App\Livewire\OutboundConnectors\TeamsOutboundPage::class)->name('outbound.teams');
     Route::get('/outbound/google-chat', \App\Livewire\OutboundConnectors\GoogleChatOutboundPage::class)->name('outbound.google_chat');
+    Route::get('/outbound/blacklist', \App\Livewire\Outbound\BlacklistPage::class)->name('outbound.blacklist');
+    Route::get('/outbound/proposals', \App\Livewire\Outbound\OutboundProposalsPage::class)->name('outbound.proposals');
 
     // Audiences & broadcasts
     Route::get('/audiences', AudienceListPage::class)->name('audiences.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -336,6 +336,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     });
 
     Route::get('/experiments', ExperimentListPage::class)->name('experiments.index');
+    Route::get('/experiments/reasoning-bank', \App\Livewire\Experiments\ReasoningBankPage::class)->name('reasoning-bank.index');
     Route::get('/experiments/{experiment}', ExperimentDetailPage::class)->name('experiments.show');
     Route::get('/experiments/{experiment}/checkpoints', \App\Livewire\Experiments\ExperimentCheckpointsPage::class)->name('experiments.checkpoints');
 
@@ -402,6 +403,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/crews/create', CreateCrewForm::class)->name('crews.create');
     Route::get('/crews/{crew}/execute', CrewExecutionPage::class)->name('crews.execute');
     Route::get('/crews/{crew}', CrewDetailPage::class)->name('crews.show');
+    Route::get('/crew-executions/{execution}/chat', \App\Livewire\Crews\CrewChatRoomPage::class)->name('crews.chat');
 
     Route::get('/releases', ReleaseListPage::class)->name('releases.index');
     Route::get('/releases/signing-keys', SigningKeysPage::class)->name('releases.signing-keys');
@@ -434,6 +436,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/world-model', WorldModelPage::class)->name('world-model.index');
     Route::get('/knowledge', KnowledgeSourcesPage::class)->name('knowledge.index');
     Route::get('/knowledge-graph', KnowledgeGraphBrowserPage::class)->name('knowledge-graph.index');
+    Route::get('/knowledge-graph/communities', \App\Livewire\KnowledgeGraph\KgCommunitiesPage::class)->name('knowledge-graph.communities');
 
     Route::get('/signals', SignalBrowserPage::class)->name('signals.index');
     Route::get('/signals/new', ManualSignalForm::class)->name('signals.create');
@@ -477,6 +480,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/notifications', NotificationInboxPage::class)->name('notifications.index');
     Route::get('/notifications/preferences', NotificationPreferencesPage::class)->name('notifications.preferences');
 
+    Route::get('/error-modes', \App\Livewire\ErrorModes\ErrorModeCatalogPage::class)->name('error-modes.index');
+    Route::get('/test-suites', \App\Livewire\Testing\TestSuitesPage::class)->name('testing.index');
+    Route::get('/test-suites/{suite}', \App\Livewire\Testing\TestSuiteDetailPage::class)->name('testing.show');
     Route::get('/triggers', TriggerRulesPage::class)->name('triggers.index');
     Route::get('/triggers/create', CreateTriggerRuleForm::class)->name('triggers.create');
 

--- a/tests/Feature/Domain/Outbound/CoreChannelDriversTest.php
+++ b/tests/Feature/Domain/Outbound/CoreChannelDriversTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature\Domain\Outbound;
+
+use App\Domain\Outbound\Connectors\DiscordConnector;
+use App\Domain\Outbound\Connectors\DummyConnector;
+use App\Domain\Outbound\Connectors\GoogleChatConnector;
+use App\Domain\Outbound\Connectors\SlackConnector;
+use App\Domain\Outbound\Connectors\TeamsConnector;
+use App\Domain\Outbound\Connectors\TelegramConnector;
+use App\Domain\Outbound\Enums\OutboundActionStatus;
+use App\Domain\Outbound\Enums\OutboundChannel;
+use App\Domain\Outbound\Managers\OutboundConnectorManager;
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use App\Domain\Outbound\Models\OutboundProposal;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class CoreChannelDriversTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private OutboundConnectorManager $manager;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->manager = app(OutboundConnectorManager::class);
+        $this->team = Team::factory()->create();
+    }
+
+    /**
+     * Each formerly-"legacy" channel must now resolve to its real connector,
+     * not the DummyConnector fallback.
+     *
+     * @return array<string, array{0: string, 1: class-string}>
+     */
+    public static function coreChannelProvider(): array
+    {
+        return [
+            'telegram' => ['telegram', TelegramConnector::class],
+            'slack' => ['slack', SlackConnector::class],
+            'discord' => ['discord', DiscordConnector::class],
+            'teams' => ['teams', TeamsConnector::class],
+            'google_chat' => ['google_chat', GoogleChatConnector::class],
+        ];
+    }
+
+    /**
+     * @dataProvider coreChannelProvider
+     *
+     * @param  class-string  $expected
+     */
+    public function test_connector_for_returns_real_connector(string $channel, string $expected): void
+    {
+        $connector = $this->manager->connectorFor($channel);
+
+        $this->assertInstanceOf($expected, $connector);
+        $this->assertNotInstanceOf(DummyConnector::class, $connector);
+        $this->assertTrue($this->manager->hasConnector($channel));
+    }
+
+    /**
+     * @dataProvider coreChannelProvider
+     */
+    public function test_channel_enum_is_core(string $channel): void
+    {
+        $this->assertTrue(OutboundChannel::from($channel)->isCore());
+    }
+
+    private function configFor(string $channel, array $credentials): void
+    {
+        OutboundConnectorConfig::create([
+            'team_id' => $this->team->id,
+            'channel' => $channel,
+            'credentials' => $credentials,
+            'is_active' => true,
+        ]);
+    }
+
+    private function proposal(OutboundChannel $channel, array $target): OutboundProposal
+    {
+        return OutboundProposal::factory()->create([
+            'team_id' => $this->team->id,
+            'channel' => $channel,
+            'target' => $target,
+            'content' => ['body' => 'Hello from FleetQ'],
+        ]);
+    }
+
+    public function test_telegram_send_uses_resolved_config_and_fakes_http(): void
+    {
+        Http::fake(['api.telegram.org/*' => Http::response(['ok' => true, 'result' => ['message_id' => 42]], 200)]);
+        $this->configFor('telegram', ['bot_token' => 'test-bot-token']);
+
+        $proposal = $this->proposal(OutboundChannel::Telegram, ['chat_id' => '123456']);
+        $action = app(TelegramConnector::class)->send($proposal);
+
+        $this->assertSame(OutboundActionStatus::Sent, $action->status);
+        $this->assertSame('42', $action->external_id);
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'api.telegram.org/bottest-bot-token/sendMessage'));
+    }
+
+    public function test_slack_send_uses_resolved_config_and_fakes_http(): void
+    {
+        Http::fake(['hooks.slack.com/*' => Http::response('ok', 200)]);
+        $this->configFor('slack', ['webhook_url' => 'https://hooks.slack.com/services/T/B/X']);
+
+        $proposal = $this->proposal(OutboundChannel::Slack, []);
+        $action = app(SlackConnector::class)->send($proposal);
+
+        $this->assertSame(OutboundActionStatus::Sent, $action->status);
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'hooks.slack.com/services/T/B/X'));
+    }
+
+}

--- a/tests/Feature/Livewire/AgentSessionPagesTest.php
+++ b/tests/Feature/Livewire/AgentSessionPagesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\AgentSession\Enums\AgentSessionStatus;
+use App\Domain\AgentSession\Models\AgentSession;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\AgentSessions\AgentSessionDetailPage;
+use App\Livewire\AgentSessions\AgentSessionListPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AgentSessionPagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Agent Session Test',
+            'slug' => 'agent-session-test',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    private function makeSession(Team $team, AgentSessionStatus $status = AgentSessionStatus::Active): AgentSession
+    {
+        return AgentSession::withoutGlobalScopes()->create([
+            'team_id' => $team->id,
+            'status' => $status,
+            'started_at' => now(),
+            'last_heartbeat_at' => now(),
+        ]);
+    }
+
+    public function test_list_shows_only_current_team_sessions(): void
+    {
+        $mine = $this->makeSession($this->team);
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other Team',
+            'slug' => 'other-agent-session-team',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+        $theirs = $this->makeSession($otherTeam);
+
+        Livewire::test(AgentSessionListPage::class)
+            ->assertSee($mine->id)
+            ->assertDontSee($theirs->id);
+    }
+
+    public function test_unauthorized_wake_aborts(): void
+    {
+        $session = $this->makeSession($this->team, AgentSessionStatus::Sleeping);
+
+        // Deny the per-action gate to prove wake() authorizes on the action,
+        // not only on mount(). Livewire renders the AuthorizationException as a 403.
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(AgentSessionDetailPage::class, ['agentSession' => $session->id])
+            ->call('wake')
+            ->assertForbidden();
+
+        $session->refresh();
+        $this->assertSame(AgentSessionStatus::Sleeping, $session->status);
+    }
+}

--- a/tests/Feature/Livewire/BlacklistPageTest.php
+++ b/tests/Feature/Livewire/BlacklistPageTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Outbound\BlacklistPage;
+use App\Models\Blacklist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class BlacklistPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->team->users()->attach($this->user, ['role' => TeamRole::Owner->value]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($this->user);
+    }
+
+    public function test_add_creates_a_blacklist_entry(): void
+    {
+        Livewire::test(BlacklistPage::class)
+            ->set('type', 'email')
+            ->set('value', 'Spam@Example.com')
+            ->set('reason', 'known spammer')
+            ->call('add')
+            ->assertHasNoErrors();
+
+        $entry = Blacklist::query()->where('type', 'email')->first();
+        $this->assertNotNull($entry);
+        // Value is normalized to lowercase.
+        $this->assertSame('spam@example.com', $entry->value);
+        $this->assertSame($this->team->id, $entry->team_id);
+        $this->assertSame($this->user->id, $entry->added_by);
+    }
+
+    public function test_remove_deletes_an_entry(): void
+    {
+        $entry = Blacklist::create([
+            'team_id' => $this->team->id,
+            'type' => 'domain',
+            'value' => 'example.com',
+            'added_by' => $this->user->id,
+        ]);
+
+        Livewire::test(BlacklistPage::class)
+            ->call('remove', $entry->id)
+            ->assertHasNoErrors();
+
+        $this->assertSame(0, Blacklist::query()->count());
+    }
+
+    public function test_list_only_shows_current_team_entries(): void
+    {
+        Blacklist::create([
+            'team_id' => $this->team->id,
+            'type' => 'email',
+            'value' => 'mine@example.com',
+            'added_by' => $this->user->id,
+        ]);
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::factory()->create(['owner_id' => $otherUser->id]);
+        Blacklist::withoutGlobalScopes()->create([
+            'team_id' => $otherTeam->id,
+            'type' => 'email',
+            'value' => 'theirs@example.com',
+            'added_by' => $otherUser->id,
+        ]);
+
+        Livewire::test(BlacklistPage::class)
+            ->assertSee('mine@example.com')
+            ->assertDontSee('theirs@example.com');
+    }
+
+    public function test_unauthorized_user_cannot_add(): void
+    {
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(BlacklistPage::class)
+            ->set('type', 'email')
+            ->set('value', 'blocked@example.com')
+            ->call('add')
+            ->assertForbidden();
+
+        $this->assertSame(0, Blacklist::query()->count());
+    }
+
+    public function test_unauthorized_user_cannot_remove(): void
+    {
+        $entry = Blacklist::create([
+            'team_id' => $this->team->id,
+            'type' => 'keyword',
+            'value' => 'unsubscribe',
+            'added_by' => $this->user->id,
+        ]);
+
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(BlacklistPage::class)
+            ->call('remove', $entry->id)
+            ->assertForbidden();
+
+        $this->assertSame(1, Blacklist::query()->count());
+    }
+}

--- a/tests/Feature/Livewire/BroadcastPagesTest.php
+++ b/tests/Feature/Livewire/BroadcastPagesTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Audience\Models\Audience;
+use App\Domain\Broadcast\Models\Broadcast;
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Broadcast\BroadcastListPage;
+use App\Livewire\Broadcast\CreateBroadcastForm;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class BroadcastPagesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function loggedInOwner(): User
+    {
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'Broadcast Test',
+            'slug' => 'broadcast-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $team->users()->attach($user, ['role' => TeamRole::Owner->value]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    public function test_list_shows_only_current_team_broadcasts(): void
+    {
+        $user = $this->loggedInOwner();
+        $teamId = $user->current_team_id;
+
+        $audience = Audience::factory()->create(['team_id' => $teamId]);
+        $mine = Broadcast::factory()->create([
+            'team_id' => $teamId,
+            'audience_id' => $audience->id,
+            'name' => 'My Team Broadcast',
+        ]);
+
+        $otherTeam = Team::factory()->create();
+        $otherAudience = Audience::factory()->create(['team_id' => $otherTeam->id]);
+        Broadcast::factory()->create([
+            'team_id' => $otherTeam->id,
+            'audience_id' => $otherAudience->id,
+            'name' => 'Other Team Broadcast',
+        ]);
+
+        Livewire::test(BroadcastListPage::class)
+            ->assertOk()
+            ->assertSee('My Team Broadcast')
+            ->assertDontSee('Other Team Broadcast');
+    }
+
+    public function test_create_aborts_when_not_authorized(): void
+    {
+        $user = $this->loggedInOwner();
+        $audience = Audience::factory()->create(['team_id' => $user->current_team_id]);
+
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(CreateBroadcastForm::class)
+            ->set('audienceId', $audience->id)
+            ->set('name', 'Blocked')
+            ->set('subject', 'Blocked')
+            ->set('body', '<p>Blocked</p>')
+            ->call('create')
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('broadcasts', ['name' => 'Blocked']);
+    }
+
+    public function test_create_with_another_teams_audience_fails_scoped_exists(): void
+    {
+        $this->loggedInOwner();
+
+        $otherTeam = Team::factory()->create();
+        $otherAudience = Audience::factory()->create(['team_id' => $otherTeam->id]);
+
+        Livewire::test(CreateBroadcastForm::class)
+            ->set('audienceId', $otherAudience->id)
+            ->set('name', 'Cross Tenant')
+            ->set('subject', 'Cross Tenant')
+            ->set('body', '<p>Cross Tenant</p>')
+            ->call('create')
+            ->assertHasErrors(['audienceId']);
+
+        $this->assertDatabaseMissing('broadcasts', ['name' => 'Cross Tenant']);
+    }
+
+    public function test_create_with_own_audience_succeeds_and_redirects(): void
+    {
+        $user = $this->loggedInOwner();
+        $audience = Audience::factory()->create(['team_id' => $user->current_team_id]);
+
+        Livewire::test(CreateBroadcastForm::class)
+            ->set('audienceId', $audience->id)
+            ->set('name', 'Launch Email')
+            ->set('subject', 'We launched')
+            ->set('body', '<p>Hello</p>')
+            ->call('create')
+            ->assertHasNoErrors()
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('broadcasts', [
+            'name' => 'Launch Email',
+            'audience_id' => $audience->id,
+            'team_id' => $user->current_team_id,
+            'status' => 'draft',
+        ]);
+    }
+}

--- a/tests/Feature/Livewire/CredentialScanPageTest.php
+++ b/tests/Feature/Livewire/CredentialScanPageTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Audit\Models\AuditEntry;
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Credentials\CredentialScanPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CredentialScanPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function loggedInOwner(): User
+    {
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'Scan',
+            'slug' => 'scan-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $team->users()->attach($user, ['role' => TeamRole::Owner->value]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function finding(string $teamId, array $overrides = []): AuditEntry
+    {
+        return AuditEntry::withoutGlobalScopes()->create(array_merge([
+            'team_id' => $teamId,
+            'user_id' => null,
+            'event' => 'secret_detected',
+            'ocsf_class_uid' => 6003,
+            'ocsf_severity_id' => 3,
+            'subject_type' => 'agent',
+            'subject_id' => (string) Str::uuid(),
+            'properties' => [
+                'pattern_id' => 'OPENAI_KEY',
+                'pattern_name' => 'OpenAI API key',
+                'field' => 'goal',
+                'content_hash' => sha1('x'),
+            ],
+            'triggered_by' => 'secret_scanner',
+            'created_at' => now(),
+        ], $overrides));
+    }
+
+    public function test_route_renders_for_authed_user(): void
+    {
+        $this->loggedInOwner();
+        $this->get('/credentials/scan')->assertStatus(200);
+    }
+
+    public function test_lists_only_findings_for_current_team(): void
+    {
+        $user = $this->loggedInOwner();
+
+        $mine = $this->finding($user->current_team_id, [
+            'properties' => ['pattern_id' => 'MINE_KEY', 'pattern_name' => 'My Finding', 'field' => 'goal'],
+        ]);
+
+        $otherTeamId = (string) Str::uuid();
+        $theirs = $this->finding($otherTeamId, [
+            'properties' => ['pattern_id' => 'THEIR_KEY', 'pattern_name' => 'Their Finding', 'field' => 'goal'],
+        ]);
+
+        Livewire::test(CredentialScanPage::class)
+            ->assertSee('My Finding')
+            ->assertDontSee('Their Finding');
+    }
+
+    public function test_acknowledged_findings_hidden_by_default_and_shown_when_toggled(): void
+    {
+        $user = $this->loggedInOwner();
+
+        $this->finding($user->current_team_id, [
+            'properties' => [
+                'pattern_id' => 'ACK_KEY',
+                'pattern_name' => 'Acked Finding',
+                'field' => 'goal',
+                'acknowledged_at' => now()->toIso8601String(),
+            ],
+        ]);
+
+        Livewire::test(CredentialScanPage::class)
+            ->assertDontSee('Acked Finding')
+            ->set('showAcknowledged', true)
+            ->assertSee('Acked Finding');
+    }
+
+    public function test_acknowledge_stamps_properties(): void
+    {
+        $user = $this->loggedInOwner();
+        $finding = $this->finding($user->current_team_id);
+
+        Livewire::test(CredentialScanPage::class)
+            ->call('acknowledge', $finding->id)
+            ->assertDispatched('scan-finding-acknowledged');
+
+        $finding->refresh();
+        $this->assertNotEmpty($finding->properties['acknowledged_at']);
+        $this->assertSame($user->id, $finding->properties['acknowledged_by']);
+    }
+
+    public function test_rescan_is_forbidden_when_edit_content_denied(): void
+    {
+        $user = $this->loggedInOwner();
+        $finding = $this->finding($user->current_team_id);
+
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(CredentialScanPage::class)
+            ->call('rescan', $finding->id)
+            ->assertForbidden();
+    }
+
+    public function test_acknowledge_is_forbidden_when_edit_content_denied(): void
+    {
+        $user = $this->loggedInOwner();
+        $finding = $this->finding($user->current_team_id);
+
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(CredentialScanPage::class)
+            ->call('acknowledge', $finding->id)
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Livewire/CrewChatRoomPageTest.php
+++ b/tests/Feature/Livewire/CrewChatRoomPageTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Crew\Actions\SendAgentMessageAction;
+use App\Domain\Crew\Enums\CrewExecutionStatus;
+use App\Domain\Crew\Enums\CrewProcessType;
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Crew\Models\CrewChatMessage;
+use App\Domain\Crew\Models\CrewExecution;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Crews\CrewChatRoomPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CrewChatRoomPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    private Crew $crew;
+
+    private CrewExecution $execution;
+
+    private Agent $agentA;
+
+    private Agent $agentB;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Chat Room Test Team',
+            'slug' => 'chat-room-test-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+
+        $this->agentA = Agent::factory()->for($this->team)->create(['name' => 'Agent Alpha']);
+        $this->agentB = Agent::factory()->for($this->team)->create(['name' => 'Agent Beta']);
+
+        $this->crew = Crew::factory()->for($this->team)->create([
+            'user_id' => $this->user->id,
+            'coordinator_agent_id' => $this->agentA->id,
+            'qa_agent_id' => $this->agentB->id,
+        ]);
+
+        $this->execution = CrewExecution::create([
+            'team_id' => $this->team->id,
+            'crew_id' => $this->crew->id,
+            'goal' => 'Investigate the bug',
+            'status' => CrewExecutionStatus::Executing,
+            'config_snapshot' => [
+                'process_type' => CrewProcessType::Parallel->value,
+            ],
+            'total_cost_credits' => 0,
+            'coordinator_iterations' => 0,
+            'delegation_depth' => 0,
+        ]);
+    }
+
+    public function test_it_shows_a_crew_executions_inter_agent_messages(): void
+    {
+        $send = new SendAgentMessageAction;
+        $send->execute($this->execution, 'finding', 'Alpha hypothesis is X.', sender: $this->agentA, recipient: $this->agentB, round: 1);
+        $send->execute($this->execution, 'broadcast', 'Heads up everyone.', sender: $this->agentA, round: 1);
+
+        Livewire::test(CrewChatRoomPage::class, ['execution' => $this->execution->id])
+            ->assertOk()
+            ->assertSee('Inter-Agent Messages')
+            ->assertSee('Alpha hypothesis is X.')
+            ->assertSee('Heads up everyone.')
+            ->assertSee('Agent Alpha')
+            ->assertSee('Agent Beta')
+            ->assertSee('broadcast');
+    }
+
+    public function test_it_shows_chat_room_transcript(): void
+    {
+        CrewChatMessage::create([
+            'crew_execution_id' => $this->execution->id,
+            'agent_id' => $this->agentA->id,
+            'agent_name' => 'Agent Alpha',
+            'role' => 'assistant',
+            'content' => 'I propose we split the work.',
+            'round' => 1,
+            'metadata' => [],
+        ]);
+
+        Livewire::test(CrewChatRoomPage::class, ['execution' => $this->execution->id])
+            ->assertOk()
+            ->assertSee('Chat Room Discussion')
+            ->assertSee('I propose we split the work.');
+    }
+
+    public function test_it_cannot_view_another_teams_execution(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::factory()->create(['owner_id' => $otherUser->id]);
+
+        $otherAgent = Agent::factory()->for($otherTeam)->create();
+        $otherCrew = Crew::factory()->for($otherTeam)->create([
+            'user_id' => $otherUser->id,
+            'coordinator_agent_id' => $otherAgent->id,
+            'qa_agent_id' => $otherAgent->id,
+        ]);
+
+        $otherExecution = CrewExecution::create([
+            'team_id' => $otherTeam->id,
+            'crew_id' => $otherCrew->id,
+            'goal' => 'Secret goal',
+            'status' => CrewExecutionStatus::Executing,
+            'config_snapshot' => [],
+            'total_cost_credits' => 0,
+            'coordinator_iterations' => 0,
+            'delegation_depth' => 0,
+        ]);
+
+        // Current user (acting as $this->user / $this->team) must not resolve
+        // another team's execution — the global TeamScope returns null and the
+        // page aborts 404.
+        Livewire::test(CrewChatRoomPage::class, ['execution' => $otherExecution->id])
+            ->assertStatus(404);
+    }
+
+    public function test_it_404s_for_unknown_execution_id(): void
+    {
+        Livewire::test(CrewChatRoomPage::class, ['execution' => '00000000-0000-0000-0000-000000000000'])
+            ->assertStatus(404);
+    }
+}

--- a/tests/Feature/Livewire/ErrorModeCatalogPageTest.php
+++ b/tests/Feature/Livewire/ErrorModeCatalogPageTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\ErrorMode\Enums\ErrorModeLever;
+use App\Domain\ErrorMode\Models\ErrorMode;
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\ErrorModes\ErrorModeCatalogPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ErrorModeCatalogPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->team->users()->attach($this->user, ['role' => TeamRole::Owner->value]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($this->user);
+    }
+
+    private function makeMode(string $teamId, string $name, array $attributes = []): ErrorMode
+    {
+        return ErrorMode::create(array_merge([
+            'team_id' => $teamId,
+            'slug' => Str::slug($name),
+            'name' => $name,
+            'lever' => ErrorModeLever::Unassigned->value,
+            'status' => 'open',
+            'occurrence_count' => 3,
+            'first_seen_at' => now(),
+            'last_seen_at' => now(),
+            'example_trace_ids' => [],
+        ], $attributes));
+    }
+
+    public function test_lists_error_modes_for_current_team(): void
+    {
+        $this->makeMode($this->team->id, 'Retrieval miss on long docs');
+
+        Livewire::test(ErrorModeCatalogPage::class)
+            ->assertSee('Retrieval miss on long docs');
+    }
+
+    public function test_does_not_show_other_teams_error_modes(): void
+    {
+        $this->makeMode($this->team->id, 'Mine only error mode');
+
+        $otherTeam = Team::factory()->create();
+        $this->makeMode($otherTeam->id, 'Their secret error mode');
+
+        Livewire::test(ErrorModeCatalogPage::class)
+            ->assertSee('Mine only error mode')
+            ->assertDontSee('Their secret error mode');
+    }
+
+    public function test_lever_filter_narrows_results(): void
+    {
+        $this->makeMode($this->team->id, 'Prompt lever mode', ['lever' => ErrorModeLever::Prompt->value]);
+        $this->makeMode($this->team->id, 'Retrieval lever mode', ['lever' => ErrorModeLever::Retrieval->value]);
+
+        Livewire::test(ErrorModeCatalogPage::class)
+            ->set('leverFilter', ErrorModeLever::Prompt->value)
+            ->assertSee('Prompt lever mode')
+            ->assertDontSee('Retrieval lever mode');
+    }
+
+    public function test_owner_can_assign_lever(): void
+    {
+        $mode = $this->makeMode($this->team->id, 'Assignable mode');
+
+        Livewire::test(ErrorModeCatalogPage::class)
+            ->call('assignLever', $mode->id, ErrorModeLever::Guardrails->value);
+
+        $this->assertSame(ErrorModeLever::Guardrails, $mode->fresh()->lever);
+    }
+
+    public function test_viewer_cannot_assign_lever(): void
+    {
+        // base 'edit-content' gate is permissive; deny it to prove assignLever
+        // authorizes on the action (cloud gates it by role).
+        \Illuminate\Support\Facades\Gate::define('edit-content', fn () => false);
+
+        $mode = $this->makeMode($this->team->id, 'Protected mode');
+
+        Livewire::test(ErrorModeCatalogPage::class)
+            ->call('assignLever', $mode->id, ErrorModeLever::Guardrails->value)
+            ->assertForbidden();
+
+        $this->assertSame(ErrorModeLever::Unassigned, $mode->fresh()->lever);
+    }
+}

--- a/tests/Feature/Livewire/EvaluationDashboardsPageTest.php
+++ b/tests/Feature/Livewire/EvaluationDashboardsPageTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Evaluation\Enums\DriftSignalType;
+use App\Domain\Evaluation\Models\DriftSignal;
+use App\Domain\Evaluation\Models\EvaluationMonitorSnapshot;
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Evaluation\DriftSignalsPage;
+use App\Livewire\Evaluation\EvalMonitorPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class EvaluationDashboardsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function loggedInOwner(): User
+    {
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'Eval',
+            'slug' => 'eval-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $team->users()->attach($user, ['role' => TeamRole::Owner->value]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function otherTeam(): Team
+    {
+        $otherOwner = User::factory()->create();
+
+        return Team::create([
+            'name' => 'Other',
+            'slug' => 'other-'.uniqid(),
+            'owner_id' => $otherOwner->id,
+            'settings' => [],
+        ]);
+    }
+
+    public function test_drift_route_renders_for_authed_user(): void
+    {
+        $this->loggedInOwner();
+        $this->get('/evaluation/drift')->assertStatus(200);
+    }
+
+    public function test_monitor_route_renders_for_authed_user(): void
+    {
+        $this->loggedInOwner();
+        $this->get('/evaluation/monitor')->assertStatus(200);
+    }
+
+    public function test_drift_page_shows_current_team_signal(): void
+    {
+        $user = $this->loggedInOwner();
+
+        DriftSignal::create([
+            'team_id' => $user->current_team_id,
+            'signal_type' => DriftSignalType::EvalScoreDecay,
+            'value' => 0.42,
+            'baseline' => 0.80,
+            'breached' => true,
+            'window' => '7d',
+            'detected_at' => now(),
+        ]);
+
+        Livewire::test(DriftSignalsPage::class)
+            ->assertSee('Eval score decay')
+            ->assertSee('Breached');
+    }
+
+    public function test_drift_page_cross_team_isolation(): void
+    {
+        $this->loggedInOwner();
+        $other = $this->otherTeam();
+
+        DriftSignal::create([
+            'team_id' => $other->id,
+            'signal_type' => DriftSignalType::ThumbsDownRate,
+            'value' => 0.99,
+            'baseline' => 0.10,
+            'breached' => true,
+            'window' => '1d',
+            'detected_at' => now(),
+        ]);
+
+        // Current team has zero drift signals, so the empty state proves the other
+        // team's row is scoped out. (Asserting on the type label would be brittle —
+        // it also appears as a filter <option>.)
+        Livewire::test(DriftSignalsPage::class)
+            ->assertSee('No drift signals recorded yet.');
+    }
+
+    public function test_monitor_page_shows_current_team_snapshot(): void
+    {
+        $user = $this->loggedInOwner();
+
+        EvaluationMonitorSnapshot::create([
+            'team_id' => $user->current_team_id,
+            'avg_score' => 7.50,
+            'pass_rate' => 91.20,
+            'active_count' => 12,
+            'deferred_passed' => 3,
+            'sampled_count' => 20,
+        ]);
+
+        Livewire::test(EvalMonitorPage::class)
+            ->assertSee('7.50')
+            ->assertSee('91.20%');
+    }
+
+    public function test_monitor_page_cross_team_isolation(): void
+    {
+        $this->loggedInOwner();
+        $other = $this->otherTeam();
+
+        EvaluationMonitorSnapshot::create([
+            'team_id' => $other->id,
+            'avg_score' => 1.11,
+            'pass_rate' => 22.22,
+            'active_count' => 5,
+            'deferred_passed' => 1,
+            'sampled_count' => 9,
+        ]);
+
+        Livewire::test(EvalMonitorPage::class)
+            ->assertDontSee('22.22%')
+            ->assertSee('No monitor snapshots in this period.');
+    }
+}

--- a/tests/Feature/Livewire/ExperimentCheckpointsPageTest.php
+++ b/tests/Feature/Livewire/ExperimentCheckpointsPageTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Experiments\ExperimentCheckpointsPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ExperimentCheckpointsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Checkpoint UI Test',
+            'slug' => 'checkpoint-ui-test',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    private function makeExperiment(Team $team, array $overrides = []): Experiment
+    {
+        return Experiment::create(array_merge([
+            'team_id' => $team->id,
+            'title' => 'Checkpoint Target',
+            'status' => 'executing',
+            'track' => 'growth',
+            'description' => 't',
+            'user_id' => $this->user->id,
+            'initiated_by_user_id' => $this->user->id,
+        ], $overrides));
+    }
+
+    public function test_lists_checkpoints_for_a_team_experiment(): void
+    {
+        $experiment = $this->makeExperiment($this->team);
+
+        $withCheckpoint = PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'order' => 1,
+            'status' => 'running',
+            'worker_id' => 'worker-abc',
+            'idempotency_key' => 'idem-123',
+            'checkpoint_version' => 2,
+            'checkpoint_data' => ['cursor' => 42],
+        ]);
+
+        // A step without checkpoint data must NOT appear.
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'order' => 2,
+            'status' => 'pending',
+        ]);
+
+        $component = Livewire::test(ExperimentCheckpointsPage::class, ['experiment' => $experiment->id])
+            ->assertOk()
+            ->assertSee('worker-abc')
+            ->assertSee('idem-123');
+
+        $this->assertCount(1, $component->instance()->checkpoints());
+        $this->assertTrue($component->instance()->checkpoints()->contains('id', $withCheckpoint->id));
+    }
+
+    public function test_cannot_view_another_teams_experiment(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other Team',
+            'slug' => 'other-team',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+        $foreign = $this->makeExperiment($otherTeam, ['user_id' => $otherUser->id, 'initiated_by_user_id' => $otherUser->id]);
+
+        Livewire::test(ExperimentCheckpointsPage::class, ['experiment' => $foreign->id])
+            ->assertStatus(404);
+    }
+
+    public function test_unauthorized_user_cannot_resume_from_checkpoint(): void
+    {
+        // Community edition's edit-content gate is always-true; deny it explicitly
+        // to exercise the per-action authorization guard.
+        Gate::define('edit-content', fn () => false);
+
+        $experiment = $this->makeExperiment($this->team);
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'order' => 1,
+            'status' => 'running',
+            'checkpoint_data' => ['cursor' => 1],
+        ]);
+
+        Livewire::test(ExperimentCheckpointsPage::class, ['experiment' => $experiment->id])
+            ->call('resumeFromCheckpoint')
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Livewire/ImportWizardPageTest.php
+++ b/tests/Feature/Livewire/ImportWizardPageTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Migration\Enums\MigrationStatus;
+use App\Domain\Migration\Models\MigrationRun;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Livewire\Migration\ImportWizardPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Mockery;
+use Tests\TestCase;
+
+class ImportWizardPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $owner;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->owner = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Import Team',
+            'slug' => 'import-team',
+            'owner_id' => $this->owner->id,
+            'settings' => [],
+        ]);
+        $this->owner->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->owner, ['role' => 'owner']);
+    }
+
+    /**
+     * Fake the AI gateway so DetectSchemaAction never hits a real provider.
+     * The detector reads `parsedOutput` first — we return a clean column_map.
+     *
+     * @param  array<string, ?string>  $columnMap
+     */
+    private function fakeGateway(array $columnMap): void
+    {
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')->andReturn(new AiResponseDTO(
+            content: json_encode(['column_map' => $columnMap, 'confidence' => 0.9, 'warnings' => []]),
+            parsedOutput: ['column_map' => $columnMap, 'confidence' => 0.9, 'warnings' => []],
+            usage: new AiUsageDTO(promptTokens: 10, completionTokens: 20, costCredits: 0),
+            provider: 'anthropic',
+            model: 'claude-haiku-4-5',
+            latencyMs: 5,
+        ));
+        $this->app->instance(AiGatewayInterface::class, $gateway);
+    }
+
+    private function csvFile(): UploadedFile
+    {
+        $csv = "Full Name,Email,Phone\nJane Doe,jane@example.com,+359100\nJohn Smith,john@example.com,+359200\n";
+
+        return UploadedFile::fake()->createWithContent('contacts.csv', $csv);
+    }
+
+    public function test_detect_step_produces_a_mapping(): void
+    {
+        $this->fakeGateway([
+            'Full Name' => 'display_name',
+            'Email' => 'email',
+            'Phone' => 'phone',
+        ]);
+
+        Livewire::actingAs($this->owner)
+            ->test(ImportWizardPage::class)
+            ->set('file', $this->csvFile())
+            ->call('detect')
+            ->assertSet('step', 2)
+            ->assertSet('mapping.Email', 'email')
+            ->assertSet('mapping.Full Name', 'display_name');
+
+        $this->assertDatabaseHas('migration_runs', [
+            'team_id' => $this->team->id,
+            'status' => MigrationStatus::AwaitingConfirmation->value,
+        ]);
+    }
+
+    public function test_import_step_executes_migration_and_creates_run(): void
+    {
+        $this->fakeGateway([
+            'Full Name' => 'display_name',
+            'Email' => 'email',
+            'Phone' => 'phone',
+        ]);
+
+        Livewire::actingAs($this->owner)
+            ->test(ImportWizardPage::class)
+            ->set('file', $this->csvFile())
+            ->call('detect')
+            ->call('import')
+            ->assertSet('step', 3)
+            ->assertHasNoErrors();
+
+        // Queue is sync in tests — ExecuteMigrationJob runs immediately.
+        $run = MigrationRun::query()->where('team_id', $this->team->id)->firstOrFail();
+        $this->assertSame(MigrationStatus::Completed, $run->status);
+        $this->assertSame(2, $run->stats['created']);
+        $this->assertDatabaseCount('contact_identities', 2);
+    }
+
+    public function test_unauthorized_user_is_aborted(): void
+    {
+        // Base edition defines `edit-content` as always-true; override it to
+        // false so the per-action authorization guard is exercised directly.
+        // (Cloud edition gates this on TeamRole — same code path, real deny.)
+        Gate::define('edit-content', fn ($user) => false);
+
+        $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($viewer, ['role' => 'viewer']);
+
+        Livewire::actingAs($viewer)
+            ->test(ImportWizardPage::class)
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Livewire/KgCommunitiesPageTest.php
+++ b/tests/Feature/Livewire/KgCommunitiesPageTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\KnowledgeGraph\Models\KgCommunity;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\KnowledgeGraph\KgCommunitiesPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class KgCommunitiesPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Communities Test Team',
+            'slug' => 'communities-test-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    private function makeCommunity(string $teamId, string $label, int $size = 3): KgCommunity
+    {
+        return KgCommunity::create([
+            'team_id' => $teamId,
+            'label' => $label,
+            'summary' => 'A cluster of related entities.',
+            'entity_ids' => ['e1', 'e2', 'e3'],
+            'size' => $size,
+            'top_entities' => [
+                ['id' => 'e1', 'name' => 'Alpha', 'type' => 'topic', 'mentions' => 5],
+            ],
+        ]);
+    }
+
+    public function test_lists_only_current_team_communities(): void
+    {
+        $this->makeCommunity($this->team->id, 'My Team Cluster Unique-A1B2C3');
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other Team',
+            'slug' => 'other-team',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+        $this->makeCommunity($otherTeam->id, 'Foreign Cluster Should-Not-Appear-Z9Y8X7');
+
+        Livewire::test(KgCommunitiesPage::class)
+            ->assertSee('My Team Cluster Unique-A1B2C3')
+            ->assertDontSee('Foreign Cluster Should-Not-Appear-Z9Y8X7');
+    }
+
+    public function test_search_filters_by_label(): void
+    {
+        $this->makeCommunity($this->team->id, 'Billing Cluster Findme-7K');
+        $this->makeCommunity($this->team->id, 'Marketing Cluster Other-2Q');
+
+        Livewire::test(KgCommunitiesPage::class)
+            ->set('search', 'Findme-7K')
+            ->assertSee('Billing Cluster Findme-7K')
+            ->assertDontSee('Marketing Cluster Other-2Q');
+    }
+
+    public function test_rebuild_forbidden_without_edit_content(): void
+    {
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(KgCommunitiesPage::class)
+            ->call('rebuild')
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Livewire/MemoryProposalsPageTest.php
+++ b/tests/Feature/Livewire/MemoryProposalsPageTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Memory\Enums\MemoryTier;
+use App\Domain\Memory\Models\Memory;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Memory\MemoryProposalsPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class MemoryProposalsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    private Agent $agent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Proposals Test Team',
+            'slug' => 'proposals-test-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+
+        $this->agent = Agent::factory()->for($this->team)->create();
+    }
+
+    private function makeProposal(array $overrides = []): Memory
+    {
+        return Memory::create(array_merge([
+            'team_id' => $this->team->id,
+            'agent_id' => $this->agent->id,
+            'content' => 'proposed memory content with enough length to pass checks',
+            'source_type' => 'experiment',
+            'tier' => MemoryTier::Proposed->value,
+            'confidence' => 0.7,
+            'proposed_by' => 'system:success_extractor',
+            'metadata' => [],
+        ], $overrides));
+    }
+
+    public function test_queue_shows_only_pending_proposals(): void
+    {
+        $pending = $this->makeProposal(['content' => 'pending proposal awaiting review here']);
+        $approved = $this->makeProposal(['proposal_status' => 'approved', 'content' => 'already approved memory item']);
+        $working = $this->makeProposal(['tier' => MemoryTier::Working->value, 'content' => 'working tier memory item here']);
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->assertSee('pending proposal awaiting review here')
+            ->assertDontSee('already approved memory item')
+            ->assertDontSee('working tier memory item here');
+    }
+
+    public function test_queue_does_not_leak_other_teams_proposals(): void
+    {
+        $other = Team::create([
+            'name' => 'Other Team',
+            'slug' => 'other-team',
+            'owner_id' => User::factory()->create()->id,
+            'settings' => [],
+        ]);
+
+        $mine = $this->makeProposal(['content' => 'my team proposal content here ok']);
+        $theirs = Memory::create([
+            'team_id' => $other->id,
+            'content' => 'other team proposal content secret',
+            'source_type' => 'experiment',
+            'tier' => MemoryTier::Proposed->value,
+            'confidence' => 0.7,
+            'proposed_by' => 'system:other',
+            'metadata' => [],
+        ]);
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->assertSee('my team proposal content here ok')
+            ->assertDontSee('other team proposal content secret');
+    }
+
+    public function test_approve_promotes_proposal_to_curated_tier(): void
+    {
+        $memory = $this->makeProposal();
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->set('approveTier.'.$memory->id, MemoryTier::Facts->value)
+            ->call('approve', $memory->id);
+
+        $memory->refresh();
+        $this->assertSame('approved', $memory->proposal_status);
+        $this->assertSame(MemoryTier::Facts->value, $memory->tier->value);
+        $this->assertNotNull($memory->reviewed_at);
+    }
+
+    public function test_approve_defaults_to_canonical_when_no_tier_chosen(): void
+    {
+        $memory = $this->makeProposal();
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->call('approve', $memory->id);
+
+        $memory->refresh();
+        $this->assertSame('approved', $memory->proposal_status);
+        $this->assertSame(MemoryTier::Canonical->value, $memory->tier->value);
+    }
+
+    public function test_reject_records_reason_and_marks_rejected(): void
+    {
+        $memory = $this->makeProposal();
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->call('startReject', $memory->id)
+            ->set('rejectReason', 'duplicate of existing canonical fact')
+            ->call('reject', $memory->id);
+
+        $memory->refresh();
+        $this->assertSame('rejected', $memory->proposal_status);
+        $this->assertSame('duplicate of existing canonical fact', $memory->rejection_reason);
+        $this->assertNotNull($memory->reviewed_at);
+    }
+
+    public function test_reject_requires_a_reason(): void
+    {
+        $memory = $this->makeProposal();
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->set('rejectReason', '   ')
+            ->call('reject', $memory->id);
+
+        $memory->refresh();
+        $this->assertNull($memory->proposal_status);
+    }
+
+    public function test_unauthorized_user_cannot_approve_or_reject(): void
+    {
+        // The community edition's edit-content gate is permissive
+        // (fn () => true). Override it here to assert the component actually
+        // routes both mutations through Gate::authorize('edit-content').
+        Gate::define('edit-content', fn () => false);
+
+        $memory = $this->makeProposal();
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->call('approve', $memory->id)
+            ->assertForbidden();
+
+        Livewire::test(MemoryProposalsPage::class)
+            ->set('rejectReason', 'spam')
+            ->call('reject', $memory->id)
+            ->assertForbidden();
+
+        $memory->refresh();
+        $this->assertNull($memory->proposal_status);
+    }
+}

--- a/tests/Feature/Livewire/OutboundProposalsPageTest.php
+++ b/tests/Feature/Livewire/OutboundProposalsPageTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Outbound\Enums\OutboundProposalStatus;
+use App\Domain\Outbound\Models\OutboundProposal;
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Outbound\OutboundProposalsPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class OutboundProposalsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->team->users()->attach($this->user, ['role' => TeamRole::Owner->value]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($this->user);
+    }
+
+    public function test_lists_proposals_for_current_team(): void
+    {
+        OutboundProposal::factory()->create([
+            'team_id' => $this->team->id,
+            'target' => ['email' => 'lead@mine.example'],
+        ]);
+
+        Livewire::test(OutboundProposalsPage::class)
+            ->assertSee('lead@mine.example');
+    }
+
+    public function test_does_not_show_other_teams_proposals(): void
+    {
+        OutboundProposal::factory()->create([
+            'team_id' => $this->team->id,
+            'target' => ['email' => 'mine@example.com'],
+        ]);
+
+        $otherTeam = Team::factory()->create();
+        OutboundProposal::factory()->create([
+            'team_id' => $otherTeam->id,
+            'target' => ['email' => 'theirs@example.com'],
+        ]);
+
+        Livewire::test(OutboundProposalsPage::class)
+            ->assertSee('mine@example.com')
+            ->assertDontSee('theirs@example.com');
+    }
+
+    public function test_status_filter_narrows_results(): void
+    {
+        OutboundProposal::factory()->create([
+            'team_id' => $this->team->id,
+            'status' => OutboundProposalStatus::PendingApproval,
+            'target' => ['email' => 'pending@example.com'],
+        ]);
+        OutboundProposal::factory()->create([
+            'team_id' => $this->team->id,
+            'status' => OutboundProposalStatus::Rejected,
+            'target' => ['email' => 'rejected@example.com'],
+        ]);
+
+        Livewire::test(OutboundProposalsPage::class)
+            ->set('statusFilter', OutboundProposalStatus::Rejected->value)
+            ->assertSee('rejected@example.com')
+            ->assertDontSee('pending@example.com');
+    }
+}

--- a/tests/Feature/Livewire/ReasoningBankPageTest.php
+++ b/tests/Feature/Livewire/ReasoningBankPageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\ReasoningBankEntry;
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Experiments\ReasoningBankPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ReasoningBankPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->team->users()->attach($this->user, ['role' => TeamRole::Owner->value]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($this->user);
+    }
+
+    private function makeEntry(Team $team, string $goal, string $outcome): ReasoningBankEntry
+    {
+        $experiment = Experiment::factory()->create(['team_id' => $team->id]);
+
+        return ReasoningBankEntry::withoutGlobalScopes()->create([
+            'team_id' => $team->id,
+            'experiment_id' => $experiment->id,
+            'goal_text' => $goal,
+            'tool_sequence' => ['bash', 'browser'],
+            'outcome_summary' => $outcome,
+        ]);
+    }
+
+    public function test_renders_current_team_entries(): void
+    {
+        $this->makeEntry($this->team, 'mine-goal-UNIQUE-7f3a', 'mine-outcome-UNIQUE-7f3a');
+
+        Livewire::test(ReasoningBankPage::class)
+            ->assertSee('mine-goal-UNIQUE-7f3a');
+    }
+
+    public function test_does_not_render_other_teams_entries(): void
+    {
+        $this->makeEntry($this->team, 'mine-goal-UNIQUE-aa11', 'mine-outcome-UNIQUE-aa11');
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::factory()->create(['owner_id' => $otherUser->id]);
+        $this->makeEntry($otherTeam, 'their-goal-UNIQUE-bb22', 'their-outcome-UNIQUE-bb22');
+
+        Livewire::test(ReasoningBankPage::class)
+            ->assertSee('mine-goal-UNIQUE-aa11')
+            ->assertDontSee('their-goal-UNIQUE-bb22');
+    }
+
+    public function test_search_filters_by_goal_text(): void
+    {
+        $this->makeEntry($this->team, 'alpha-goal-UNIQUE-cc33', 'alpha-outcome');
+        $this->makeEntry($this->team, 'beta-goal-UNIQUE-dd44', 'beta-outcome');
+
+        Livewire::test(ReasoningBankPage::class)
+            ->set('search', 'alpha-goal-UNIQUE-cc33')
+            ->assertSee('alpha-goal-UNIQUE-cc33')
+            ->assertDontSee('beta-goal-UNIQUE-dd44');
+    }
+}

--- a/tests/Feature/Livewire/SigningKeysPageTest.php
+++ b/tests/Feature/Livewire/SigningKeysPageTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Release\Crypto\Enums\SigningKeyStatus;
+use App\Domain\Release\Crypto\Models\ReleaseSigningKey;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Releases\SigningKeysPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SigningKeysPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    public function test_generate_creates_an_active_key(): void
+    {
+        Livewire::test(SigningKeysPage::class)
+            ->call('generate')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('release_signing_keys', [
+            'team_id' => $this->team->id,
+            'status' => SigningKeyStatus::Active->value,
+        ]);
+    }
+
+    public function test_revoke_flips_status_to_revoked(): void
+    {
+        $key = ReleaseSigningKey::create([
+            'team_id' => $this->team->id,
+            'public_key' => base64_encode('pubkey-bytes'),
+            'secret_data' => base64_encode('secret-bytes'),
+            'status' => SigningKeyStatus::Active,
+        ]);
+
+        Livewire::test(SigningKeysPage::class)
+            ->call('revoke', $key->id)
+            ->assertHasNoErrors();
+
+        $this->assertSame(SigningKeyStatus::Revoked, $key->refresh()->status);
+        $this->assertNotNull($key->revoked_at);
+    }
+
+    public function test_non_authorized_user_cannot_revoke(): void
+    {
+        // Simulate a viewer/non-owner: deny the management gate.
+        Gate::define('manage-team', fn () => false);
+
+        $key = ReleaseSigningKey::create([
+            'team_id' => $this->team->id,
+            'public_key' => base64_encode('pubkey-bytes'),
+            'secret_data' => base64_encode('secret-bytes'),
+            'status' => SigningKeyStatus::Active,
+        ]);
+
+        Livewire::test(SigningKeysPage::class)
+            ->call('revoke', $key->id)
+            ->assertStatus(403);
+
+        $this->assertSame(SigningKeyStatus::Active, $key->refresh()->status);
+    }
+}

--- a/tests/Feature/Livewire/SkillOpsPageTest.php
+++ b/tests/Feature/Livewire/SkillOpsPageTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Skill\Enums\AnnotationRating;
+use App\Domain\Skill\Enums\BenchmarkStatus;
+use App\Domain\Skill\Jobs\SkillImprovementIterationJob;
+use App\Domain\Skill\Models\Skill;
+use App\Domain\Skill\Models\SkillBenchmark;
+use App\Domain\Skill\Models\SkillVersion;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Livewire\Skills\SkillOpsPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SkillOpsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function loggedInOwner(): User
+    {
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'Ops Test',
+            'slug' => 'ops-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $team->users()->attach($user, ['role' => TeamRole::Owner->value]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function bindFakeGateway(): void
+    {
+        $gateway = new class implements AiGatewayInterface
+        {
+            public function complete(AiRequestDTO $request): AiResponseDTO
+            {
+                return new AiResponseDTO(
+                    content: 'faked',
+                    parsedOutput: null,
+                    usage: new AiUsageDTO(promptTokens: 1, completionTokens: 1, costCredits: 1),
+                    provider: 'anthropic',
+                    model: 'claude-sonnet-4-5',
+                    latencyMs: 1,
+                );
+            }
+
+            public function stream(AiRequestDTO $request, ?callable $onChunk = null): AiResponseDTO
+            {
+                return $this->complete($request);
+            }
+
+            public function estimateCost(AiRequestDTO $request): int
+            {
+                return 1;
+            }
+        };
+
+        $this->app->instance(AiGatewayInterface::class, $gateway);
+    }
+
+    public function test_lists_only_current_teams_skills(): void
+    {
+        $user = $this->loggedInOwner();
+
+        $mine = Skill::factory()->create(['team_id' => $user->currentTeam->id, 'name' => 'My Skill']);
+        $other = Skill::factory()->create(['name' => 'Foreign Skill']);
+
+        Livewire::test(SkillOpsPage::class)
+            ->assertSee('My Skill')
+            ->assertDontSee('Foreign Skill');
+    }
+
+    public function test_start_loop_requires_authorization(): void
+    {
+        $user = $this->loggedInOwner();
+        Skill::factory()->create(['team_id' => $user->currentTeam->id]);
+
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(SkillOpsPage::class)
+            ->call('startLoop')
+            ->assertForbidden();
+    }
+
+    public function test_start_loop_creates_benchmark_and_dispatches_job(): void
+    {
+        Queue::fake();
+        $user = $this->loggedInOwner();
+        $skill = Skill::factory()->create(['team_id' => $user->currentTeam->id]);
+
+        Livewire::test(SkillOpsPage::class)
+            ->set('tab', 'loop')
+            ->set('skillId', $skill->id)
+            ->set('loopMetric', 'accuracy')
+            ->set('loopMaxIterations', 3)
+            ->call('startLoop')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('skill_benchmarks', [
+            'skill_id' => $skill->id,
+            'metric_name' => 'accuracy',
+            'status' => BenchmarkStatus::Running->value,
+        ]);
+
+        Queue::assertPushed(SkillImprovementIterationJob::class);
+    }
+
+    public function test_start_benchmark_creates_running_benchmark(): void
+    {
+        Queue::fake();
+        $this->bindFakeGateway();
+        $user = $this->loggedInOwner();
+        $skill = Skill::factory()->create(['team_id' => $user->currentTeam->id]);
+        SkillVersion::factory()->create(['skill_id' => $skill->id, 'version' => 1]);
+
+        Livewire::test(SkillOpsPage::class)
+            ->set('tab', 'benchmarks')
+            ->set('benchSkillId', $skill->id)
+            ->set('benchMetricName', 'latency_ms')
+            ->set('benchTestInputs', '[{"input":"hi"}]')
+            ->call('startBenchmark')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('skill_benchmarks', [
+            'skill_id' => $skill->id,
+            'metric_name' => 'latency_ms',
+            'status' => BenchmarkStatus::Running->value,
+        ]);
+    }
+
+    public function test_cancel_benchmark_marks_cancelled(): void
+    {
+        $user = $this->loggedInOwner();
+        $skill = Skill::factory()->create(['team_id' => $user->currentTeam->id]);
+        $benchmark = SkillBenchmark::create([
+            'skill_id' => $skill->id,
+            'team_id' => $user->currentTeam->id,
+            'metric_name' => 'accuracy',
+            'metric_direction' => 'maximize',
+            'baseline_value' => 0.0,
+            'best_value' => 0.0,
+            'test_inputs' => [],
+            'iteration_count' => 0,
+            'max_iterations' => 5,
+            'time_budget_seconds' => 600,
+            'iteration_budget_seconds' => 60,
+            'complexity_penalty' => 0.0,
+            'improvement_threshold' => 0.0,
+            'status' => BenchmarkStatus::Running,
+            'started_at' => now(),
+            'settings' => [],
+        ]);
+
+        Livewire::test(SkillOpsPage::class)
+            ->call('cancelBenchmark', $benchmark->id);
+
+        $this->assertEquals(BenchmarkStatus::Cancelled, $benchmark->fresh()->status);
+    }
+
+    public function test_submit_annotation_persists_rating(): void
+    {
+        $user = $this->loggedInOwner();
+        $skill = Skill::factory()->create(['team_id' => $user->currentTeam->id]);
+        $version = SkillVersion::factory()->create(['skill_id' => $skill->id, 'version' => 1]);
+
+        Livewire::test(SkillOpsPage::class)
+            ->set('tab', 'annotations')
+            ->set('annotateVersionId', $version->id)
+            ->set('annotateModelId', 'anthropic/claude-sonnet-4-5')
+            ->set('annotateInput', 'test input')
+            ->set('annotateOutput', 'test output')
+            ->set('annotateRating', 'good')
+            ->call('submitAnnotation')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('skill_annotations', [
+            'skill_version_id' => $version->id,
+            'team_id' => $user->currentTeam->id,
+            'rating' => AnnotationRating::Good->value,
+        ]);
+    }
+
+    public function test_submit_annotation_requires_authorization(): void
+    {
+        $user = $this->loggedInOwner();
+        $skill = Skill::factory()->create(['team_id' => $user->currentTeam->id]);
+        $version = SkillVersion::factory()->create(['skill_id' => $skill->id, 'version' => 1]);
+
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(SkillOpsPage::class)
+            ->set('annotateVersionId', $version->id)
+            ->set('annotateModelId', 'anthropic/claude-sonnet-4-5')
+            ->set('annotateInput', 'x')
+            ->set('annotateOutput', 'y')
+            ->set('annotateRating', 'good')
+            ->call('submitAnnotation')
+            ->assertForbidden();
+
+        $this->assertDatabaseCount('skill_annotations', 0);
+    }
+}

--- a/tests/Feature/Livewire/TestSuitesPageTest.php
+++ b/tests/Feature/Livewire/TestSuitesPageTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Project\Models\Project;
+use App\Domain\Shared\Enums\TeamRole;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Testing\Enums\TestStatus;
+use App\Domain\Testing\Enums\TestStrategy;
+use App\Domain\Testing\Models\TestRun;
+use App\Domain\Testing\Models\TestSuite;
+use App\Livewire\Testing\TestSuiteDetailPage;
+use App\Livewire\Testing\TestSuitesPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TestSuitesPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->team->users()->attach($this->user, ['role' => TeamRole::Owner->value]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($this->user);
+    }
+
+    private function makeSuite(Team $team, string $name): TestSuite
+    {
+        $project = Project::factory()->create(['team_id' => $team->id]);
+
+        return TestSuite::withoutGlobalScopes()->create([
+            'team_id' => $team->id,
+            'project_id' => $project->id,
+            'name' => $name,
+            'test_strategy' => TestStrategy::Regression,
+        ]);
+    }
+
+    public function test_list_only_shows_current_team_suites(): void
+    {
+        $mineName = 'Mine '.Str::random(8);
+        $theirsName = 'Theirs '.Str::random(8);
+
+        $this->makeSuite($this->team, $mineName);
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::factory()->create(['owner_id' => $otherUser->id]);
+        $this->makeSuite($otherTeam, $theirsName);
+
+        Livewire::test(TestSuitesPage::class)
+            ->assertSee($mineName)
+            ->assertDontSee($theirsName);
+    }
+
+    public function test_detail_page_blocks_cross_tenant_suite(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::factory()->create(['owner_id' => $otherUser->id]);
+        $foreignSuite = $this->makeSuite($otherTeam, 'Foreign '.Str::random(8));
+
+        Livewire::test(TestSuiteDetailPage::class, ['suite' => $foreignSuite->id])
+            ->assertStatus(404);
+    }
+
+    public function test_detail_page_shows_runs_for_owned_suite(): void
+    {
+        $suite = $this->makeSuite($this->team, 'Owned '.Str::random(8));
+
+        $experiment = \App\Domain\Experiment\Models\Experiment::factory()->create(['team_id' => $this->team->id]);
+
+        $run = TestRun::create([
+            'test_suite_id' => $suite->id,
+            'experiment_id' => $experiment->id,
+            'status' => TestStatus::Passed,
+            'score' => 0.91,
+            'started_at' => now(),
+        ]);
+
+        Livewire::test(TestSuiteDetailPage::class, ['suite' => $suite->id])
+            ->assertOk()
+            ->assertSee('Passed');
+
+        $this->assertSame($suite->id, $run->fresh()->test_suite_id);
+    }
+}

--- a/tests/Feature/Livewire/Workflows/WorkflowOpsPageTest.php
+++ b/tests/Feature/Livewire/Workflows/WorkflowOpsPageTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire\Workflows;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Workflow\Enums\WorkflowNodeType;
+use App\Domain\Workflow\Models\Workflow;
+use App\Domain\Workflow\Models\WorkflowEdge;
+use App\Domain\Workflow\Models\WorkflowNode;
+use App\Livewire\Workflows\WorkflowOpsPage;
+use App\Livewire\Workflows\WorkflowSimulationPanel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class WorkflowOpsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Ops Test Team',
+            'slug' => 'ops-test-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    /**
+     * Builds a failed workflow experiment with one completed step whose node
+     * has a compensation node defined (so it surfaces in the compensation view).
+     */
+    private function makeCompensatedFailedExperiment(Team $team): Experiment
+    {
+        $workflow = Workflow::factory()->for($team)->create();
+        $compensationNode = WorkflowNode::factory()->for($workflow)->create();
+        $node = WorkflowNode::factory()->for($workflow)->create([
+            'compensation_node_id' => $compensationNode->id,
+        ]);
+
+        $experiment = Experiment::factory()->for($team)->create([
+            'workflow_id' => $workflow->id,
+            'status' => 'execution_failed',
+        ]);
+
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'workflow_node_id' => $node->id,
+            'order' => 0,
+            'status' => 'completed',
+        ]);
+
+        return $experiment;
+    }
+
+    public function test_lists_failed_runs_that_triggered_compensation(): void
+    {
+        $experiment = $this->makeCompensatedFailedExperiment($this->team);
+
+        Livewire::test(WorkflowOpsPage::class)
+            ->assertSee($experiment->title)
+            ->tap(function ($component): void {
+                $runs = $component->viewData('runs');
+                $this->assertCount(1, $runs);
+                $this->assertSame(1, $runs->first()['compensated_count']);
+            });
+    }
+
+    public function test_excludes_failed_runs_without_compensation_nodes(): void
+    {
+        $workflow = Workflow::factory()->for($this->team)->create();
+        $node = WorkflowNode::factory()->for($workflow)->create(); // no compensation_node_id
+
+        $experiment = Experiment::factory()->for($this->team)->create([
+            'workflow_id' => $workflow->id,
+            'status' => 'execution_failed',
+        ]);
+
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'workflow_node_id' => $node->id,
+            'order' => 0,
+            'status' => 'completed',
+        ]);
+
+        Livewire::test(WorkflowOpsPage::class)
+            ->tap(fn ($component) => $this->assertCount(0, $component->viewData('runs')));
+    }
+
+    public function test_does_not_leak_other_team_compensation_runs(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other Ops',
+            'slug' => 'other-ops',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+
+        $this->makeCompensatedFailedExperiment($otherTeam);
+
+        Livewire::test(WorkflowOpsPage::class)
+            ->tap(fn ($component) => $this->assertCount(0, $component->viewData('runs')));
+    }
+
+    public function test_simulation_renders_predicted_path_for_team_workflow(): void
+    {
+        $workflow = Workflow::factory()->for($this->team)->create();
+
+        $start = WorkflowNode::factory()->for($workflow)->start()->create();
+        $agent = WorkflowNode::factory()->for($workflow)->create([
+            'type' => WorkflowNodeType::Agent,
+            'label' => 'Do the thing',
+        ]);
+        $end = WorkflowNode::factory()->for($workflow)->end()->create();
+
+        WorkflowEdge::factory()->for($workflow)->create([
+            'source_node_id' => $start->id,
+            'target_node_id' => $agent->id,
+        ]);
+        WorkflowEdge::factory()->for($workflow)->create([
+            'source_node_id' => $agent->id,
+            'target_node_id' => $end->id,
+        ]);
+
+        Livewire::test(WorkflowSimulationPanel::class, ['workflow' => $workflow])
+            ->call('simulate')
+            ->assertSet('terminationStatus', 'completed')
+            ->assertSee('Do the thing')
+            ->tap(function ($component) use ($start, $agent, $end): void {
+                $path = collect($component->get('executedPath'))->pluck('id')->all();
+                $this->assertSame([$start->id, $agent->id, $end->id], $path);
+            });
+    }
+
+    public function test_simulate_is_forbidden_without_edit_content(): void
+    {
+        // Base community edition grants edit-content to everyone; deny it here to
+        // prove the per-action guard exists (cloud overrides the gate by role).
+        Gate::define('edit-content', fn () => false);
+
+        $workflow = Workflow::factory()->for($this->team)->create();
+        WorkflowNode::factory()->for($workflow)->start()->create();
+
+        Livewire::test(WorkflowSimulationPanel::class, ['workflow' => $workflow])
+            ->call('simulate')
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## UI-Gap Backlog — Waves 1–3 (21 features)

Surfaces backends that existed in code but had **no UI**, per `docs/feature-inventory-full_2026-06-09.md`. Built via parallel agents, integrated + tested serially. **Draft — review before merge; not for auto-merge.**

### Wave 1 (7)
AgentSession viewer (list + timeline, wake/cancel) · Release signing-key mgmt (gen/rotate/revoke) · Drift dashboard · Eval monitor · Broadcast list/create · CSV import wizard · 5 outbound chat channels as core drivers + config UI (Telegram/Slack/Discord/Teams/Google Chat)

### Wave 2 (8)
Blacklist CRUD · Outbound proposals (read-only) · Skill Ops (loop/benchmark/annotation) · Workflow Compensation view + Simulation panel · Experiment Checkpoints · Memory Proposals queue · Credential Secret-Scan findings (+ `secret_scan_findings` MCP tool)

### Wave 3 (6)
Reasoning Bank · Error-Mode catalog · Test Suites (read-only) · KG Communities · Crew Chat Room

### Quality
- Per-action authorization on every mutation (architecture test green); team-scoped; pint clean.
- ~95 feature tests added across the waves, all green locally (Docker/SQLite).
- A background security review caught 2 cross-tenant bugs (secret-scan tool + checkpoints page) — **fixed** in `48f0e1a9`.
- Cross-DB fix: portable `lower() LIKE` instead of Postgres-only ILIKE.

### ⚠️ Review carefully
Registering the 5 outbound channels as **core drivers** means real sends now fire (instead of Dummy no-op) for any queued proposal on those channels. Blacklist/rate-limit/quality gates still apply (channel-agnostic). Confirm no stale proposals before this reaches prod.

### Deferred / follow-ups (documented, not in this PR)
- 3 outbound channels (Matrix/SignalProtocol/SupabaseRealtime) — connectors ignore resolved config; need `OutboundCredentialResolver` wiring.
- Cloud Team-export **download controller** (GDPR) — request UI exists (WIP), gated download endpoint not built.
- Broadcast `SendBroadcastJob` chunking; cloud sidebar entries; ~8 MCP read-tool gaps.
- Wave-3 surgical partials (editable heartbeat, deps repeater, SLA config, KMS recovery, agent dry-run, done-gate toggle).
- Wave 4: Partner portal, Marketplace earnings (needs backend), Fleet (deferred — needs product spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
