### PR TITLE
feat(ui): Wave-3 partials + broadcast chunking + complete 8 outbound channels

### DIFF
--- a/app/Domain/Broadcast/Jobs/SendBroadcastChunkJob.php
+++ b/app/Domain/Broadcast/Jobs/SendBroadcastChunkJob.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Domain\Broadcast\Jobs;
+
+use App\Domain\Broadcast\Enums\BroadcastRecipientStatus;
+use App\Domain\Broadcast\Models\Broadcast;
+use App\Domain\Broadcast\Models\BroadcastRecipient;
+use App\Domain\Broadcast\Services\BroadcastMailer;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Delivers one chunk of a broadcast's recipients. Dispatched as a batched job
+ * by SendBroadcastJob; the broadcast is only rolled to a terminal status after
+ * the whole batch settles, never mid-flight.
+ *
+ * @param  list<string>  $recipientIds  the recipient rows this chunk owns
+ */
+class SendBroadcastChunkJob implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 600;
+
+    /**
+     * @param  list<string>  $recipientIds
+     */
+    public function __construct(
+        public string $broadcastId,
+        public array $recipientIds,
+    ) {}
+
+    public function handle(BroadcastMailer $mailer): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        $broadcast = Broadcast::withoutGlobalScopes()->find($this->broadcastId);
+
+        if (! $broadcast) {
+            return;
+        }
+
+        $recipients = BroadcastRecipient::withoutGlobalScopes()
+            ->where('team_id', $broadcast->team_id)
+            ->where('broadcast_id', $broadcast->id)
+            ->whereIn('id', $this->recipientIds)
+            ->where('status', BroadcastRecipientStatus::Pending->value)
+            ->get();
+
+        foreach ($recipients as $recipient) {
+            try {
+                $result = $mailer->send(
+                    teamId: $broadcast->team_id,
+                    toEmail: $recipient->email,
+                    subject: $broadcast->subject,
+                    html: $broadcast->body,
+                    idempotencyKey: hash('xxh128', "broadcast|{$recipient->id}"),
+                );
+
+                $recipient->update([
+                    'status' => BroadcastRecipientStatus::Sent,
+                    'message_id' => $result['message_id'],
+                    'sent_at' => now(),
+                ]);
+            } catch (\Throwable $e) {
+                $recipient->update([
+                    'status' => BroadcastRecipientStatus::Failed,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+    }
+}

--- a/app/Domain/Broadcast/Jobs/SendBroadcastJob.php
+++ b/app/Domain/Broadcast/Jobs/SendBroadcastJob.php
@@ -6,29 +6,32 @@ use App\Domain\Broadcast\Enums\BroadcastRecipientStatus;
 use App\Domain\Broadcast\Enums\BroadcastStatus;
 use App\Domain\Broadcast\Models\Broadcast;
 use App\Domain\Broadcast\Models\BroadcastRecipient;
-use App\Domain\Broadcast\Services\BroadcastMailer;
+use App\Domain\Broadcast\Services\BroadcastBudgetGuard;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Bus;
 
 /**
- * Delivers an approved broadcast to every pending recipient, then rolls the
- * broadcast up to a terminal status.
+ * Orchestrates delivery of an approved broadcast: gates on budget, fans the
+ * pending recipients out across batched SendBroadcastChunkJob jobs, and rolls
+ * the broadcast to a terminal status only once the whole batch settles.
  *
- * For very large audiences this should be chunked into per-recipient jobs;
- * the single-job approach is sufficient at current scale (see sprint plan).
+ * The per-recipient send loop lives in SendBroadcastChunkJob so large audiences
+ * never run in a single 600s synchronous loop.
  */
 class SendBroadcastJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public int $timeout = 600;
+    /** Recipients per chunk job. */
+    private const CHUNK_SIZE = 100;
 
     public function __construct(public string $broadcastId) {}
 
-    public function handle(BroadcastMailer $mailer): void
+    public function handle(BroadcastBudgetGuard $budgetGuard): void
     {
         $broadcast = Broadcast::withoutGlobalScopes()->find($this->broadcastId);
 
@@ -36,35 +39,53 @@ class SendBroadcastJob implements ShouldQueue
             return;
         }
 
-        $recipients = BroadcastRecipient::withoutGlobalScopes()
+        $pendingQuery = BroadcastRecipient::withoutGlobalScopes()
+            ->where('team_id', $broadcast->team_id)
             ->where('broadcast_id', $broadcast->id)
-            ->where('status', BroadcastRecipientStatus::Pending->value)
-            ->get();
+            ->where('status', BroadcastRecipientStatus::Pending->value);
 
-        foreach ($recipients as $recipient) {
-            try {
-                $result = $mailer->send(
-                    teamId: $broadcast->team_id,
-                    toEmail: $recipient->email,
-                    subject: $broadcast->subject,
-                    html: $broadcast->body,
-                    idempotencyKey: hash('xxh128', "broadcast|{$recipient->id}"),
-                );
+        $pendingCount = (clone $pendingQuery)->count();
 
-                $recipient->update([
-                    'status' => BroadcastRecipientStatus::Sent,
-                    'message_id' => $result['message_id'],
-                    'sent_at' => now(),
-                ]);
-            } catch (\Throwable $e) {
-                $recipient->update([
-                    'status' => BroadcastRecipientStatus::Failed,
-                    'error' => $e->getMessage(),
-                ]);
-            }
+        if ($pendingCount === 0) {
+            self::finalize($broadcast->id);
+
+            return;
+        }
+
+        $budgetGuard->assertCanSend($broadcast->team_id, $pendingCount);
+
+        $jobs = [];
+        $pendingQuery->select('id')->chunkById(self::CHUNK_SIZE, function ($recipients) use ($broadcast, &$jobs) {
+            $jobs[] = new SendBroadcastChunkJob(
+                broadcastId: $broadcast->id,
+                recipientIds: $recipients->pluck('id')->all(),
+            );
+        });
+
+        $broadcastId = $broadcast->id;
+
+        Bus::batch($jobs)
+            ->name("broadcast:{$broadcastId}")
+            ->onQueue('outbound')
+            ->finally(function () use ($broadcastId) {
+                self::finalize($broadcastId);
+            })
+            ->dispatch();
+    }
+
+    /**
+     * Roll the broadcast to a terminal status once every chunk has settled.
+     */
+    private static function finalize(string $broadcastId): void
+    {
+        $broadcast = Broadcast::withoutGlobalScopes()->find($broadcastId);
+
+        if (! $broadcast || $broadcast->status !== BroadcastStatus::Sending) {
+            return;
         }
 
         $sentCount = BroadcastRecipient::withoutGlobalScopes()
+            ->where('team_id', $broadcast->team_id)
             ->where('broadcast_id', $broadcast->id)
             ->where('status', BroadcastRecipientStatus::Sent->value)
             ->count();

--- a/app/Domain/Outbound/Connectors/MatrixConnector.php
+++ b/app/Domain/Outbound/Connectors/MatrixConnector.php
@@ -6,6 +6,7 @@ use App\Domain\Outbound\Contracts\OutboundConnectorInterface;
 use App\Domain\Outbound\Enums\OutboundActionStatus;
 use App\Domain\Outbound\Models\OutboundAction;
 use App\Domain\Outbound\Models\OutboundProposal;
+use App\Domain\Outbound\Services\OutboundCredentialResolver;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 
@@ -13,7 +14,8 @@ use Illuminate\Support\Str;
  * Matrix Protocol outbound connector via Matrix Client-Server API.
  *
  * Sends messages to a Matrix room using the PUT /_matrix/client/v3/rooms/{roomId}/send endpoint.
- * Credentials expected in proposal target:
+ * Credentials are resolved via OutboundCredentialResolver (saved config + .env),
+ * with the proposal target overriding per-send:
  *   homeserver_url — Matrix homeserver (e.g. https://matrix.org)
  *   access_token   — Bot access token
  *   room_id        — Target Matrix room ID (e.g. !abc123:matrix.org)
@@ -38,12 +40,14 @@ class MatrixConnector implements OutboundConnectorInterface
         ]);
 
         try {
-            $target = $proposal->target;
+            $resolver = app(OutboundCredentialResolver::class);
+            $creds = $resolver->resolve('matrix', $proposal->target, $proposal->team_id);
+
             $content = $proposal->content;
 
-            $homeserverUrl = rtrim($target['homeserver_url'] ?? config('services.matrix.homeserver_url', ''), '/');
-            $accessToken = $target['access_token'] ?? config('services.matrix.access_token');
-            $roomId = $target['room_id'] ?? null;
+            $homeserverUrl = rtrim($creds['homeserver_url'] ?? '', '/');
+            $accessToken = $creds['access_token'] ?? null;
+            $roomId = $creds['room_id'] ?? null;
 
             if (! $homeserverUrl || ! $accessToken || ! $roomId) {
                 throw new \InvalidArgumentException('matrix connector requires homeserver_url, access_token, and room_id');

--- a/app/Domain/Outbound/Connectors/SignalProtocolConnector.php
+++ b/app/Domain/Outbound/Connectors/SignalProtocolConnector.php
@@ -6,6 +6,7 @@ use App\Domain\Outbound\Contracts\OutboundConnectorInterface;
 use App\Domain\Outbound\Enums\OutboundActionStatus;
 use App\Domain\Outbound\Models\OutboundAction;
 use App\Domain\Outbound\Models\OutboundProposal;
+use App\Domain\Outbound\Services\OutboundCredentialResolver;
 use Illuminate\Support\Facades\Http;
 
 /**
@@ -37,12 +38,14 @@ class SignalProtocolConnector implements OutboundConnectorInterface
         ]);
 
         try {
-            $target = $proposal->target;
+            $resolver = app(OutboundCredentialResolver::class);
+            $creds = $resolver->resolve('signal_protocol', $proposal->target, $proposal->team_id);
+
             $content = $proposal->content;
 
-            $apiUrl = rtrim($target['api_url'] ?? config('services.signal.api_url', 'http://signal-sidecar:8080'), '/');
-            $phoneNumber = $target['phone_number'] ?? config('services.signal.phone_number');
-            $recipient = $target['recipient'] ?? $target['phone'] ?? null;
+            $apiUrl = rtrim($creds['api_url'] ?? 'http://signal-sidecar:8080', '/');
+            $phoneNumber = $creds['phone_number'] ?? null;
+            $recipient = $creds['recipient'] ?? $creds['phone'] ?? null;
 
             if (! $phoneNumber || ! $recipient) {
                 throw new \InvalidArgumentException('signal_protocol connector requires phone_number and recipient');

--- a/app/Domain/Outbound/Connectors/SupabaseRealtimeConnector.php
+++ b/app/Domain/Outbound/Connectors/SupabaseRealtimeConnector.php
@@ -6,6 +6,7 @@ use App\Domain\Outbound\Contracts\OutboundConnectorInterface;
 use App\Domain\Outbound\Enums\OutboundActionStatus;
 use App\Domain\Outbound\Models\OutboundAction;
 use App\Domain\Outbound\Models\OutboundProposal;
+use App\Domain\Outbound\Services\OutboundCredentialResolver;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -49,11 +50,13 @@ class SupabaseRealtimeConnector implements OutboundConnectorInterface
         ]);
 
         try {
-            $target = $proposal->target;
-            $ref = $target['ref'] ?? null;
-            $channel = $target['channel'] ?? 'agent:results';
-            $event = $target['event'] ?? 'message';
-            $apiKey = $target['key'] ?? null;
+            $resolver = app(OutboundCredentialResolver::class);
+            $creds = $resolver->resolve('supabase_realtime', $proposal->target, $proposal->team_id);
+
+            $ref = $creds['ref'] ?? null;
+            $channel = $creds['channel'] ?? 'agent:results';
+            $event = $creds['event'] ?? 'message';
+            $apiKey = $creds['key'] ?? null;
 
             if (! $ref || ! $apiKey) {
                 Log::warning('SupabaseRealtimeConnector: missing ref or key in target', [

--- a/app/Domain/Outbound/Enums/OutboundChannel.php
+++ b/app/Domain/Outbound/Enums/OutboundChannel.php
@@ -25,9 +25,6 @@ enum OutboundChannel: string
      */
     public function isCore(): bool
     {
-        // signal_protocol, matrix, supabase_realtime have connectors that do not yet
-        // read resolved config credentials — deferred from core until wired to
-        // OutboundCredentialResolver.
-        return ! in_array($this, [self::SignalProtocol, self::Matrix, self::SupabaseRealtime], true);
+        return true;
     }
 }

--- a/app/Domain/Outbound/Managers/OutboundConnectorManager.php
+++ b/app/Domain/Outbound/Managers/OutboundConnectorManager.php
@@ -6,9 +6,12 @@ use App\Domain\Outbound\Connectors\DiscordConnector;
 use App\Domain\Outbound\Connectors\DummyConnector;
 use App\Domain\Outbound\Connectors\EmailConnectorDispatcher;
 use App\Domain\Outbound\Connectors\GoogleChatConnector;
+use App\Domain\Outbound\Connectors\MatrixConnector;
 use App\Domain\Outbound\Connectors\NotificationConnector;
 use App\Domain\Outbound\Connectors\NtfyConnector;
+use App\Domain\Outbound\Connectors\SignalProtocolConnector;
 use App\Domain\Outbound\Connectors\SlackConnector;
+use App\Domain\Outbound\Connectors\SupabaseRealtimeConnector;
 use App\Domain\Outbound\Connectors\TeamsConnector;
 use App\Domain\Outbound\Connectors\TelegramConnector;
 use App\Domain\Outbound\Connectors\WebhookOutboundConnector;
@@ -20,9 +23,7 @@ use Illuminate\Support\Manager;
  * Laravel Manager for outbound connector resolution.
  *
  * Core drivers: email, webhook, notification, whatsapp, ntfy, telegram, slack,
- * discord, teams, google_chat, dummy.
- * Deferred (connector ignores resolved config — needs OutboundCredentialResolver
- * wiring before going core): signal_protocol, matrix, supabase_realtime.
+ * discord, teams, google_chat, matrix, signal_protocol, supabase_realtime, dummy.
  * Plugins extend via: $manager->extend('custom', fn ($app) => new CustomConnector);
  *
  * Usage:
@@ -85,6 +86,21 @@ class OutboundConnectorManager extends Manager
     protected function createGoogleChatDriver(): OutboundConnectorInterface
     {
         return $this->container->make(GoogleChatConnector::class);
+    }
+
+    protected function createMatrixDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(MatrixConnector::class);
+    }
+
+    protected function createSignalProtocolDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(SignalProtocolConnector::class);
+    }
+
+    protected function createSupabaseRealtimeDriver(): OutboundConnectorInterface
+    {
+        return $this->container->make(SupabaseRealtimeConnector::class);
     }
 
     protected function createDummyDriver(): OutboundConnectorInterface

--- a/app/Domain/Outbound/Services/OutboundCredentialResolver.php
+++ b/app/Domain/Outbound/Services/OutboundCredentialResolver.php
@@ -22,6 +22,18 @@ class OutboundCredentialResolver
         'discord' => ['webhook_url' => null], // Discord has no global config fallback
         'teams' => ['webhook_url' => 'services.teams.webhook_url'],
         'google_chat' => ['webhook_url' => 'services.google_chat.webhook_url'],
+        'matrix' => [
+            'homeserver_url' => 'services.matrix.homeserver_url',
+            'access_token' => 'services.matrix.access_token',
+        ],
+        'signal_protocol' => [
+            'api_url' => 'services.signal.api_url',
+            'phone_number' => 'services.signal.phone_number',
+        ],
+        'supabase_realtime' => [
+            'ref' => 'services.supabase.ref',
+            'key' => 'services.supabase.key',
+        ],
         'whatsapp' => [
             'phone_number_id' => 'services.whatsapp.phone_number_id',
             'access_token' => 'services.whatsapp.access_token',
@@ -139,6 +151,9 @@ class OutboundCredentialResolver
             'discord' => ['webhook_url'],
             'teams' => ['webhook_url'],
             'google_chat' => ['webhook_url'],
+            'matrix' => ['homeserver_url', 'access_token', 'room_id'],
+            'signal_protocol' => ['api_url', 'phone_number', 'recipient', 'phone'],
+            'supabase_realtime' => ['ref', 'key', 'channel', 'event'],
             'whatsapp' => ['phone', 'to'],
             'email' => ['email'],
             'webhook' => ['url', 'headers', 'secret'],

--- a/app/Livewire/Agents/AgentDetailPage.php
+++ b/app/Livewire/Agents/AgentDetailPage.php
@@ -3,8 +3,10 @@
 namespace App\Livewire\Agents;
 
 use App\Domain\Agent\Actions\CreateAgentFeedbackAction;
+use App\Domain\Agent\Actions\DryRunAgentAction;
 use App\Domain\Agent\Actions\ExportAgentWorkspaceAction;
 use App\Domain\Agent\Actions\RecordAgentConfigRevisionAction;
+use App\Domain\Agent\DTOs\AgentHeartbeatTask;
 use App\Domain\Agent\Enums\AgentEnvironment;
 use App\Domain\Agent\Enums\AgentStatus;
 use App\Domain\Agent\Enums\FeedbackRating;
@@ -29,6 +31,7 @@ use App\Domain\Tool\Models\Tool;
 use App\Domain\Tool\Models\ToolSearchLog;
 use App\Infrastructure\AI\Enums\ReasoningEffort;
 use App\Infrastructure\AI\Services\ProviderResolver;
+use Cron\CronExpression;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Validation\Rule;
@@ -149,6 +152,23 @@ class AgentDetailPage extends Component
     public string $exportFormat = 'zip';
 
     public bool $exportIncludeMemories = true;
+
+    // Heartbeat schedule editor
+    public bool $editingHeartbeat = false;
+
+    public string $heartbeatCron = '0 * * * *';
+
+    public string $heartbeatPrompt = '';
+
+    public bool $heartbeatEnabled = true;
+
+    // Agent dry-run
+    public string $dryRunInput = '';
+
+    /** @var array<string, mixed>|null */
+    public ?array $dryRunResult = null;
+
+    public ?string $dryRunError = null;
 
     public function mount(Agent $agent): void
     {
@@ -585,6 +605,100 @@ class AgentDetailPage extends Component
         );
 
         session()->flash('message', 'Heartbeat dispatched.');
+    }
+
+    /**
+     * Open the heartbeat schedule editor, prefilling from the current definition.
+     */
+    public function startEditHeartbeat(): void
+    {
+        $this->authorize('edit-content');
+
+        $definition = $this->agent->heartbeat_definition ?? [];
+        $this->heartbeatCron = $definition['cron'] ?? '0 * * * *';
+        $this->heartbeatPrompt = $definition['prompt'] ?? '';
+        $this->heartbeatEnabled = (bool) ($definition['enabled'] ?? false);
+        $this->editingHeartbeat = true;
+        $this->resetValidation();
+    }
+
+    public function cancelEditHeartbeat(): void
+    {
+        $this->editingHeartbeat = false;
+        $this->resetValidation();
+    }
+
+    /**
+     * Persist the agent's heartbeat schedule via the same path the
+     * agent_heartbeat_update MCP tool uses: validate the cron expression,
+     * enforce the 5-minute minimum interval, and store the AgentHeartbeatTask.
+     */
+    public function saveHeartbeat(): void
+    {
+        $this->authorize('edit-content');
+
+        $this->validate([
+            'heartbeatCron' => 'required|string|max:100',
+            'heartbeatPrompt' => 'required|string|max:2000',
+            'heartbeatEnabled' => 'boolean',
+        ]);
+
+        try {
+            $expr = new CronExpression($this->heartbeatCron);
+        } catch (\InvalidArgumentException $e) {
+            $this->addError('heartbeatCron', 'Invalid cron expression: '.$e->getMessage());
+
+            return;
+        }
+
+        // Mirror the MCP tool: refuse schedules firing more often than every 5 minutes.
+        $now = new \DateTimeImmutable;
+        $next = $expr->getNextRunDate($now);
+        $afterNext = $expr->getNextRunDate($next);
+        if ($afterNext->getTimestamp() - $next->getTimestamp() < 300) {
+            $this->addError('heartbeatCron', 'Heartbeat schedule must fire no more than once every 5 minutes.');
+
+            return;
+        }
+
+        $task = new AgentHeartbeatTask(
+            enabled: $this->heartbeatEnabled,
+            cron: $this->heartbeatCron,
+            prompt: $this->heartbeatPrompt,
+            nextRunAt: null, // reset so it fires on the next evaluation cycle
+        );
+
+        $this->agent->update(['heartbeat_definition' => $task->toArray()]);
+        $this->agent->refresh();
+        $this->editingHeartbeat = false;
+
+        session()->flash('message', 'Heartbeat schedule saved.');
+    }
+
+    /**
+     * Run the agent through a single LLM completion without persisting any
+     * execution record, artifact, or AiRun row (DryRunAgentAction).
+     */
+    public function dryRun(): void
+    {
+        $this->authorize('edit-content');
+
+        $this->validate([
+            'dryRunInput' => 'required|string|min:1|max:10000',
+        ]);
+
+        $this->dryRunResult = null;
+        $this->dryRunError = null;
+
+        try {
+            $this->dryRunResult = app(DryRunAgentAction::class)->execute(
+                agent: $this->agent,
+                userMessage: $this->dryRunInput,
+                userId: (string) auth()->id(),
+            );
+        } catch (\InvalidArgumentException $e) {
+            $this->dryRunError = $e->getMessage();
+        }
     }
 
     public function saveHook(): void

--- a/app/Livewire/Approvals/HumanTaskForm.php
+++ b/app/Livewire/Approvals/HumanTaskForm.php
@@ -20,10 +20,79 @@ class HumanTaskForm extends Component
 
     public string $rejectionReason = '';
 
+    public bool $showEscalationConfig = false;
+
+    public ?int $slaHours = null;
+
+    /** @var array<int, string> Ordered list of assignee user IDs. */
+    public array $escalationChain = [];
+
     public function mount(ApprovalRequest $task): void
     {
         $this->task = $task;
         $this->initFormData();
+        $this->slaHours = $task->context['sla_hours'] ?? null;
+        $this->escalationChain = array_values(array_filter((array) $task->escalation_chain));
+    }
+
+    /**
+     * Team members eligible as escalation assignees, scoped to the task's team.
+     *
+     * @return array<int, array{id: string, name: string}>
+     */
+    public function getTeamMembersProperty(): array
+    {
+        return $this->task->team
+            ->users()
+            ->get(['users.id', 'users.name'])
+            ->map(fn ($u) => ['id' => $u->id, 'name' => $u->name])
+            ->all();
+    }
+
+    public function addEscalationLevel(): void
+    {
+        Gate::authorize('edit-content');
+
+        $this->escalationChain[] = '';
+    }
+
+    public function removeEscalationLevel(int $index): void
+    {
+        Gate::authorize('edit-content');
+
+        unset($this->escalationChain[$index]);
+        $this->escalationChain = array_values($this->escalationChain);
+    }
+
+    public function saveEscalationConfig(): void
+    {
+        Gate::authorize('edit-content');
+
+        $memberIds = array_column($this->teamMembers, 'id');
+
+        $this->validate([
+            'slaHours' => ['nullable', 'integer', 'min:1', 'max:8760'],
+            'escalationChain' => ['array'],
+            'escalationChain.*' => ['required', 'string', 'in:'.implode(',', $memberIds)],
+        ]);
+
+        $chain = array_values(array_filter($this->escalationChain));
+
+        $context = $this->task->context ?? [];
+        if ($this->slaHours !== null) {
+            $context['sla_hours'] = $this->slaHours;
+        } else {
+            unset($context['sla_hours']);
+        }
+
+        $this->task->update([
+            'context' => $context,
+            'escalation_chain' => $chain ?: null,
+        ]);
+
+        $this->escalationChain = $chain;
+        $this->showEscalationConfig = false;
+        session()->flash('message', 'Escalation configuration saved.');
     }
 
     public function submit(): void

--- a/app/Livewire/OutboundConnectors/MatrixOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/MatrixOutboundPage.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Matrix outbound connector.
+ *
+ * Credentials are stored encrypted in OutboundConnectorConfig (channel=matrix)
+ * and resolved at send time by OutboundCredentialResolver. The access_token field
+ * is write-only: it is preserved on save when left blank.
+ */
+class MatrixOutboundPage extends Component
+{
+    public string $homeserverUrl = '';
+
+    public string $roomId = '';
+
+    /** Matrix bot access token (write-only). */
+    public string $accessToken = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'matrix')
+            ->first();
+
+        if ($config) {
+            $creds = $config->credentials ?? [];
+            $this->homeserverUrl = $creds['homeserver_url'] ?? '';
+            $this->roomId = $creds['room_id'] ?? '';
+            // access_token is never pre-filled (write-only)
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'homeserverUrl' => 'nullable|url|max:512',
+            'roomId' => 'nullable|string|max:255',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $existing = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'matrix')
+            ->first();
+
+        $credentials = [
+            'homeserver_url' => $this->homeserverUrl ?: null,
+            'room_id' => $this->roomId ?: null,
+        ];
+
+        if ($this->accessToken) {
+            $credentials['access_token'] = $this->accessToken;
+        } elseif ($existing) {
+            $credentials['access_token'] = $existing->credentials['access_token'] ?? '';
+        } else {
+            $credentials['access_token'] = '';
+        }
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'matrix'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->accessToken = '';
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Matrix connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'matrix')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $creds = $config->credentials ?? [];
+        $homeserverUrl = rtrim($creds['homeserver_url'] ?? '', '/');
+        $token = $creds['access_token'] ?? '';
+
+        if (! $homeserverUrl || ! $token) {
+            $this->testError = 'Homeserver URL and access token are not configured.';
+
+            return;
+        }
+
+        $response = null;
+
+        try {
+            $response = Http::timeout(10)
+                ->withToken($token)
+                ->get("{$homeserverUrl}/_matrix/client/v3/account/whoami");
+            $status = $response->successful() ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success' && $response !== null) {
+            $this->testMessage = 'Connected as '.($response->json('user_id') ?? 'verified');
+            $this->testError = null;
+        } else {
+            $this->testError = 'Matrix API error: '.($response?->json('error') ?? 'Invalid homeserver URL or access token');
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.matrix-outbound-page')
+            ->layout('layouts.app', ['header' => 'Matrix Delivery']);
+    }
+}

--- a/app/Livewire/OutboundConnectors/SignalProtocolOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/SignalProtocolOutboundPage.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Signal outbound connector.
+ *
+ * Sends via a self-hosted bbernhard/signal-cli-rest-api sidecar. Credentials are
+ * stored encrypted in OutboundConnectorConfig (channel=signal_protocol) and resolved
+ * at send time by OutboundCredentialResolver.
+ */
+class SignalProtocolOutboundPage extends Component
+{
+    public string $apiUrl = '';
+
+    public string $phoneNumber = '';
+
+    public string $recipient = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'signal_protocol')
+            ->first();
+
+        if ($config) {
+            $creds = $config->credentials ?? [];
+            $this->apiUrl = $creds['api_url'] ?? '';
+            $this->phoneNumber = $creds['phone_number'] ?? '';
+            $this->recipient = $creds['recipient'] ?? '';
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'apiUrl' => 'nullable|url|max:512',
+            'phoneNumber' => 'nullable|string|max:32',
+            'recipient' => 'nullable|string|max:32',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $credentials = [
+            'api_url' => $this->apiUrl ?: null,
+            'phone_number' => $this->phoneNumber ?: null,
+            'recipient' => $this->recipient ?: null,
+        ];
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'signal_protocol'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Signal connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'signal_protocol')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $apiUrl = rtrim($config->credentials['api_url'] ?? 'http://signal-sidecar:8080', '/');
+
+        $response = null;
+
+        try {
+            $response = Http::timeout(10)->get("{$apiUrl}/v1/about");
+            $status = $response->successful() ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success') {
+            $this->testMessage = 'signal-cli-rest-api reachable at '.$apiUrl;
+            $this->testError = null;
+        } else {
+            $this->testError = 'signal-cli-rest-api error: '.($response?->status() ?? 'unreachable');
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.signal-protocol-outbound-page')
+            ->layout('layouts.app', ['header' => 'Signal Delivery']);
+    }
+}

--- a/app/Livewire/OutboundConnectors/SupabaseRealtimeOutboundPage.php
+++ b/app/Livewire/OutboundConnectors/SupabaseRealtimeOutboundPage.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Livewire\OutboundConnectors;
+
+use App\Domain\Outbound\Models\OutboundConnectorConfig;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Http;
+use Livewire\Component;
+
+/**
+ * Livewire component for configuring the Supabase Realtime Broadcast outbound connector.
+ *
+ * Credentials are stored encrypted in OutboundConnectorConfig (channel=supabase_realtime)
+ * and resolved at send time by OutboundCredentialResolver. The key field is write-only:
+ * it is preserved on save when left blank.
+ */
+class SupabaseRealtimeOutboundPage extends Component
+{
+    public string $ref = '';
+
+    public string $channel = 'agent:results';
+
+    public string $event = 'message';
+
+    /** Supabase apikey (anon or service role) — write-only. */
+    public string $apiKey = '';
+
+    public bool $isActive = true;
+
+    public ?string $lastTestedAt = null;
+
+    public ?string $lastTestStatus = null;
+
+    public ?string $testMessage = null;
+
+    public ?string $testError = null;
+
+    public function mount(): void
+    {
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'supabase_realtime')
+            ->first();
+
+        if ($config) {
+            $creds = $config->credentials ?? [];
+            $this->ref = $creds['ref'] ?? '';
+            $this->channel = $creds['channel'] ?? 'agent:results';
+            $this->event = $creds['event'] ?? 'message';
+            // key is never pre-filled (write-only)
+            $this->isActive = (bool) $config->is_active;
+            $this->lastTestedAt = $config->last_tested_at?->diffForHumans();
+            $this->lastTestStatus = $config->last_test_status;
+        }
+    }
+
+    public function save(): void
+    {
+        Gate::authorize('manage-team');
+
+        $this->validate([
+            'ref' => 'nullable|string|max:128',
+            'channel' => 'nullable|string|max:255',
+            'event' => 'nullable|string|max:255',
+        ]);
+
+        $team = auth()->user()->currentTeam;
+
+        $existing = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'supabase_realtime')
+            ->first();
+
+        $credentials = [
+            'ref' => $this->ref ?: null,
+            'channel' => $this->channel ?: null,
+            'event' => $this->event ?: null,
+        ];
+
+        if ($this->apiKey) {
+            $credentials['key'] = $this->apiKey;
+        } elseif ($existing) {
+            $credentials['key'] = $existing->credentials['key'] ?? '';
+        } else {
+            $credentials['key'] = '';
+        }
+
+        OutboundConnectorConfig::updateOrCreate(
+            ['team_id' => $team->id, 'channel' => 'supabase_realtime'],
+            ['credentials' => $credentials, 'is_active' => $this->isActive],
+        );
+
+        $this->apiKey = '';
+        $this->testMessage = null;
+        $this->testError = null;
+
+        session()->flash('message', 'Supabase Realtime connector saved successfully.');
+    }
+
+    public function testConnection(): void
+    {
+        Gate::authorize('manage-team');
+
+        $team = auth()->user()->currentTeam;
+        $config = OutboundConnectorConfig::where('team_id', $team->id)
+            ->where('channel', 'supabase_realtime')
+            ->first();
+
+        if (! $config) {
+            $this->testError = 'Save the connector first before testing.';
+
+            return;
+        }
+
+        $creds = $config->credentials ?? [];
+        $ref = $creds['ref'] ?? '';
+        $key = $creds['key'] ?? '';
+
+        if (! $ref || ! $key) {
+            $this->testError = 'Project ref and key are not configured.';
+
+            return;
+        }
+
+        $response = null;
+
+        try {
+            $response = Http::withHeaders([
+                'apikey' => $key,
+                'Authorization' => "Bearer {$key}",
+                'Content-Type' => 'application/json',
+            ])->timeout(10)->post("https://{$ref}.supabase.co/realtime/v1/api/broadcast", [
+                'messages' => [[
+                    'topic' => $creds['channel'] ?? 'agent:results',
+                    'event' => $creds['event'] ?? 'message',
+                    'payload' => ['test' => true, 'source' => 'fleetq'],
+                ]],
+            ]);
+            $status = $response->successful() ? 'success' : 'failed';
+        } catch (\Throwable) {
+            $status = 'failed';
+        }
+
+        $config->update([
+            'last_tested_at' => now(),
+            'last_test_status' => $status,
+        ]);
+
+        $this->lastTestedAt = 'just now';
+        $this->lastTestStatus = $status;
+
+        if ($status === 'success') {
+            $this->testMessage = 'Test broadcast sent successfully.';
+            $this->testError = null;
+        } else {
+            $this->testError = 'Supabase returned '.($response?->status() ?? 'an error').'.';
+            $this->testMessage = null;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.outbound-connectors.supabase-realtime-outbound-page')
+            ->layout('layouts.app', ['header' => 'Supabase Realtime Delivery']);
+    }
+}

--- a/app/Livewire/Projects/EditProjectForm.php
+++ b/app/Livewire/Projects/EditProjectForm.php
@@ -10,6 +10,7 @@ use App\Domain\Project\Enums\OverlapPolicy;
 use App\Domain\Project\Enums\ProjectExecutionMode;
 use App\Domain\Project\Enums\ScheduleFrequency;
 use App\Domain\Project\Models\Project;
+use App\Domain\Project\Models\ProjectDependency;
 use App\Domain\Tool\Models\Tool;
 use App\Domain\Workflow\Enums\WorkflowStatus;
 use App\Domain\Workflow\Models\Workflow;
@@ -82,6 +83,9 @@ class EditProjectForm extends Component
 
     public array $selectedCredentialIds = [];
 
+    // Dependencies (predecessor projects)
+    public array $dependencies = [];
+
     // Quality Gates (live in project.settings JSONB)
     public bool $doneGateEnabled = false;
 
@@ -136,6 +140,16 @@ class EditProjectForm extends Component
         $this->selectedToolIds = $project->allowed_tool_ids ?? [];
         $this->selectedCredentialIds = $project->allowed_credential_ids ?? [];
 
+        // Dependencies (predecessor projects)
+        $this->dependencies = $project->dependencies()->ordered()->get()
+            ->map(fn (ProjectDependency $dep) => [
+                'depends_on_id' => $dep->depends_on_id,
+                'alias' => $dep->alias,
+                'reference_type' => $dep->reference_type,
+                'is_required' => $dep->is_required,
+            ])
+            ->all();
+
         // Quality Gates
         $settings = $project->settings ?? [];
         $this->doneGateEnabled = (bool) ($settings['done_gate_enabled'] ?? false);
@@ -176,6 +190,11 @@ class EditProjectForm extends Component
 
         $rules['doneGateEnabled'] = 'boolean';
         $rules['doneGateKillSwitch'] = 'boolean';
+
+        $rules['dependencies'] = 'array';
+        $rules['dependencies.*.depends_on_id'] = "required|exists:projects,id,team_id,{$teamId}";
+        $rules['dependencies.*.alias'] = 'nullable|string|max:50';
+        $rules['dependencies.*.reference_type'] = 'required|in:latest_run,specific_run';
 
         return $rules;
     }
@@ -237,8 +256,68 @@ class EditProjectForm extends Component
 
         app(UpdateProjectAction::class)->execute($this->project, $data);
 
+        $this->syncDependencies();
+
         session()->flash('message', 'Project updated successfully!');
         $this->redirect(route('projects.show', $this->project));
+    }
+
+    public function addDependency(): void
+    {
+        $this->dependencies[] = [
+            'depends_on_id' => '',
+            'alias' => '',
+            'reference_type' => 'latest_run',
+            'is_required' => true,
+        ];
+    }
+
+    public function removeDependency(int $index): void
+    {
+        unset($this->dependencies[$index]);
+        $this->dependencies = array_values($this->dependencies);
+    }
+
+    public function updatedDependencies($value, $key): void
+    {
+        // Auto-generate alias from project title when selecting a project
+        if (str_ends_with($key, '.depends_on_id') && $value) {
+            $index = (int) explode('.', $key)[0];
+            $project = Project::find($value);
+            if ($project && empty($this->dependencies[$index]['alias'])) {
+                $this->dependencies[$index]['alias'] = str($project->title)->slug('_')->limit(50)->toString();
+            }
+        }
+    }
+
+    private function syncDependencies(): void
+    {
+        $teamId = auth()->user()->current_team_id;
+
+        $rows = array_values(array_filter(
+            $this->dependencies,
+            fn ($d) => ! empty($d['depends_on_id']),
+        ));
+
+        $keptIds = [];
+        foreach ($rows as $index => $dep) {
+            $record = ProjectDependency::updateOrCreate(
+                [
+                    'project_id' => $this->project->id,
+                    'depends_on_id' => $dep['depends_on_id'],
+                ],
+                [
+                    'team_id' => $teamId,
+                    'alias' => $dep['alias'] ?: 'dependency_'.$index,
+                    'reference_type' => $dep['reference_type'] ?? 'latest_run',
+                    'is_required' => $dep['is_required'] ?? true,
+                    'sort_order' => $index,
+                ],
+            );
+            $keptIds[] = $record->id;
+        }
+
+        $this->project->dependencies()->whereNotIn('id', $keptIds)->delete();
     }
 
     public function getSchedulePreviewProperty(): array
@@ -259,6 +338,9 @@ class EditProjectForm extends Component
         $tools = Tool::where('status', 'active')->orderBy('name')->get(['id', 'name', 'type']);
         $credentials = Credential::where('status', 'active')->orderBy('name')->get(['id', 'name', 'credential_type']);
         $emailTemplates = EmailTemplate::where('status', 'active')->orderBy('name')->get(['id', 'name', 'subject']);
+        $availableProjects = Project::where('id', '!=', $this->project->id)
+            ->orderBy('title')
+            ->get(['id', 'title', 'type', 'status']);
 
         return view('livewire.projects.edit-project-form', [
             'agents' => $agents,
@@ -268,6 +350,7 @@ class EditProjectForm extends Component
             'tools' => $tools,
             'credentials' => $credentials,
             'emailTemplates' => $emailTemplates,
+            'availableProjects' => $availableProjects,
             'executionModes' => ProjectExecutionMode::cases(),
             'schedulePreview' => $this->schedulePreview,
         ])->layout('layouts.app', ['header' => 'Edit: '.$this->project->title]);

--- a/app/Livewire/Projects/EditProjectForm.php
+++ b/app/Livewire/Projects/EditProjectForm.php
@@ -283,7 +283,7 @@ class EditProjectForm extends Component
         // Auto-generate alias from project title when selecting a project
         if (str_ends_with($key, '.depends_on_id') && $value) {
             $index = (int) explode('.', $key)[0];
-            $project = Project::find($value);
+            $project = Project::where('team_id', auth()->user()->current_team_id)->find($value);
             if ($project && empty($this->dependencies[$index]['alias'])) {
                 $this->dependencies[$index]['alias'] = str($project->title)->slug('_')->limit(50)->toString();
             }
@@ -338,7 +338,8 @@ class EditProjectForm extends Component
         $tools = Tool::where('status', 'active')->orderBy('name')->get(['id', 'name', 'type']);
         $credentials = Credential::where('status', 'active')->orderBy('name')->get(['id', 'name', 'credential_type']);
         $emailTemplates = EmailTemplate::where('status', 'active')->orderBy('name')->get(['id', 'name', 'subject']);
-        $availableProjects = Project::where('id', '!=', $this->project->id)
+        $availableProjects = Project::where('team_id', auth()->user()->current_team_id)
+            ->where('id', '!=', $this->project->id)
             ->orderBy('title')
             ->get(['id', 'title', 'type', 'status']);
 

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -513,6 +513,19 @@ use App\Mcp\Tools\Skill\SkillVersionsTool;
 use App\Mcp\Tools\Skill\SupabaseEdgeFunctionSkillTool;
 use App\Mcp\Tools\System\AuditLogTool;
 use App\Mcp\Tools\System\SecretScanFindingsTool;
+use App\Mcp\Tools\Crew\CrewBlackboardGetTool;
+use App\Mcp\Tools\Experiment\ExperimentCheckpointsTool;
+use App\Mcp\Tools\Experiment\ReasoningBankListTool;
+use App\Mcp\Tools\Outbound\OutboundProposalListTool;
+use App\Mcp\Tools\Workflow\WorkflowCompensationRunsTool;
+use App\Mcp\Tools\Workflow\WorkflowSimulateTool;
+use App\Mcp\Tools\Testing\TestSuiteListTool;
+use App\Mcp\Tools\Testing\TestSuiteGetTool;
+use App\Mcp\Tools\ErrorMode\ErrorModeListTool;
+use App\Mcp\Tools\ErrorMode\ErrorModeGetTool;
+use App\Mcp\Tools\ErrorMode\ErrorModeAssignLeverTool;
+use App\Mcp\Tools\Signal\KgCommunityListTool;
+use App\Mcp\Tools\Signal\KgCommunityRebuildTool;
 use App\Mcp\Tools\System\BlacklistManageTool;
 use App\Mcp\Tools\System\DashboardKpisTool;
 use App\Mcp\Tools\System\GlobalSettingsUpdateTool;
@@ -1343,6 +1356,19 @@ class AgentFleetServer extends Server
         SystemDiscoveryGetTool::class,
         AuditLogTool::class,
         SecretScanFindingsTool::class,
+        CrewBlackboardGetTool::class,
+        ExperimentCheckpointsTool::class,
+        ReasoningBankListTool::class,
+        OutboundProposalListTool::class,
+        WorkflowCompensationRunsTool::class,
+        WorkflowSimulateTool::class,
+        TestSuiteListTool::class,
+        TestSuiteGetTool::class,
+        ErrorModeListTool::class,
+        ErrorModeGetTool::class,
+        ErrorModeAssignLeverTool::class,
+        KgCommunityListTool::class,
+        KgCommunityRebuildTool::class,
         GlobalSettingsUpdateTool::class,
         BlacklistManageTool::class,
         SecurityPolicyManageTool::class,

--- a/app/Mcp/Tools/Crew/CrewBlackboardGetTool.php
+++ b/app/Mcp/Tools/Crew/CrewBlackboardGetTool.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Mcp\Tools\Crew;
+
+use App\Domain\Crew\Models\CrewChatMessage;
+use App\Domain\Crew\Models\CrewExecution;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Redis;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class CrewBlackboardGetTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'crew_blackboard_get';
+
+    protected string $description = 'Get the full communication view for a crew execution: ephemeral blackboard posts (Redis sorted set, 24h TTL) plus the chat-room transcript (CrewChatMessage). Use crew_blackboard_read for just the blackboard posts.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'execution_id' => $schema->string()
+                ->description('The crew execution UUID')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate([
+            'execution_id' => 'required|string',
+        ]);
+
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $execution = CrewExecution::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['execution_id']);
+
+        if (! $execution) {
+            return $this->notFoundError('crew execution');
+        }
+
+        $raw = Redis::zrange('crew:blackboard:'.$execution->id, 0, -1);
+        $blackboardPosts = collect($raw)
+            ->map(fn ($entry) => json_decode((string) $entry, true))
+            ->filter(fn ($decoded) => is_array($decoded))
+            ->values()
+            ->all();
+
+        // CrewChatMessage has no team_id of its own; it is scoped transitively
+        // through the already-team-scoped CrewExecution resolved above.
+        $chatMessages = $execution->chatMessages()->get()
+            ->map(fn (CrewChatMessage $m): array => [
+                'agent_name' => $m->agent_name,
+                'role' => $m->role,
+                'content' => $m->content,
+                'round' => $m->round,
+                'created_at' => $m->created_at?->toIso8601String(),
+            ])->values()->toArray();
+
+        return Response::text(json_encode([
+            'execution_id' => $execution->id,
+            'blackboard_post_count' => count($blackboardPosts),
+            'blackboard_posts' => $blackboardPosts,
+            'chat_message_count' => count($chatMessages),
+            'chat_messages' => $chatMessages,
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Experiment/ExperimentCheckpointsTool.php
+++ b/app/Mcp/Tools/Experiment/ExperimentCheckpointsTool.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Mcp\Tools\Experiment;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+class ExperimentCheckpointsTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'experiment_checkpoints';
+
+    protected string $description = 'List an experiment\'s checkpoints — playbook steps carrying checkpoint_data, most-recently-updated first. Returns step id, status, checkpoint version, worker_id, idempotency_key, and last heartbeat.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'experiment_id' => $schema->string()
+                ->description('The experiment UUID')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate(['experiment_id' => 'required|string']);
+
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $experiment = Experiment::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['experiment_id']);
+
+        if (! $experiment) {
+            return $this->notFoundError('experiment');
+        }
+
+        $checkpoints = PlaybookStep::where('experiment_id', $experiment->id)
+            ->whereNotNull('checkpoint_data')
+            ->orderByDesc('updated_at')
+            ->get();
+
+        return Response::text(json_encode([
+            'experiment_id' => $experiment->id,
+            'count' => $checkpoints->count(),
+            'checkpoints' => $checkpoints->map(fn (PlaybookStep $s) => [
+                'id' => $s->id,
+                'order' => $s->order,
+                'status' => $s->status,
+                'version' => $s->checkpoint_version,
+                'worker_id' => $s->worker_id,
+                'idempotency_key' => $s->idempotency_key,
+                'last_heartbeat' => $s->last_heartbeat_at?->toIso8601String(),
+                'updated_at' => $s->updated_at?->toIso8601String(),
+            ])->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Experiment/ReasoningBankListTool.php
+++ b/app/Mcp/Tools/Experiment/ReasoningBankListTool.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Mcp\Tools\Experiment;
+
+use App\Domain\Experiment\Models\ReasoningBankEntry;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class ReasoningBankListTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'reasoning_bank_list';
+
+    protected string $description = 'List reasoning bank entries (past experiment strategies) newest-first. Returns goal_text, outcome_summary, the linked experiment, and recorded time. Optional substring search over goal/outcome. Use reasoning_bank_search for semantic similarity lookup.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'search' => $schema->string()
+                ->description('Case-insensitive substring filter over goal_text and outcome_summary'),
+            'limit' => $schema->integer()
+                ->description('Max entries to return (1–100, default 30)')
+                ->default(30),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $limit = min(max((int) $request->get('limit', 30), 1), 100);
+
+        $query = ReasoningBankEntry::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->with('experiment:id,title')
+            ->latest('created_at');
+
+        if ($search = $request->get('search')) {
+            $term = '%'.mb_strtolower($search).'%';
+            $query->where(function ($q) use ($term) {
+                $q->whereRaw('lower(goal_text) like ?', [$term])
+                    ->orWhereRaw('lower(outcome_summary) like ?', [$term]);
+            });
+        }
+
+        $entries = $query->limit($limit)->get();
+
+        return Response::text(json_encode([
+            'count' => $entries->count(),
+            'entries' => $entries->map(fn (ReasoningBankEntry $entry): array => [
+                'id' => $entry->id,
+                'goal_text' => $entry->goal_text,
+                'outcome_summary' => $entry->outcome_summary,
+                'experiment_id' => $entry->experiment_id,
+                'experiment_title' => $entry->experiment?->title,
+                'created_at' => $entry->created_at?->toIso8601String(),
+            ])->values()->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Outbound/ConnectorConfigSaveTool.php
+++ b/app/Mcp/Tools/Outbound/ConnectorConfigSaveTool.php
@@ -40,7 +40,7 @@ class ConnectorConfigSaveTool extends Tool
     public function handle(Request $request): Response
     {
         $channel = $request->get('channel');
-        $validChannels = ['email', 'webhook', 'notification', 'telegram', 'slack', 'discord', 'teams', 'google_chat', 'whatsapp', 'ntfy'];
+        $validChannels = ['email', 'webhook', 'notification', 'telegram', 'slack', 'discord', 'teams', 'google_chat', 'whatsapp', 'ntfy', 'matrix', 'signal_protocol', 'supabase_realtime'];
 
         if (! in_array($channel, $validChannels)) {
             return $this->invalidArgumentError('Invalid channel. Must be one of: '.implode(', ', $validChannels));

--- a/app/Mcp/Tools/Outbound/ConnectorConfigTestTool.php
+++ b/app/Mcp/Tools/Outbound/ConnectorConfigTestTool.php
@@ -63,6 +63,9 @@ class ConnectorConfigTestTool extends Tool
                 'whatsapp' => $this->testWhatsApp($creds),
                 'email' => $this->testSmtp($creds),
                 'webhook' => $this->testWebhook($creds),
+                'matrix' => $this->testMatrix($creds),
+                'signal_protocol' => $this->testSignal($creds),
+                'supabase_realtime' => $this->testSupabaseRealtime($creds),
                 default => throw new \RuntimeException('Unknown channel'),
             };
 
@@ -237,6 +240,70 @@ class ConnectorConfigTestTool extends Tool
         }
 
         throw new \RuntimeException("Unexpected SMTP response: {$banner}");
+    }
+
+    private function testMatrix(array $creds): string
+    {
+        $homeserverUrl = rtrim($creds['homeserver_url'] ?? '', '/');
+        $accessToken = $creds['access_token'] ?? '';
+
+        if (! $homeserverUrl || ! $accessToken) {
+            throw new \RuntimeException('Homeserver URL and access token are required');
+        }
+
+        $response = Http::timeout(10)
+            ->withToken($accessToken)
+            ->get("{$homeserverUrl}/_matrix/client/v3/account/whoami");
+
+        if ($response->successful()) {
+            return 'Connected as '.($response->json('user_id') ?? 'verified');
+        }
+
+        throw new \RuntimeException($response->json('error', 'Invalid homeserver URL or access token'));
+    }
+
+    private function testSignal(array $creds): string
+    {
+        $apiUrl = rtrim($creds['api_url'] ?? 'http://signal-sidecar:8080', '/');
+
+        $response = Http::timeout(10)->get("{$apiUrl}/v1/about");
+
+        if ($response->successful()) {
+            return 'signal-cli-rest-api reachable at '.$apiUrl;
+        }
+
+        throw new \RuntimeException('signal-cli-rest-api returned '.$response->status());
+    }
+
+    private function testSupabaseRealtime(array $creds): string
+    {
+        $ref = $creds['ref'] ?? '';
+        $apiKey = $creds['key'] ?? '';
+
+        if (! $ref || ! $apiKey) {
+            throw new \RuntimeException('Project ref and key are required');
+        }
+
+        $channel = $creds['channel'] ?? 'agent:results';
+        $event = $creds['event'] ?? 'message';
+
+        $response = Http::withHeaders([
+            'apikey' => $apiKey,
+            'Authorization' => "Bearer {$apiKey}",
+            'Content-Type' => 'application/json',
+        ])->timeout(10)->post("https://{$ref}.supabase.co/realtime/v1/api/broadcast", [
+            'messages' => [[
+                'topic' => $channel,
+                'event' => $event,
+                'payload' => ['test' => true, 'source' => 'fleetq'],
+            ]],
+        ]);
+
+        if ($response->successful()) {
+            return 'Broadcast sent successfully';
+        }
+
+        throw new \RuntimeException('Supabase returned '.$response->status());
     }
 
     private function testWebhook(array $creds): string

--- a/app/Mcp/Tools/Outbound/OutboundProposalListTool.php
+++ b/app/Mcp/Tools/Outbound/OutboundProposalListTool.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Mcp\Tools\Outbound;
+
+use App\Domain\Outbound\Models\OutboundProposal;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Str;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class OutboundProposalListTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'outbound_proposal_list';
+
+    protected string $description = 'List outbound delivery proposals. Returns status, channel, target, risk_score, a content preview, and the linked experiment. Filterable by status and channel.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'status' => $schema->string()
+                ->description('Filter by status: pending_approval, approved, rejected, expired, cancelled'),
+            'channel' => $schema->string()
+                ->description('Filter by channel: email, webhook, notification, telegram, slack, whatsapp, discord, teams, google_chat, signal_protocol, matrix, supabase_realtime, ntfy'),
+            'limit' => $schema->integer()
+                ->description('Max proposals to return (1–100, default 25)')
+                ->default(25),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $limit = min(max((int) $request->get('limit', 25), 1), 100);
+
+        $query = OutboundProposal::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->with('experiment:id,title')
+            ->latest();
+
+        if ($status = $request->get('status')) {
+            $query->where('status', $status);
+        }
+
+        if ($channel = $request->get('channel')) {
+            $query->where('channel', $channel);
+        }
+
+        $proposals = $query->limit($limit)->get();
+
+        return Response::text(json_encode([
+            'count' => $proposals->count(),
+            'proposals' => $proposals->map(function (OutboundProposal $p): array {
+                return [
+                    'id' => $p->id,
+                    'status' => $p->status->value,
+                    'channel' => $p->channel->value,
+                    'target' => $p->target,
+                    'risk_score' => $p->risk_score,
+                    'content_preview' => Str::limit((string) json_encode($p->content), 240),
+                    'experiment_id' => $p->experiment_id,
+                    'experiment_title' => $p->experiment?->title,
+                    'created_at' => $p->created_at?->toIso8601String(),
+                ];
+            })->values()->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Signal/KgCommunityListTool.php
+++ b/app/Mcp/Tools/Signal/KgCommunityListTool.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Mcp\Tools\Signal;
+
+use App\Domain\KnowledgeGraph\Models\KgCommunity;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class KgCommunityListTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'kg_community_list';
+
+    protected string $description = 'List knowledge graph communities (entity clusters with LLM-generated label and summary), largest first. Optional label search. Returns label, size, top_entities and summary per community. Mirrors the KG Communities page.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'search' => $schema->string()
+                ->description('Case-insensitive substring filter on community label'),
+            'page' => $schema->integer()
+                ->description('Page number (default: 1)')
+                ->default(1),
+            'per_page' => $schema->integer()
+                ->description('Results per page (default: 20, max: 100)')
+                ->default(20),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $perPage = min(max((int) $request->get('per_page', 20), 1), 100);
+        $page = max((int) $request->get('page', 1), 1);
+
+        $query = KgCommunity::query()
+            ->where('team_id', $teamId);
+
+        if ($search = $request->get('search')) {
+            $query->whereRaw('lower(label) like ?', ['%'.mb_strtolower((string) $search).'%']);
+        }
+
+        $communities = $query
+            ->orderByDesc('size')
+            ->paginate($perPage, ['*'], 'page', $page);
+
+        return Response::text(json_encode([
+            'communities' => collect($communities->items())->map(fn (KgCommunity $c) => [
+                'id' => $c->id,
+                'label' => $c->label,
+                'size' => $c->size,
+                'top_entities' => $c->top_entities,
+                'summary' => $c->summary,
+            ])->values()->toArray(),
+            'pagination' => [
+                'page' => $communities->currentPage(),
+                'per_page' => $communities->perPage(),
+                'total' => $communities->total(),
+                'last_page' => $communities->lastPage(),
+            ],
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Signal/KgCommunityRebuildTool.php
+++ b/app/Mcp/Tools/Signal/KgCommunityRebuildTool.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Mcp\Tools\Signal;
+
+use App\Domain\KnowledgeGraph\Actions\BuildKgCommunitiesAction;
+use App\Domain\KnowledgeGraph\Models\KgCommunity;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('write')]
+class KgCommunityRebuildTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'kg_community_rebuild';
+
+    // WARNING: synchronous + LLM-backed (one LLM call per community) + DELETES all
+    // existing communities for the team before recreating. Slow and costly on large graphs.
+    protected string $description = 'Rebuild this team\'s knowledge graph communities from scratch using the Louvain algorithm. WARNING: runs synchronously, DELETES all existing communities for the team, then makes one LLM call per detected community to generate a summary. This can be slow and costly on large graphs. Returns the resulting community count.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        app(BuildKgCommunitiesAction::class)->execute($teamId);
+
+        $count = KgCommunity::query()
+            ->where('team_id', $teamId)
+            ->count();
+
+        return Response::text(json_encode([
+            'success' => true,
+            'message' => 'Communities rebuilt.',
+            'community_count' => $count,
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Testing/TestSuiteGetTool.php
+++ b/app/Mcp/Tools/Testing/TestSuiteGetTool.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Mcp\Tools\Testing;
+
+use App\Domain\Testing\Models\TestRun;
+use App\Domain\Testing\Models\TestSuite;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+class TestSuiteGetTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'test_suite_get';
+
+    protected string $description = 'Get one test suite and its test runs. Returns suite config plus each run\'s status, score, experiment_id, duration, and timestamps.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'test_suite_id' => $schema->string()
+                ->description('The test suite UUID')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate(['test_suite_id' => 'required|string']);
+
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $suite = TestSuite::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['test_suite_id']);
+
+        if (! $suite) {
+            return $this->notFoundError('test_suite');
+        }
+
+        // TestRun has no team_id; constrain via the team-scoped suite.
+        $runs = TestRun::where('test_suite_id', $suite->id)
+            ->orderByDesc('created_at')
+            ->get();
+
+        return Response::text(json_encode([
+            'id' => $suite->id,
+            'name' => $suite->name,
+            'project_id' => $suite->project_id,
+            'strategy' => $suite->test_strategy?->value,
+            'active' => $suite->is_active,
+            'quality_threshold' => $suite->quality_threshold,
+            'pass_rate' => $suite->pass_rate,
+            'last_run_at' => $suite->last_run_at?->toIso8601String(),
+            'run_count' => $runs->count(),
+            'runs' => $runs->map(fn (TestRun $r) => [
+                'id' => $r->id,
+                'experiment_id' => $r->experiment_id,
+                'status' => $r->status?->value,
+                'score' => $r->score,
+                'duration_ms' => $r->duration_ms,
+                'started_at' => $r->started_at?->toIso8601String(),
+                'completed_at' => $r->completed_at?->toIso8601String(),
+            ])->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Testing/TestSuiteListTool.php
+++ b/app/Mcp/Tools/Testing/TestSuiteListTool.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mcp\Tools\Testing;
+
+use App\Domain\Testing\Models\TestSuite;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+class TestSuiteListTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'test_suite_list';
+
+    protected string $description = 'List the team\'s test suites. Returns id, name, project_id, test strategy, active flag, quality threshold, pass rate, and run count.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $suites = TestSuite::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->withCount('testRuns')
+            ->orderByDesc('created_at')
+            ->get();
+
+        return Response::text(json_encode([
+            'count' => $suites->count(),
+            'test_suites' => $suites->map(fn (TestSuite $s) => [
+                'id' => $s->id,
+                'name' => $s->name,
+                'project_id' => $s->project_id,
+                'strategy' => $s->test_strategy?->value,
+                'active' => $s->is_active,
+                'quality_threshold' => $s->quality_threshold,
+                'pass_rate' => $s->pass_rate,
+                'run_count' => $s->test_runs_count,
+                'last_run_at' => $s->last_run_at?->toIso8601String(),
+            ])->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Workflow/WorkflowCompensationRunsTool.php
+++ b/app/Mcp/Tools/Workflow/WorkflowCompensationRunsTool.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Mcp\Tools\Workflow;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use App\Domain\Workflow\Models\WorkflowNode;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+/**
+ * List failed workflow-run experiments that had compensation-eligible steps.
+ *
+ * Compensation (saga) runs are NOT persisted as their own queryable records, so
+ * this tool reconstructs them exactly like WorkflowOpsPage: failed workflow
+ * experiments whose completed steps had a workflow node with a
+ * compensation_node_id (i.e. steps that would have been rolled back). Read-only.
+ */
+#[IsReadOnly]
+#[IsIdempotent]
+class WorkflowCompensationRunsTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'workflow_compensation_runs';
+
+    protected string $description = 'List failed workflow-run experiments that had compensation-eligible steps (saga rollback candidates). Reconstructed from failed experiments whose completed steps had a workflow node with a compensation node defined.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        // Only failed workflow-run experiments can trigger compensation.
+        $experiments = Experiment::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->whereNotNull('workflow_id')
+            ->whereIn('status', ['execution_failed', 'building_failed', 'planning_failed', 'scoring_failed'])
+            ->with('workflow:id,name')
+            ->orderByDesc('updated_at')
+            ->limit(50)
+            ->get();
+
+        $runs = $experiments
+            ->map(function (Experiment $experiment): array {
+                $completedNodeIds = PlaybookStep::query()
+                    ->where('experiment_id', $experiment->id)
+                    ->where('status', 'completed')
+                    ->whereNotNull('workflow_node_id')
+                    ->pluck('workflow_node_id');
+
+                if ($completedNodeIds->isEmpty()) {
+                    return ['experiment' => $experiment, 'compensated_count' => 0];
+                }
+
+                $compensatedCount = WorkflowNode::withoutGlobalScopes()
+                    ->whereHas('workflow', fn ($q) => $q->where('team_id', $experiment->team_id))
+                    ->whereIn('id', $completedNodeIds)
+                    ->whereNotNull('compensation_node_id')
+                    ->count();
+
+                return ['experiment' => $experiment, 'compensated_count' => $compensatedCount];
+            })
+            ->filter(fn (array $row): bool => $row['compensated_count'] > 0)
+            ->values()
+            ->map(fn (array $row): array => [
+                'experiment_id' => $row['experiment']->id,
+                'workflow_id' => $row['experiment']->workflow_id,
+                'workflow_name' => $row['experiment']->workflow?->name,
+                'status' => $row['experiment']->status->value,
+                'compensated_count' => $row['compensated_count'],
+                'updated_at' => $row['experiment']->updated_at?->toIso8601String(),
+            ]);
+
+        return Response::text(json_encode([
+            'count' => $runs->count(),
+            'runs' => $runs->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/Workflow/WorkflowSimulateTool.php
+++ b/app/Mcp/Tools/Workflow/WorkflowSimulateTool.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Mcp\Tools\Workflow;
+
+use App\Domain\Workflow\Enums\WorkflowNodeType;
+use App\Domain\Workflow\Models\Workflow;
+use App\Domain\Workflow\Services\WorkflowSimulator;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+/**
+ * Dry-run a workflow graph through WorkflowSimulator and return the predicted
+ * execution path / termination. WorkflowSimulator is pure: no real execution,
+ * no LLM calls, no cost, no DB writes. Execution (non-control-flow) nodes are
+ * auto-stubbed with empty output so the simulator can walk the whole graph,
+ * mirroring the WorkflowSimulationPanel surface.
+ */
+#[IsReadOnly]
+#[IsIdempotent]
+class WorkflowSimulateTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'workflow_simulate';
+
+    protected string $description = 'Dry-run a workflow graph and return the predicted execution path and termination (no real execution, no LLM calls, no cost, no DB writes). Execution nodes are auto-stubbed with empty output.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'workflow_id' => $schema->string()
+                ->description('The workflow UUID to simulate')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate(['workflow_id' => 'required|string']);
+
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $workflow = Workflow::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['workflow_id']);
+
+        if (! $workflow) {
+            return $this->notFoundError('workflow');
+        }
+
+        $nodes = $workflow->nodes()->get()->keyBy('id');
+
+        // Auto-stub every execution (non-control-flow) node with empty output.
+        $simulator = new WorkflowSimulator;
+        foreach ($nodes as $node) {
+            if (! $node->type->isControlFlow() && $node->type !== WorkflowNodeType::End) {
+                $simulator = $simulator->stub($node->id, []);
+            }
+        }
+
+        $result = $simulator->run($workflow);
+
+        return Response::text(json_encode([
+            'workflow_id' => $workflow->id,
+            'termination_status' => $result->terminationStatus,
+            'termination_node_id' => $result->terminationNodeId,
+            'executed_path' => collect($result->executedPath)
+                ->map(fn (string $nodeId): array => [
+                    'id' => $nodeId,
+                    'label' => $nodes->get($nodeId)?->label ?? $nodeId,
+                    'type' => $nodes->get($nodeId)?->type->value ?? 'unknown',
+                ])
+                ->toArray(),
+        ]));
+    }
+}

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -189,6 +189,9 @@
                 <x-sidebar-link href="{{ route('outbound.discord') }}" :active="request()->routeIs('outbound.discord')" icon="chat-bubble-left-right">Discord</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.teams') }}" :active="request()->routeIs('outbound.teams')" icon="chat-bubble-left-right">Teams</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.google_chat') }}" :active="request()->routeIs('outbound.google_chat')" icon="chat-bubble-left-right">Google Chat</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.matrix') }}" :active="request()->routeIs('outbound.matrix')" icon="chat-bubble-left-right">Matrix</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.signal_protocol') }}" :active="request()->routeIs('outbound.signal_protocol')" icon="chat-bubble-left-right">Signal</x-sidebar-link>
+                <x-sidebar-link href="{{ route('outbound.supabase_realtime') }}" :active="request()->routeIs('outbound.supabase_realtime')" icon="chat-bubble-left-right">Supabase Realtime</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.proposals') }}" :active="request()->routeIs('outbound.proposals')" icon="paper-airplane">Outbound Proposals</x-sidebar-link>
                 <x-sidebar-link href="{{ route('outbound.blacklist') }}" :active="request()->routeIs('outbound.blacklist')" icon="shield-check">Blacklist</x-sidebar-link>
                 <x-sidebar-link href="{{ route('audiences.index') }}" :active="request()->routeIs('audiences.*', 'broadcasts.*')" icon="identification">Audiences</x-sidebar-link>

--- a/resources/views/livewire/agents/agent-detail-page.blade.php
+++ b/resources/views/livewire/agents/agent-detail-page.blade.php
@@ -1394,8 +1394,8 @@
                             <h3 class="text-sm font-semibold text-gray-900">Heartbeat Schedule</h3>
                             <p class="mt-0.5 text-xs text-gray-500">A recurring task the agent runs automatically on a cron schedule. Evaluated every minute by the scheduler.</p>
                         </div>
-                        @if(!empty($agent->heartbeat_definition))
-                            <div class="flex items-center gap-2">
+                        <div class="flex items-center gap-2">
+                            @if(!empty($agent->heartbeat_definition))
                                 <span class="text-xs {{ ($agent->heartbeat_definition['enabled'] ?? false) ? 'text-green-700 bg-green-100' : 'text-gray-600 bg-gray-100' }} rounded-full px-2.5 py-1 font-medium">
                                     {{ ($agent->heartbeat_definition['enabled'] ?? false) ? 'Enabled' : 'Disabled' }}
                                 </span>
@@ -1408,11 +1408,48 @@
                                     class="rounded-lg bg-primary-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-primary-700">
                                     Run Now
                                 </button>
-                            </div>
-                        @endif
+                            @endif
+                            @unless($editingHeartbeat)
+                                <button wire:click="startEditHeartbeat"
+                                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50">
+                                    {{ !empty($agent->heartbeat_definition) ? 'Edit schedule' : 'Configure' }}
+                                </button>
+                            @endunless
+                        </div>
                     </div>
 
-                    @if(!empty($agent->heartbeat_definition))
+                    @if($editingHeartbeat)
+                        <div class="space-y-4">
+                            <x-form-input
+                                wire:model="heartbeatCron"
+                                name="heartbeatCron"
+                                label="Cron Expression"
+                                hint='e.g. "0 * * * *" hourly, "*/15 * * * *" every 15 min. Must fire no more than once every 5 minutes.'
+                                mono
+                                :error="$errors->first('heartbeatCron')" />
+                            <x-form-textarea
+                                wire:model="heartbeatPrompt"
+                                name="heartbeatPrompt"
+                                label="Prompt"
+                                hint="The task sent to the agent on each heartbeat execution."
+                                rows="4"
+                                :error="$errors->first('heartbeatPrompt')" />
+                            <x-form-checkbox
+                                wire:model="heartbeatEnabled"
+                                name="heartbeatEnabled"
+                                label="Schedule enabled" />
+                            <div class="flex items-center gap-2">
+                                <button wire:click="saveHeartbeat"
+                                    class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700">
+                                    Save schedule
+                                </button>
+                                <button wire:click="cancelEditHeartbeat"
+                                    class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50">
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+                    @elseif(!empty($agent->heartbeat_definition))
                         <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                             <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
                                 <dt class="mb-1 text-xs font-medium text-gray-500">Cron Expression</dt>
@@ -1434,11 +1471,64 @@
                                 <dd class="whitespace-pre-wrap text-sm text-gray-900">{{ $agent->heartbeat_definition['prompt'] ?? '—' }}</dd>
                             </div>
                         </dl>
-                        <p class="mt-4 text-xs text-gray-400">To change the schedule, use the MCP tool <code class="font-mono">agent_heartbeat_update</code> or update the agent's <code class="font-mono">heartbeat_definition</code> JSONB field directly.</p>
                     @else
                         <div class="rounded-lg border border-dashed border-gray-300 p-8 text-center">
                             <p class="text-sm text-gray-500">No heartbeat configured for this agent.</p>
-                            <p class="mt-1 text-xs text-gray-400">Use the MCP tool <code class="font-mono">agent_heartbeat_update</code> to set a schedule.</p>
+                            <p class="mt-1 text-xs text-gray-400">Click <span class="font-medium">Configure</span> to set a schedule.</p>
+                        </div>
+                    @endif
+                </div>
+
+                {{-- Agent dry-run — one LLM call, no execution/artifact/AiRun persisted --}}
+                <div class="rounded-xl border border-gray-200 bg-white p-6">
+                    <div class="mb-4">
+                        <h3 class="text-sm font-semibold text-gray-900">Dry Run</h3>
+                        <p class="mt-0.5 text-xs text-gray-500">Send a sample message through the agent's system prompt as a single LLM call. No execution record, artifact, or AiRun is saved. Costs credits.</p>
+                    </div>
+
+                    @if($dryRunError)
+                        <div class="mb-3 rounded-md bg-red-50 px-3 py-2 text-xs text-red-700">{{ $dryRunError }}</div>
+                    @endif
+
+                    <div class="space-y-3">
+                        <x-form-textarea
+                            wire:model="dryRunInput"
+                            name="dryRunInput"
+                            label="Sample input message"
+                            rows="3"
+                            :error="$errors->first('dryRunInput')" />
+                        <button wire:click="dryRun"
+                            wire:loading.attr="disabled"
+                            class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                            <span wire:loading.remove wire:target="dryRun">Run dry run</span>
+                            <span wire:loading wire:target="dryRun">Running…</span>
+                        </button>
+                    </div>
+
+                    @if($dryRunResult)
+                        <div class="mt-4 space-y-3">
+                            <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                                <dt class="mb-1 text-xs font-medium text-gray-500">Output</dt>
+                                <dd class="whitespace-pre-wrap text-sm text-gray-900">{{ $dryRunResult['output'] }}</dd>
+                            </div>
+                            <dl class="grid grid-cols-2 gap-3 text-xs sm:grid-cols-4">
+                                <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                                    <dt class="text-gray-500">Provider / Model</dt>
+                                    <dd class="mt-0.5 font-mono text-gray-900">{{ $dryRunResult['provider'] }} · {{ $dryRunResult['model'] }}</dd>
+                                </div>
+                                <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                                    <dt class="text-gray-500">Latency</dt>
+                                    <dd class="mt-0.5 font-mono text-gray-900">{{ number_format($dryRunResult['latency_ms']) }} ms</dd>
+                                </div>
+                                <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                                    <dt class="text-gray-500">Cost</dt>
+                                    <dd class="mt-0.5 font-mono text-gray-900">{{ number_format($dryRunResult['cost_credits']) }} credits</dd>
+                                </div>
+                                <div class="rounded-lg border border-gray-100 bg-gray-50 p-3">
+                                    <dt class="text-gray-500">Tokens (in / out)</dt>
+                                    <dd class="mt-0.5 font-mono text-gray-900">{{ number_format($dryRunResult['tokens_input']) }} / {{ number_format($dryRunResult['tokens_output']) }}</dd>
+                                </div>
+                            </dl>
                         </div>
                     @endif
                 </div>

--- a/resources/views/livewire/approvals/human-task-form.blade.php
+++ b/resources/views/livewire/approvals/human-task-form.blade.php
@@ -190,6 +190,75 @@
             </div>
         </form>
 
+        {{-- Escalation Configuration --}}
+        @can('edit-content')
+            <div class="mt-4 border-t border-gray-100 pt-4">
+                <button type="button" wire:click="$toggle('showEscalationConfig')"
+                    class="flex items-center gap-1 text-sm font-medium text-gray-600 hover:text-gray-900">
+                    <span>{{ $showEscalationConfig ? '▾' : '▸' }}</span>
+                    Escalation settings
+                </button>
+
+                @if($showEscalationConfig)
+                    <div class="mt-3 space-y-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+                        <x-form-input
+                            wire:model="slaHours"
+                            type="number"
+                            min="1"
+                            max="8760"
+                            label="SLA hours"
+                            hint="Hours before the task is overdue and escalates to the next assignee."
+                        />
+                        @error('slaHours')
+                            <p class="mt-1 text-xs text-red-600" role="alert">{{ $message }}</p>
+                        @enderror
+
+                        <div>
+                            <span class="mb-1 block text-sm font-medium text-gray-700">Escalation chain</span>
+                            <p class="mb-2 text-xs text-gray-500">Ordered list of team members the task escalates to.</p>
+
+                            @forelse($escalationChain as $index => $assigneeId)
+                                <div class="mb-2 flex items-center gap-2">
+                                    <span class="w-6 text-xs text-gray-400">{{ $index + 1 }}.</span>
+                                    <x-form-select
+                                        wire:model="escalationChain.{{ $index }}"
+                                        compact
+                                        class="flex-1"
+                                    >
+                                        <option value="">-- Select team member --</option>
+                                        @foreach($this->teamMembers as $member)
+                                            <option value="{{ $member['id'] }}">{{ $member['name'] }}</option>
+                                        @endforeach
+                                    </x-form-select>
+                                    <button type="button" wire:click="removeEscalationLevel({{ $index }})"
+                                        class="rounded-lg border border-red-200 px-2 py-1 text-xs text-red-600 hover:bg-red-50">
+                                        Remove
+                                    </button>
+                                </div>
+                                @error("escalationChain.{$index}")
+                                    <p class="mb-2 ml-8 text-xs text-red-600" role="alert">{{ $message }}</p>
+                                @enderror
+                            @empty
+                                <p class="mb-2 text-xs text-gray-400">No escalation levels configured.</p>
+                            @endforelse
+
+                            <button type="button" wire:click="addEscalationLevel"
+                                class="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100">
+                                + Add level
+                            </button>
+                        </div>
+
+                        <div class="border-t border-gray-200 pt-3">
+                            <button type="button" wire:click="saveEscalationConfig"
+                                class="rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700">
+                                Save escalation settings
+                            </button>
+                        </div>
+                    </div>
+                @endif
+            </div>
+        @endcan
+
         {{-- Reject Modal --}}
         @if($showRejectModal)
             <div class="mt-4 rounded-lg border border-red-200 bg-red-50 p-4">

--- a/resources/views/livewire/outbound-connectors/matrix-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/matrix-outbound-page.blade.php
@@ -1,0 +1,96 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Matrix Credentials</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    Provide a bot
+                    <a href="https://matrix.org/docs/guides/client-server-api/" target="_blank" rel="noopener" class="text-primary-600 hover:text-primary-800">access token</a>
+                    and the target room. Testing calls <code class="rounded bg-gray-100 px-1 text-xs">/account/whoami</code>.
+                </p>
+            </div>
+            <div class="grid grid-cols-1 gap-5 p-6 sm:grid-cols-2">
+                <x-form-input
+                    wire:model="homeserverUrl"
+                    label="Homeserver URL"
+                    placeholder="https://matrix.org"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Base URL of your Matrix homeserver.</x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="roomId"
+                    label="Default Room ID"
+                    placeholder="!abc123:matrix.org"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Optional. Used when a proposal target doesn't specify a room_id.</x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="accessToken"
+                    type="password"
+                    label="Access Token"
+                    placeholder="{{ $lastTestedAt || $homeserverUrl ? '(leave blank to keep existing)' : 'syt_…' }}"
+                    autocomplete="new-password"
+                >
+                    <x-slot:hint>Bot access token (write-only).</x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/outbound-connectors/signal-protocol-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/signal-protocol-outbound-page.blade.php
@@ -1,0 +1,95 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Signal (signal-cli-rest-api)</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    Requires a self-hosted
+                    <a href="https://github.com/bbernhard/signal-cli-rest-api" target="_blank" rel="noopener" class="text-primary-600 hover:text-primary-800">signal-cli-rest-api</a>
+                    sidecar with a registered number. Testing pings <code class="rounded bg-gray-100 px-1 text-xs">/v1/about</code>.
+                </p>
+            </div>
+            <div class="grid grid-cols-1 gap-5 p-6 sm:grid-cols-2">
+                <x-form-input
+                    wire:model="apiUrl"
+                    label="Sidecar API URL"
+                    placeholder="http://signal-sidecar:8080"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Base URL of the signal-cli-rest-api sidecar.</x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="phoneNumber"
+                    label="From Number"
+                    placeholder="+15551234567"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Registered Signal number to send from.</x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="recipient"
+                    label="Default Recipient"
+                    placeholder="+15557654321"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Optional. Used when a proposal target doesn't specify a recipient.</x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/outbound-connectors/supabase-realtime-outbound-page.blade.php
+++ b/resources/views/livewire/outbound-connectors/supabase-realtime-outbound-page.blade.php
@@ -1,0 +1,105 @@
+<div>
+    @if (session('message'))
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ session('message') }}</div>
+    @endif
+
+    @if ($testMessage)
+        <div class="mb-4 rounded-lg bg-green-50 p-4 text-sm text-green-700">{{ $testMessage }}</div>
+    @endif
+
+    @if ($testError)
+        <div class="mb-4 rounded-lg bg-red-50 p-4 text-sm text-red-700">{{ $testError }}</div>
+    @endif
+
+    <div class="space-y-6">
+
+        {{-- Status bar --}}
+        <div class="flex items-center justify-between rounded-xl border border-gray-200 bg-white px-6 py-4">
+            <div class="flex items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <span class="inline-block h-2.5 w-2.5 rounded-full {{ $isActive ? 'bg-green-500' : 'bg-gray-300' }}"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ $isActive ? 'Active' : 'Inactive' }}</span>
+                </div>
+                @if ($lastTestedAt)
+                    <span class="text-sm text-gray-500">
+                        Last tested {{ $lastTestedAt }}
+                        <span class="ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {{ $lastTestStatus === 'success' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' }}">
+                            {{ $lastTestStatus }}
+                        </span>
+                    </span>
+                @endif
+            </div>
+            <div class="flex items-center gap-3">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" wire:model="isActive" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="text-sm text-gray-700">Enabled</span>
+                </label>
+                <button wire:click="testConnection" wire:loading.attr="disabled"
+                    class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                    <span wire:loading.remove wire:target="testConnection">Test Connection</span>
+                    <span wire:loading wire:target="testConnection">Testing…</span>
+                </button>
+            </div>
+        </div>
+
+        {{-- Credentials --}}
+        <div class="rounded-xl border border-gray-200 bg-white">
+            <div class="border-b border-gray-200 px-6 py-4">
+                <h2 class="text-base font-semibold text-gray-900">Supabase Realtime Broadcast</h2>
+                <p class="mt-0.5 text-sm text-gray-500">
+                    Pushes agent output to a
+                    <a href="https://supabase.com/docs/guides/realtime/broadcast" target="_blank" rel="noopener" class="text-primary-600 hover:text-primary-800">Realtime Broadcast</a>
+                    channel. Testing sends a test broadcast to the channel below.
+                </p>
+            </div>
+            <div class="grid grid-cols-1 gap-5 p-6 sm:grid-cols-2">
+                <x-form-input
+                    wire:model="ref"
+                    label="Project Ref"
+                    placeholder="xyzabcdef"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Supabase project reference ID (the subdomain).</x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="apiKey"
+                    type="password"
+                    label="API Key"
+                    placeholder="{{ $lastTestedAt || $ref ? '(leave blank to keep existing)' : 'anon or service role key' }}"
+                    autocomplete="new-password"
+                >
+                    <x-slot:hint>Anon or service-role key (write-only).</x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="channel"
+                    label="Channel Topic"
+                    placeholder="agent:results"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Realtime channel topic clients subscribe to.</x-slot:hint>
+                </x-form-input>
+
+                <x-form-input
+                    wire:model="event"
+                    label="Event Name"
+                    placeholder="message"
+                    autocomplete="off"
+                >
+                    <x-slot:hint>Broadcast event name.</x-slot:hint>
+                </x-form-input>
+            </div>
+        </div>
+
+        {{-- Save --}}
+        <div class="flex justify-end">
+            <button wire:click="save" wire:loading.attr="disabled"
+                class="rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50">
+                <span wire:loading.remove wire:target="save">Save Configuration</span>
+                <span wire:loading wire:target="save">Saving…</span>
+            </button>
+        </div>
+
+    </div>
+</div>

--- a/resources/views/livewire/projects/edit-project-form.blade.php
+++ b/resources/views/livewire/projects/edit-project-form.blade.php
@@ -246,6 +246,43 @@
                 </div>
             </div>
 
+            {{-- Dependencies (Based on) --}}
+            <div>
+                <h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500">Based on (optional)</h3>
+                <p class="mb-3 text-xs text-gray-500">Use results from previous projects as input context. The predecessor's artifacts and outputs will be injected into this project's pipeline.</p>
+
+                @foreach($dependencies as $index => $dep)
+                    <div class="mb-3 flex items-start gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3" wire:key="dep-{{ $index }}">
+                        <div class="grid flex-1 grid-cols-3 gap-3">
+                            <x-form-select wire:model.live="dependencies.{{ $index }}.depends_on_id" label="Project" compact>
+                                <option value="">Select project...</option>
+                                @foreach($availableProjects as $proj)
+                                    <option value="{{ $proj->id }}">{{ $proj->title }}</option>
+                                @endforeach
+                            </x-form-select>
+
+                            <x-form-input wire:model="dependencies.{{ $index }}.alias" label="Alias" type="text"
+                                placeholder="e.g. research" compact />
+
+                            <x-form-select wire:model="dependencies.{{ $index }}.reference_type" label="Use results from" compact>
+                                <option value="latest_run">Latest completed run</option>
+                                <option value="specific_run">Specific run</option>
+                            </x-form-select>
+                        </div>
+
+                        <button wire:click="removeDependency({{ $index }})" type="button"
+                            class="mt-6 rounded p-1 text-red-500 hover:bg-red-50">
+                            <i class="fa-solid fa-xmark text-base"></i>
+                        </button>
+                    </div>
+                @endforeach
+
+                <button wire:click="addDependency" type="button"
+                    class="mt-1 rounded-lg border border-dashed border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-500 hover:border-gray-400 hover:text-gray-700">
+                    + Add Predecessor Project
+                </button>
+            </div>
+
             {{-- Tools & Credentials --}}
             <div>
                 <h3 class="mb-3 text-sm font-semibold uppercase tracking-wider text-gray-500">Tools & Credentials (optional)</h3>

--- a/routes/web.php
+++ b/routes/web.php
@@ -498,6 +498,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/outbound/discord', \App\Livewire\OutboundConnectors\DiscordOutboundPage::class)->name('outbound.discord');
     Route::get('/outbound/teams', \App\Livewire\OutboundConnectors\TeamsOutboundPage::class)->name('outbound.teams');
     Route::get('/outbound/google-chat', \App\Livewire\OutboundConnectors\GoogleChatOutboundPage::class)->name('outbound.google_chat');
+    Route::get('/outbound/matrix', \App\Livewire\OutboundConnectors\MatrixOutboundPage::class)->name('outbound.matrix');
+    Route::get('/outbound/signal', \App\Livewire\OutboundConnectors\SignalProtocolOutboundPage::class)->name('outbound.signal_protocol');
+    Route::get('/outbound/supabase-realtime', \App\Livewire\OutboundConnectors\SupabaseRealtimeOutboundPage::class)->name('outbound.supabase_realtime');
     Route::get('/outbound/blacklist', \App\Livewire\Outbound\BlacklistPage::class)->name('outbound.blacklist');
     Route::get('/outbound/proposals', \App\Livewire\Outbound\OutboundProposalsPage::class)->name('outbound.proposals');
 

--- a/tests/Feature/Domain/Broadcast/SendBroadcastChunkingTest.php
+++ b/tests/Feature/Domain/Broadcast/SendBroadcastChunkingTest.php
@@ -5,18 +5,22 @@ namespace Tests\Feature\Domain\Broadcast;
 use App\Domain\Audience\Models\Audience;
 use App\Domain\Broadcast\Enums\BroadcastRecipientStatus;
 use App\Domain\Broadcast\Enums\BroadcastStatus;
+use App\Domain\Broadcast\Jobs\SendBroadcastChunkJob;
 use App\Domain\Broadcast\Jobs\SendBroadcastJob;
 use App\Domain\Broadcast\Models\Broadcast;
 use App\Domain\Broadcast\Models\BroadcastRecipient;
 use App\Domain\Broadcast\Services\BroadcastBudgetGuard;
+use App\Domain\Broadcast\Services\BroadcastMailer;
 use App\Domain\Outbound\Models\OutboundConnectorConfig;
 use App\Domain\Shared\Models\ContactIdentity;
 use App\Domain\Shared\Models\Team;
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
-class SendBroadcastJobTest extends TestCase
+class SendBroadcastChunkingTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -46,22 +50,51 @@ class SendBroadcastJobTest extends TestCase
             'audience_id' => $audience->id,
             'status' => BroadcastStatus::Sending,
         ]);
+    }
 
-        foreach (['a@example.com', 'b@example.com'] as $email) {
+    private function seedRecipients(int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
             BroadcastRecipient::create([
                 'team_id' => $this->team->id,
                 'broadcast_id' => $this->broadcast->id,
                 'contact_identity_id' => ContactIdentity::factory()->create(['team_id' => $this->team->id])->id,
-                'email' => $email,
+                'email' => "user{$i}@example.com",
                 'status' => BroadcastRecipientStatus::Pending,
             ]);
         }
     }
 
-    public function test_sends_to_all_pending_recipients_and_marks_broadcast_sent(): void
+    public function test_dispatches_a_batch_of_chunk_jobs_for_a_large_audience(): void
+    {
+        Bus::fake();
+        $this->seedRecipients(250);
+
+        (new SendBroadcastJob($this->broadcast->id))->handle(app(BroadcastBudgetGuard::class));
+
+        // 250 recipients / chunk size 100 => 3 chunk jobs in one batch.
+        Bus::assertBatched(function (PendingBatch $batch) {
+            return $batch->jobs->count() === 3
+                && $batch->jobs->every(fn ($job) => $job instanceof SendBroadcastChunkJob);
+        });
+    }
+
+    public function test_small_audience_dispatches_a_single_chunk_job(): void
+    {
+        Bus::fake();
+        $this->seedRecipients(2);
+
+        (new SendBroadcastJob($this->broadcast->id))->handle(app(BroadcastBudgetGuard::class));
+
+        Bus::assertBatched(fn (PendingBatch $batch) => $batch->jobs->count() === 1);
+    }
+
+    public function test_broadcast_finalizes_to_sent_only_after_chunks_run(): void
     {
         Http::fake(['api.resend.com/*' => Http::response(['id' => 're_msg'], 200)]);
+        $this->seedRecipients(2);
 
+        // Sync queue: the batch runs its chunk jobs, then finally() finalizes.
         (new SendBroadcastJob($this->broadcast->id))->handle(app(BroadcastBudgetGuard::class));
 
         $this->assertSame(BroadcastStatus::Sent, $this->broadcast->fresh()->status);
@@ -71,16 +104,25 @@ class SendBroadcastJobTest extends TestCase
             ->count());
     }
 
-    public function test_marks_recipient_failed_when_provider_rejects(): void
+    public function test_chunk_job_sends_per_recipient_and_updates_status(): void
     {
-        Http::fake(['api.resend.com/*' => Http::response(['message' => 'boom'], 500)]);
+        Http::fake(['api.resend.com/*' => Http::response(['id' => 're_msg'], 200)]);
+        $this->seedRecipients(3);
 
-        (new SendBroadcastJob($this->broadcast->id))->handle(app(BroadcastBudgetGuard::class));
-
-        $this->assertSame(BroadcastStatus::Failed, $this->broadcast->fresh()->status);
-        $this->assertSame(2, BroadcastRecipient::withoutGlobalScopes()
+        $recipientIds = BroadcastRecipient::withoutGlobalScopes()
             ->where('broadcast_id', $this->broadcast->id)
-            ->where('status', BroadcastRecipientStatus::Failed->value)
+            ->pluck('id')
+            ->all();
+
+        (new SendBroadcastChunkJob($this->broadcast->id, $recipientIds))
+            ->handle(app(BroadcastMailer::class));
+
+        $this->assertSame(3, BroadcastRecipient::withoutGlobalScopes()
+            ->where('broadcast_id', $this->broadcast->id)
+            ->where('status', BroadcastRecipientStatus::Sent->value)
             ->count());
+
+        // The chunk job alone does not roll the broadcast to a terminal status.
+        $this->assertSame(BroadcastStatus::Sending, $this->broadcast->fresh()->status);
     }
 }

--- a/tests/Feature/Domain/Outbound/CoreChannelDriversTest.php
+++ b/tests/Feature/Domain/Outbound/CoreChannelDriversTest.php
@@ -5,7 +5,10 @@ namespace Tests\Feature\Domain\Outbound;
 use App\Domain\Outbound\Connectors\DiscordConnector;
 use App\Domain\Outbound\Connectors\DummyConnector;
 use App\Domain\Outbound\Connectors\GoogleChatConnector;
+use App\Domain\Outbound\Connectors\MatrixConnector;
+use App\Domain\Outbound\Connectors\SignalProtocolConnector;
 use App\Domain\Outbound\Connectors\SlackConnector;
+use App\Domain\Outbound\Connectors\SupabaseRealtimeConnector;
 use App\Domain\Outbound\Connectors\TeamsConnector;
 use App\Domain\Outbound\Connectors\TelegramConnector;
 use App\Domain\Outbound\Enums\OutboundActionStatus;
@@ -47,6 +50,9 @@ class CoreChannelDriversTest extends TestCase
             'discord' => ['discord', DiscordConnector::class],
             'teams' => ['teams', TeamsConnector::class],
             'google_chat' => ['google_chat', GoogleChatConnector::class],
+            'matrix' => ['matrix', MatrixConnector::class],
+            'signal_protocol' => ['signal_protocol', SignalProtocolConnector::class],
+            'supabase_realtime' => ['supabase_realtime', SupabaseRealtimeConnector::class],
         ];
     }
 
@@ -117,4 +123,69 @@ class CoreChannelDriversTest extends TestCase
         Http::assertSent(fn ($request) => str_contains($request->url(), 'hooks.slack.com/services/T/B/X'));
     }
 
+    public function test_matrix_send_uses_resolved_config_and_fakes_http(): void
+    {
+        Http::fake(['matrix.example.org/*' => Http::response(['event_id' => '$evt:matrix.example.org'], 200)]);
+        $this->configFor('matrix', [
+            'homeserver_url' => 'https://matrix.example.org',
+            'access_token' => 'cfg-token',
+            'room_id' => '!cfgroom:matrix.example.org',
+        ]);
+
+        // Empty target — connector must fall back to resolved config creds.
+        $proposal = $this->proposal(OutboundChannel::Matrix, []);
+        $action = app(MatrixConnector::class)->send($proposal);
+
+        $this->assertSame(OutboundActionStatus::Sent, $action->status);
+        $this->assertSame('$evt:matrix.example.org', $action->external_id);
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), 'matrix.example.org/_matrix/client/v3/rooms/')
+                && str_contains($request->url(), urlencode('!cfgroom:matrix.example.org'))
+                && $request->hasHeader('Authorization', 'Bearer cfg-token');
+        });
+    }
+
+    public function test_signal_send_uses_resolved_config_and_fakes_http(): void
+    {
+        Http::fake(['signal.example.org:8080/*' => Http::response(['timestamp' => 1700000000], 201)]);
+        $this->configFor('signal_protocol', [
+            'api_url' => 'http://signal.example.org:8080',
+            'phone_number' => '+15551112222',
+            'recipient' => '+15553334444',
+        ]);
+
+        // Empty target — connector must fall back to resolved config creds.
+        $proposal = $this->proposal(OutboundChannel::SignalProtocol, []);
+        $action = app(SignalProtocolConnector::class)->send($proposal);
+
+        $this->assertSame(OutboundActionStatus::Sent, $action->status);
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), 'signal.example.org:8080/v2/send')
+                && $request['number'] === '+15551112222'
+                && $request['recipients'] === ['+15553334444'];
+        });
+    }
+
+    public function test_supabase_realtime_send_uses_resolved_config_and_fakes_http(): void
+    {
+        Http::fake(['cfgref.supabase.co/*' => Http::response('', 202)]);
+        $this->configFor('supabase_realtime', [
+            'ref' => 'cfgref',
+            'key' => 'cfg-key',
+            'channel' => 'cfg:channel',
+            'event' => 'cfg_event',
+        ]);
+
+        // Empty target — connector must fall back to resolved config creds.
+        $proposal = $this->proposal(OutboundChannel::SupabaseRealtime, []);
+        $action = app(SupabaseRealtimeConnector::class)->send($proposal);
+
+        $this->assertSame(OutboundActionStatus::Sent, $action->status);
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), 'cfgref.supabase.co/realtime/v1/api/broadcast')
+                && $request->hasHeader('apikey', 'cfg-key')
+                && $request['messages'][0]['topic'] === 'cfg:channel'
+                && $request['messages'][0]['event'] === 'cfg_event';
+        });
+    }
 }

--- a/tests/Feature/Livewire/AgentDetailHeartbeatTest.php
+++ b/tests/Feature/Livewire/AgentDetailHeartbeatTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Livewire\Agents\AgentDetailPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AgentDetailHeartbeatTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Agent $agent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'T',
+            'slug' => 't-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+        $this->agent = Agent::factory()->create(['team_id' => $team->id]);
+    }
+
+    public function test_save_heartbeat_persists_the_definition(): void
+    {
+        Livewire::test(AgentDetailPage::class, ['agent' => $this->agent])
+            ->call('startEditHeartbeat')
+            ->set('heartbeatCron', '0 * * * *')
+            ->set('heartbeatPrompt', 'Run your scheduled check-in.')
+            ->set('heartbeatEnabled', true)
+            ->call('saveHeartbeat')
+            ->assertHasNoErrors()
+            ->assertSet('editingHeartbeat', false);
+
+        $definition = $this->agent->fresh()->heartbeat_definition;
+        $this->assertSame('0 * * * *', $definition['cron']);
+        $this->assertSame('Run your scheduled check-in.', $definition['prompt']);
+        $this->assertTrue($definition['enabled']);
+        $this->assertNull($definition['next_run_at']);
+    }
+
+    public function test_save_heartbeat_rejects_too_frequent_schedule(): void
+    {
+        Livewire::test(AgentDetailPage::class, ['agent' => $this->agent])
+            ->call('startEditHeartbeat')
+            ->set('heartbeatCron', '* * * * *') // every minute
+            ->set('heartbeatPrompt', 'too often')
+            ->call('saveHeartbeat')
+            ->assertHasErrors(['heartbeatCron']);
+
+        $this->assertNull($this->agent->fresh()->heartbeat_definition);
+    }
+
+    public function test_save_heartbeat_rejects_invalid_cron(): void
+    {
+        Livewire::test(AgentDetailPage::class, ['agent' => $this->agent])
+            ->call('startEditHeartbeat')
+            ->set('heartbeatCron', 'not a cron')
+            ->set('heartbeatPrompt', 'x')
+            ->call('saveHeartbeat')
+            ->assertHasErrors(['heartbeatCron']);
+
+        $this->assertNull($this->agent->fresh()->heartbeat_definition);
+    }
+
+    public function test_unauthorized_user_cannot_save_heartbeat(): void
+    {
+        // Base 'edit-content' gate is permissive; force-deny to exercise the
+        // per-action authorize() guard.
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(AgentDetailPage::class, ['agent' => $this->agent])
+            ->set('editingHeartbeat', true)
+            ->set('heartbeatCron', '0 * * * *')
+            ->set('heartbeatPrompt', 'should not save')
+            ->call('saveHeartbeat')
+            ->assertForbidden();
+
+        $this->assertNull($this->agent->fresh()->heartbeat_definition);
+    }
+
+    public function test_dry_run_returns_a_result(): void
+    {
+        $this->mock(AiGatewayInterface::class, function ($mock) {
+            $mock->shouldReceive('complete')->once()->andReturn(new AiResponseDTO(
+                content: 'dry-run output',
+                parsedOutput: null,
+                usage: new AiUsageDTO(promptTokens: 10, completionTokens: 5, costCredits: 3),
+                provider: 'anthropic',
+                model: 'claude-sonnet-4-5',
+                latencyMs: 42,
+            ));
+        });
+
+        $component = Livewire::test(AgentDetailPage::class, ['agent' => $this->agent])
+            ->set('dryRunInput', 'Hello agent')
+            ->call('dryRun')
+            ->assertHasNoErrors()
+            ->assertSet('dryRunError', null);
+
+        $result = $component->get('dryRunResult');
+        $this->assertSame('dry-run output', $result['output']);
+        $this->assertSame('anthropic', $result['provider']);
+        $this->assertSame(3, $result['cost_credits']);
+        $this->assertSame(42, $result['latency_ms']);
+    }
+
+    public function test_unauthorized_user_cannot_dry_run(): void
+    {
+        Gate::define('edit-content', fn () => false);
+
+        Livewire::test(AgentDetailPage::class, ['agent' => $this->agent])
+            ->set('dryRunInput', 'Hello agent')
+            ->call('dryRun')
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Livewire/EditProjectFormDependenciesTest.php
+++ b/tests/Feature/Livewire/EditProjectFormDependenciesTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Project\Models\Project;
+use App\Domain\Project\Models\ProjectDependency;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Projects\EditProjectForm;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class EditProjectFormDependenciesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $this->user->id]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+    }
+
+    public function test_mount_loads_existing_dependencies(): void
+    {
+        $project = $this->makeProject();
+        $upstream = $this->makeProject();
+
+        ProjectDependency::create([
+            'project_id' => $project->id,
+            'depends_on_id' => $upstream->id,
+            'team_id' => $this->team->id,
+            'alias' => 'research',
+            'reference_type' => 'latest_run',
+            'is_required' => true,
+            'sort_order' => 0,
+        ]);
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->assertSet('dependencies', [
+                [
+                    'depends_on_id' => $upstream->id,
+                    'alias' => 'research',
+                    'reference_type' => 'latest_run',
+                    'is_required' => true,
+                ],
+            ]);
+    }
+
+    public function test_save_persists_new_dependency_team_scoped(): void
+    {
+        $project = $this->makeProject();
+        $upstream = $this->makeProject();
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->set('dependencies', [
+                [
+                    'depends_on_id' => $upstream->id,
+                    'alias' => 'research',
+                    'reference_type' => 'latest_run',
+                    'is_required' => true,
+                ],
+            ])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('project_dependencies', [
+            'project_id' => $project->id,
+            'depends_on_id' => $upstream->id,
+            'team_id' => $this->team->id,
+            'alias' => 'research',
+            'reference_type' => 'latest_run',
+        ]);
+    }
+
+    public function test_save_removes_dependency_when_cleared(): void
+    {
+        $project = $this->makeProject();
+        $upstream = $this->makeProject();
+
+        ProjectDependency::create([
+            'project_id' => $project->id,
+            'depends_on_id' => $upstream->id,
+            'team_id' => $this->team->id,
+            'alias' => 'research',
+            'reference_type' => 'latest_run',
+            'is_required' => true,
+            'sort_order' => 0,
+        ]);
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->set('dependencies', [])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseMissing('project_dependencies', [
+            'project_id' => $project->id,
+            'depends_on_id' => $upstream->id,
+        ]);
+    }
+
+    public function test_cannot_add_another_teams_project_as_upstream(): void
+    {
+        $project = $this->makeProject();
+
+        $otherTeam = Team::factory()->create();
+        $foreignUpstream = Project::factory()->for($otherTeam)->create();
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->set('dependencies', [
+                [
+                    'depends_on_id' => $foreignUpstream->id,
+                    'alias' => 'foreign',
+                    'reference_type' => 'latest_run',
+                    'is_required' => true,
+                ],
+            ])
+            ->call('save')
+            ->assertHasErrors('dependencies.0.depends_on_id');
+
+        $this->assertDatabaseMissing('project_dependencies', [
+            'project_id' => $project->id,
+            'depends_on_id' => $foreignUpstream->id,
+        ]);
+    }
+
+    public function test_save_is_forbidden_without_edit_content_gate(): void
+    {
+        Gate::define('edit-content', fn () => false);
+
+        $project = $this->makeProject();
+        $upstream = $this->makeProject();
+
+        Livewire::test(EditProjectForm::class, ['project' => $project])
+            ->set('dependencies', [
+                [
+                    'depends_on_id' => $upstream->id,
+                    'alias' => 'research',
+                    'reference_type' => 'latest_run',
+                    'is_required' => true,
+                ],
+            ])
+            ->call('save')
+            ->assertForbidden();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function makeProject(array $overrides = []): Project
+    {
+        $agent = Agent::factory()->for($this->team)->create();
+
+        return Project::factory()->for($this->team)->create(array_merge([
+            'agent_config' => ['lead_agent_id' => $agent->id],
+        ], $overrides));
+    }
+}

--- a/tests/Feature/Livewire/HumanTaskSlaConfigTest.php
+++ b/tests/Feature/Livewire/HumanTaskSlaConfigTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Domain\Approval\Enums\ApprovalStatus;
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Approvals\HumanTaskForm;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class HumanTaskSlaConfigTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'T '.bin2hex(random_bytes(3)),
+            'slug' => 't-'.bin2hex(random_bytes(3)),
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+
+        $this->actingAs($this->user);
+    }
+
+    private function makeTask(?Team $team = null): ApprovalRequest
+    {
+        $team ??= $this->team;
+
+        return ApprovalRequest::withoutGlobalScopes()->create([
+            'team_id' => $team->id,
+            'status' => ApprovalStatus::Pending,
+            'form_schema' => ['properties' => ['note' => ['type' => 'string']]],
+            'workflow_node_id' => null,
+            'context' => ['node_label' => 'Review'],
+        ]);
+    }
+
+    public function test_save_sets_sla_hours_and_escalation_chain(): void
+    {
+        $second = User::factory()->create();
+        $this->team->users()->attach($second, ['role' => 'member']);
+
+        $task = $this->makeTask();
+
+        Livewire::test(HumanTaskForm::class, ['task' => $task])
+            ->set('slaHours', 12)
+            ->set('escalationChain', [$this->user->id, $second->id])
+            ->call('saveEscalationConfig')
+            ->assertHasNoErrors();
+
+        $task->refresh();
+        $this->assertSame(12, $task->context['sla_hours']);
+        $this->assertSame([$this->user->id, $second->id], $task->escalation_chain);
+    }
+
+    public function test_escalation_chain_rejects_user_from_other_team(): void
+    {
+        $otherOwner = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other',
+            'slug' => 'other-'.bin2hex(random_bytes(3)),
+            'owner_id' => $otherOwner->id,
+            'settings' => [],
+        ]);
+        $otherTeam->users()->attach($otherOwner, ['role' => 'owner']);
+
+        $task = $this->makeTask();
+
+        Livewire::test(HumanTaskForm::class, ['task' => $task])
+            ->set('escalationChain', [$otherOwner->id])
+            ->call('saveEscalationConfig')
+            ->assertHasErrors('escalationChain.0');
+
+        $task->refresh();
+        $this->assertNull($task->escalation_chain);
+    }
+
+    public function test_unauthorized_user_cannot_save_escalation_config(): void
+    {
+        Gate::define('edit-content', fn () => false);
+
+        $task = $this->makeTask();
+
+        Livewire::test(HumanTaskForm::class, ['task' => $task])
+            ->set('slaHours', 6)
+            ->call('saveEscalationConfig')
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Mcp/CrewBlackboardGetToolTest.php
+++ b/tests/Feature/Mcp/CrewBlackboardGetToolTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Crew\Enums\CrewExecutionStatus;
+use App\Domain\Crew\Models\Crew;
+use App\Domain\Crew\Models\CrewChatMessage;
+use App\Domain\Crew\Models\CrewExecution;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\Crew\CrewBlackboardGetTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class CrewBlackboardGetToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $user->id]);
+        $user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($user);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    public function test_it_returns_chat_messages_for_the_teams_execution(): void
+    {
+        $execution = $this->makeExecution($this->team);
+        CrewChatMessage::create([
+            'crew_execution_id' => $execution->id,
+            'agent_name' => 'Agent Alpha',
+            'role' => 'assistant',
+            'content' => 'I propose we split the work.',
+            'round' => 1,
+            'metadata' => [],
+        ]);
+
+        $result = $this->decode((new CrewBlackboardGetTool)->handle(new Request([
+            'execution_id' => $execution->id,
+        ])));
+
+        $this->assertSame($execution->id, $result['execution_id']);
+        $this->assertSame(1, $result['chat_message_count']);
+        $this->assertSame('I propose we split the work.', $result['chat_messages'][0]['content']);
+    }
+
+    public function test_it_does_not_return_another_teams_execution(): void
+    {
+        $otherTeam = Team::factory()->create();
+        $otherExecution = $this->makeExecution($otherTeam);
+
+        $result = $this->decode((new CrewBlackboardGetTool)->handle(new Request([
+            'execution_id' => $otherExecution->id,
+        ])));
+
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    private function makeExecution(Team $team): CrewExecution
+    {
+        $agent = Agent::factory()->for($team)->create();
+        $crew = Crew::factory()->for($team)->create([
+            'coordinator_agent_id' => $agent->id,
+            'qa_agent_id' => $agent->id,
+        ]);
+
+        return CrewExecution::create([
+            'team_id' => $team->id,
+            'crew_id' => $crew->id,
+            'goal' => 'Investigate the bug',
+            'status' => CrewExecutionStatus::Executing,
+            'config_snapshot' => [],
+            'total_cost_credits' => 0,
+            'coordinator_iterations' => 0,
+            'delegation_depth' => 0,
+        ]);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+}

--- a/tests/Feature/Mcp/ErrorModeAssignLeverToolTest.php
+++ b/tests/Feature/Mcp/ErrorModeAssignLeverToolTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\ErrorMode\Enums\ErrorModeLever;
+use App\Domain\ErrorMode\Enums\ErrorModeStatus;
+use App\Domain\ErrorMode\Models\ErrorMode;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\ErrorMode\ErrorModeAssignLeverTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class ErrorModeAssignLeverToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'EM Assign',
+            'slug' => 'em-assign-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $user->update(['current_team_id' => $this->team->id]);
+
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    private function makeMode(string $teamId): ErrorMode
+    {
+        return ErrorMode::create([
+            'team_id' => $teamId,
+            'slug' => 'mode-'.uniqid(),
+            'name' => 'Missed retrieval',
+            'lever' => ErrorModeLever::Unassigned,
+            'status' => ErrorModeStatus::Open,
+            'occurrence_count' => 3,
+            'last_seen_at' => now(),
+            'example_trace_ids' => [],
+            'metadata' => [],
+        ]);
+    }
+
+    public function test_assigns_lever_for_own_team_mode(): void
+    {
+        $mode = $this->makeMode($this->team->id);
+
+        $tool = new ErrorModeAssignLeverTool;
+        $payload = $this->decode($tool->handle(new Request([
+            'error_mode_id' => $mode->id,
+            'lever' => 'retrieval',
+        ])));
+
+        $this->assertSame($mode->id, $payload['id']);
+        $this->assertSame(ErrorModeLever::Retrieval, $mode->fresh()->lever);
+    }
+
+    public function test_cannot_assign_another_teams_mode(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other',
+            'slug' => 'other-'.uniqid(),
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+        $foreignMode = $this->makeMode($otherTeam->id);
+
+        $tool = new ErrorModeAssignLeverTool;
+        $payload = $this->decode($tool->handle(new Request([
+            'error_mode_id' => $foreignMode->id,
+            'lever' => 'retrieval',
+        ])));
+
+        $this->assertSame('Error mode not found.', $payload['error']);
+        // Foreign mode is untouched.
+        $this->assertSame(ErrorModeLever::Unassigned, $foreignMode->fresh()->lever);
+    }
+}

--- a/tests/Feature/Mcp/ErrorModeListToolTest.php
+++ b/tests/Feature/Mcp/ErrorModeListToolTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\ErrorMode\Enums\ErrorModeLever;
+use App\Domain\ErrorMode\Enums\ErrorModeStatus;
+use App\Domain\ErrorMode\Models\ErrorMode;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\ErrorMode\ErrorModeListTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class ErrorModeListToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'EM List',
+            'slug' => 'em-list-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $user->update(['current_team_id' => $this->team->id]);
+
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    private function makeMode(string $teamId, string $name, ErrorModeLever $lever): ErrorMode
+    {
+        return ErrorMode::create([
+            'team_id' => $teamId,
+            'slug' => str($name)->slug().'-'.uniqid(),
+            'name' => $name,
+            'lever' => $lever,
+            'status' => ErrorModeStatus::Open,
+            'occurrence_count' => 1,
+            'last_seen_at' => now(),
+            'example_trace_ids' => [],
+            'metadata' => [],
+        ]);
+    }
+
+    public function test_lists_only_own_team_modes(): void
+    {
+        $mine = $this->makeMode($this->team->id, 'Hallucinated citation', ErrorModeLever::Prompt);
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other',
+            'slug' => 'other-'.uniqid(),
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+        $this->makeMode($otherTeam->id, 'Cross tenant mode', ErrorModeLever::Retrieval);
+
+        $tool = new ErrorModeListTool;
+        $payload = $this->decode($tool->handle(new Request([])));
+
+        $ids = array_column($payload['error_modes'], 'id');
+        $this->assertContains($mine->id, $ids);
+        $this->assertCount(1, $payload['error_modes']);
+    }
+
+    public function test_filters_by_lever(): void
+    {
+        $this->makeMode($this->team->id, 'Bad retrieval', ErrorModeLever::Retrieval);
+        $this->makeMode($this->team->id, 'Bad prompt', ErrorModeLever::Prompt);
+
+        $tool = new ErrorModeListTool;
+        $payload = $this->decode($tool->handle(new Request(['lever' => 'retrieval'])));
+
+        $this->assertCount(1, $payload['error_modes']);
+        $this->assertSame('retrieval', $payload['error_modes'][0]['lever']);
+    }
+}

--- a/tests/Feature/Mcp/ExperimentCheckpointsToolTest.php
+++ b/tests/Feature/Mcp/ExperimentCheckpointsToolTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\Experiment\ExperimentCheckpointsTool;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class ExperimentCheckpointsToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->team = Team::factory()->create();
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    public function test_lists_only_steps_with_checkpoint_data(): void
+    {
+        $experiment = Experiment::factory()->create(['team_id' => $this->team->id]);
+
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'order' => 1,
+            'status' => 'running',
+            'worker_id' => 'worker-abc',
+            'idempotency_key' => 'idem-123',
+            'checkpoint_version' => 2,
+            'checkpoint_data' => ['cursor' => 42],
+        ]);
+
+        // No checkpoint_data — must be excluded.
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'order' => 2,
+            'status' => 'pending',
+        ]);
+
+        $payload = $this->decode((new ExperimentCheckpointsTool)->handle(
+            new Request(['experiment_id' => $experiment->id]),
+        ));
+
+        $this->assertSame(1, $payload['count']);
+        $this->assertSame('worker-abc', $payload['checkpoints'][0]['worker_id']);
+        $this->assertSame('idem-123', $payload['checkpoints'][0]['idempotency_key']);
+        $this->assertSame(2, $payload['checkpoints'][0]['version']);
+    }
+
+    public function test_rejects_cross_tenant_experiment(): void
+    {
+        $other = Experiment::factory()->create();
+
+        $response = (new ExperimentCheckpointsTool)->handle(
+            new Request(['experiment_id' => $other->id]),
+        );
+
+        $this->assertSame('NOT_FOUND', $this->decode($response)['error']['code']);
+    }
+}

--- a/tests/Feature/Mcp/KgCommunityListToolTest.php
+++ b/tests/Feature/Mcp/KgCommunityListToolTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\KnowledgeGraph\Models\KgCommunity;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\Signal\KgCommunityListTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Tests\TestCase;
+
+class KgCommunityListToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lists_only_own_team_communities(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'KG List Team',
+            'slug' => 'kg-list-team',
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other KG Team',
+            'slug' => 'kg-list-other',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+
+        KgCommunity::create([
+            'team_id' => $team->id,
+            'label' => 'Mine',
+            'summary' => 'A community of mine',
+            'entity_ids' => [],
+            'size' => 5,
+            'top_entities' => [],
+        ]);
+        KgCommunity::create([
+            'team_id' => $otherTeam->id,
+            'label' => 'Theirs',
+            'summary' => 'Should never appear',
+            'entity_ids' => [],
+            'size' => 9,
+            'top_entities' => [],
+        ]);
+
+        app()->instance('mcp.team_id', $team->id);
+
+        $response = (new KgCommunityListTool)->handle(new Request([]));
+        $payload = json_decode((string) $response->content(), true);
+
+        $this->assertFalse($response->isError());
+        $this->assertSame(1, $payload['pagination']['total']);
+        $this->assertCount(1, $payload['communities']);
+        $this->assertSame('Mine', $payload['communities'][0]['label']);
+    }
+}

--- a/tests/Feature/Mcp/KgCommunityRebuildToolTest.php
+++ b/tests/Feature/Mcp/KgCommunityRebuildToolTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\KnowledgeGraph\Models\KgCommunity;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Signal\Models\Entity;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Mcp\Tools\Signal\KgCommunityRebuildTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Laravel\Mcp\Request;
+use Tests\TestCase;
+
+class KgCommunityRebuildToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_rebuilds_communities_for_own_team_only(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'KG Rebuild Team',
+            'slug' => 'kg-rebuild-team',
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other Rebuild Team',
+            'slug' => 'kg-rebuild-other',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+
+        // Another team's community must survive the rebuild untouched.
+        $otherCommunity = KgCommunity::create([
+            'team_id' => $otherTeam->id,
+            'label' => 'Other Team Community',
+            'summary' => 'Belongs to another team',
+            'entity_ids' => [],
+            'size' => 3,
+            'top_entities' => [],
+        ]);
+
+        // Build a small connected graph for the acting team (triangle => one community).
+        $entities = Entity::factory()->count(3)->for($team)->create();
+        $this->linkEntities($team->id, $entities[0]->id, $entities[1]->id);
+        $this->linkEntities($team->id, $entities[1]->id, $entities[2]->id);
+        $this->linkEntities($team->id, $entities[0]->id, $entities[2]->id);
+
+        // Stub the LLM gateway so no real API call is made.
+        $this->app->instance(AiGatewayInterface::class, new class implements AiGatewayInterface
+        {
+            public function complete(AiRequestDTO $request): AiResponseDTO
+            {
+                return new AiResponseDTO(
+                    content: '{"label": "Stub Cluster", "summary": "A stubbed summary."}',
+                    parsedOutput: null,
+                    usage: new AiUsageDTO(0, 0, 0),
+                    provider: $request->provider,
+                    model: $request->model,
+                    latencyMs: 0,
+                );
+            }
+
+            public function stream(AiRequestDTO $request, ?callable $onChunk = null): AiResponseDTO
+            {
+                return $this->complete($request);
+            }
+
+            public function estimateCost(AiRequestDTO $request): int
+            {
+                return 0;
+            }
+        });
+
+        app()->instance('mcp.team_id', $team->id);
+
+        $response = (new KgCommunityRebuildTool)->handle(new Request([]));
+        $payload = json_decode((string) $response->content(), true);
+
+        $this->assertFalse($response->isError(), 'Got error: '.json_encode($payload));
+        $this->assertTrue($payload['success']);
+        $this->assertGreaterThanOrEqual(1, $payload['community_count']);
+
+        // All built communities belong to the acting team.
+        $this->assertSame(
+            $payload['community_count'],
+            KgCommunity::where('team_id', $team->id)->count(),
+        );
+        $this->assertSame(
+            0,
+            KgCommunity::where('team_id', $team->id)->where('team_id', '!=', $team->id)->count(),
+        );
+
+        // The other team's community was not deleted.
+        $this->assertDatabaseHas('kg_communities', [
+            'id' => $otherCommunity->id,
+            'team_id' => $otherTeam->id,
+        ]);
+    }
+
+    private function linkEntities(string $teamId, string $source, string $target): void
+    {
+        DB::table('kg_edges')->insert([
+            'id' => (string) Str::uuid(),
+            'team_id' => $teamId,
+            'source_entity_id' => $source,
+            'target_entity_id' => $target,
+            'relation_type' => 'relates_to',
+            'edge_type' => 'relates_to',
+            'fact' => 'related',
+            'attributes' => '{}',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/Mcp/OutboundProposalListToolTest.php
+++ b/tests/Feature/Mcp/OutboundProposalListToolTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Outbound\Models\OutboundProposal;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\Outbound\OutboundProposalListTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class OutboundProposalListToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $user->id]);
+        $user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($user);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    public function test_it_lists_only_the_current_teams_proposals(): void
+    {
+        $mine = OutboundProposal::factory()->create(['team_id' => $this->team->id]);
+
+        $otherTeam = Team::factory()->create();
+        $theirs = OutboundProposal::factory()->create(['team_id' => $otherTeam->id]);
+
+        $result = $this->decode((new OutboundProposalListTool)->handle(new Request([])));
+
+        $ids = array_column($result['proposals'], 'id');
+        $this->assertContains($mine->id, $ids);
+        $this->assertNotContains($theirs->id, $ids);
+        $this->assertSame(1, $result['count']);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+}

--- a/tests/Feature/Mcp/ReasoningBankListToolTest.php
+++ b/tests/Feature/Mcp/ReasoningBankListToolTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\ReasoningBankEntry;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\Experiment\ReasoningBankListTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class ReasoningBankListToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $user->id]);
+        $user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($user);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    public function test_it_lists_only_the_current_teams_entries(): void
+    {
+        $mine = $this->makeEntry($this->team, 'Improve onboarding');
+
+        $otherTeam = Team::factory()->create();
+        $theirs = $this->makeEntry($otherTeam, 'Secret strategy');
+
+        $result = $this->decode((new ReasoningBankListTool)->handle(new Request([])));
+
+        $ids = array_column($result['entries'], 'id');
+        $this->assertContains($mine->id, $ids);
+        $this->assertNotContains($theirs->id, $ids);
+        $this->assertSame(1, $result['count']);
+    }
+
+    private function makeEntry(Team $team, string $goal): ReasoningBankEntry
+    {
+        $experiment = Experiment::factory()->create(['team_id' => $team->id]);
+
+        return ReasoningBankEntry::withoutGlobalScopes()->create([
+            'team_id' => $team->id,
+            'experiment_id' => $experiment->id,
+            'goal_text' => $goal,
+            'tool_sequence' => [],
+            'outcome_summary' => 'Summary for '.$goal,
+        ]);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+}

--- a/tests/Feature/Mcp/TestSuiteGetToolTest.php
+++ b/tests/Feature/Mcp/TestSuiteGetToolTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Testing\Enums\TestStatus;
+use App\Domain\Testing\Enums\TestStrategy;
+use App\Domain\Testing\Models\TestRun;
+use App\Domain\Testing\Models\TestSuite;
+use App\Mcp\Tools\Testing\TestSuiteGetTool;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class TestSuiteGetToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->team = Team::factory()->create();
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    public function test_returns_suite_with_its_runs(): void
+    {
+        $suite = TestSuite::withoutGlobalScopes()->create([
+            'team_id' => $this->team->id,
+            'project_id' => \App\Domain\Project\Models\Project::factory()->create(['team_id' => $this->team->id])->id,
+            'name' => 'Owned',
+            'test_strategy' => TestStrategy::Regression,
+        ]);
+
+        $experiment = Experiment::factory()->create(['team_id' => $this->team->id]);
+
+        TestRun::create([
+            'test_suite_id' => $suite->id,
+            'experiment_id' => $experiment->id,
+            'status' => TestStatus::Passed,
+            'score' => 0.91,
+            'started_at' => now(),
+        ]);
+
+        $payload = $this->decode((new TestSuiteGetTool)->handle(
+            new Request(['test_suite_id' => $suite->id]),
+        ));
+
+        $this->assertSame('Owned', $payload['name']);
+        $this->assertSame(1, $payload['run_count']);
+        $this->assertSame('passed', $payload['runs'][0]['status']);
+        $this->assertSame(0.91, $payload['runs'][0]['score']);
+    }
+
+    public function test_rejects_cross_tenant_suite(): void
+    {
+        $otherTeam = Team::factory()->create();
+        $foreign = TestSuite::withoutGlobalScopes()->create([
+            'team_id' => $otherTeam->id,
+            'project_id' => \App\Domain\Project\Models\Project::factory()->create(['team_id' => $otherTeam->id])->id,
+            'name' => 'Foreign',
+            'test_strategy' => TestStrategy::Full,
+        ]);
+
+        $response = (new TestSuiteGetTool)->handle(
+            new Request(['test_suite_id' => $foreign->id]),
+        );
+
+        $this->assertSame('NOT_FOUND', $this->decode($response)['error']['code']);
+    }
+}

--- a/tests/Feature/Mcp/TestSuiteListToolTest.php
+++ b/tests/Feature/Mcp/TestSuiteListToolTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Shared\Models\Team;
+use App\Domain\Testing\Enums\TestStrategy;
+use App\Domain\Testing\Models\TestSuite;
+use App\Mcp\Tools\Testing\TestSuiteListTool;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class TestSuiteListToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->team = Team::factory()->create();
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    public function test_lists_only_current_team_suites(): void
+    {
+        TestSuite::withoutGlobalScopes()->create([
+            'team_id' => $this->team->id,
+            'project_id' => \App\Domain\Project\Models\Project::factory()->create(['team_id' => $this->team->id])->id,
+            'name' => 'Mine',
+            'test_strategy' => TestStrategy::Regression,
+        ]);
+
+        $otherTeam = Team::factory()->create();
+        TestSuite::withoutGlobalScopes()->create([
+            'team_id' => $otherTeam->id,
+            'project_id' => \App\Domain\Project\Models\Project::factory()->create(['team_id' => $otherTeam->id])->id,
+            'name' => 'Theirs',
+            'test_strategy' => TestStrategy::Full,
+        ]);
+
+        $payload = $this->decode((new TestSuiteListTool)->handle(new Request([])));
+
+        $this->assertSame(1, $payload['count']);
+        $this->assertSame('Mine', $payload['test_suites'][0]['name']);
+        $this->assertSame('regression', $payload['test_suites'][0]['strategy']);
+        $this->assertSame(0, $payload['test_suites'][0]['run_count']);
+    }
+}

--- a/tests/Feature/Mcp/Tools/Workflow/WorkflowCompensationRunsToolTest.php
+++ b/tests/Feature/Mcp/Tools/Workflow/WorkflowCompensationRunsToolTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp\Tools\Workflow;
+
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\PlaybookStep;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Workflow\Models\Workflow;
+use App\Domain\Workflow\Models\WorkflowNode;
+use App\Mcp\Tools\Workflow\WorkflowCompensationRunsTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class WorkflowCompensationRunsToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Comp Runs Team',
+            'slug' => 'comp-runs-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    /**
+     * Create a failed workflow experiment with one completed step whose node has
+     * a compensation node — i.e. a compensation-eligible run.
+     */
+    private function compensationEligibleRun(Team $team): Experiment
+    {
+        $workflow = Workflow::factory()->for($team)->create();
+        $compensationNode = WorkflowNode::factory()->for($workflow)->end()->create();
+        $node = WorkflowNode::factory()->for($workflow)->create([
+            'compensation_node_id' => $compensationNode->id,
+        ]);
+
+        $experiment = Experiment::factory()
+            ->for($team)
+            ->withStatus(ExperimentStatus::ExecutionFailed)
+            ->create(['workflow_id' => $workflow->id]);
+
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'workflow_node_id' => $node->id,
+            'order' => 0,
+            'status' => 'completed',
+        ]);
+
+        return $experiment;
+    }
+
+    public function test_lists_compensation_eligible_failed_runs(): void
+    {
+        $experiment = $this->compensationEligibleRun($this->team);
+
+        $response = (new WorkflowCompensationRunsTool)->handle(new Request([]));
+
+        $this->assertFalse($response->isError());
+        $payload = $this->decode($response);
+
+        $this->assertSame(1, $payload['count']);
+        $this->assertSame($experiment->id, $payload['runs'][0]['experiment_id']);
+        $this->assertSame(1, $payload['runs'][0]['compensated_count']);
+        $this->assertSame('execution_failed', $payload['runs'][0]['status']);
+    }
+
+    public function test_excludes_failed_run_with_no_compensation_node(): void
+    {
+        $workflow = Workflow::factory()->for($this->team)->create();
+        $node = WorkflowNode::factory()->for($workflow)->create(['compensation_node_id' => null]);
+
+        $experiment = Experiment::factory()
+            ->for($this->team)
+            ->withStatus(ExperimentStatus::ExecutionFailed)
+            ->create(['workflow_id' => $workflow->id]);
+
+        PlaybookStep::create([
+            'experiment_id' => $experiment->id,
+            'workflow_node_id' => $node->id,
+            'order' => 0,
+            'status' => 'completed',
+        ]);
+
+        $payload = $this->decode((new WorkflowCompensationRunsTool)->handle(new Request([])));
+
+        $this->assertSame(0, $payload['count']);
+    }
+
+    public function test_does_not_leak_other_team_runs(): void
+    {
+        // Eligible run belonging to a different team.
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other Comp Team',
+            'slug' => 'other-comp-team',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+        $this->compensationEligibleRun($otherTeam);
+
+        // Current team has its own eligible run.
+        $ours = $this->compensationEligibleRun($this->team);
+
+        $payload = $this->decode((new WorkflowCompensationRunsTool)->handle(new Request([])));
+
+        $this->assertSame(1, $payload['count']);
+        $this->assertSame($ours->id, $payload['runs'][0]['experiment_id']);
+    }
+
+    public function test_missing_team_returns_permission_denied(): void
+    {
+        app()->forgetInstance('mcp.team_id');
+        Auth::logout();
+
+        $response = (new WorkflowCompensationRunsTool)->handle(new Request([]));
+
+        $this->assertTrue($response->isError());
+        $payload = json_decode((string) $response->content(), true);
+        $this->assertSame('PERMISSION_DENIED', $payload['error']['code']);
+    }
+}

--- a/tests/Feature/Mcp/Tools/Workflow/WorkflowSimulateToolTest.php
+++ b/tests/Feature/Mcp/Tools/Workflow/WorkflowSimulateToolTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp\Tools\Workflow;
+
+use App\Domain\Shared\Models\Team;
+use App\Domain\Workflow\Models\Workflow;
+use App\Domain\Workflow\Models\WorkflowEdge;
+use App\Domain\Workflow\Models\WorkflowNode;
+use App\Mcp\Tools\Workflow\WorkflowSimulateTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class WorkflowSimulateToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Simulate Team',
+            'slug' => 'simulate-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    /** Build a linear Start -> Agent -> End graph. */
+    private function linearWorkflow(Team $team): Workflow
+    {
+        $workflow = Workflow::factory()->for($team)->create();
+        $start = WorkflowNode::factory()->for($workflow)->start()->create();
+        $agent = WorkflowNode::factory()->for($workflow)->create(['label' => 'Do Work']);
+        $end = WorkflowNode::factory()->for($workflow)->end()->create();
+
+        WorkflowEdge::factory()->for($workflow)->create([
+            'source_node_id' => $start->id,
+            'target_node_id' => $agent->id,
+        ]);
+        WorkflowEdge::factory()->for($workflow)->create([
+            'source_node_id' => $agent->id,
+            'target_node_id' => $end->id,
+        ]);
+
+        return $workflow;
+    }
+
+    public function test_simulates_linear_workflow_to_completion(): void
+    {
+        $workflow = $this->linearWorkflow($this->team);
+
+        $response = (new WorkflowSimulateTool)->handle(new Request(['workflow_id' => $workflow->id]));
+
+        $this->assertFalse($response->isError());
+        $payload = $this->decode($response);
+
+        $this->assertSame($workflow->id, $payload['workflow_id']);
+        $this->assertSame('completed', $payload['termination_status']);
+        $this->assertCount(3, $payload['executed_path']);
+        $this->assertSame('end', end($payload['executed_path'])['type']);
+    }
+
+    public function test_cross_tenant_workflow_returns_not_found(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other Simulate Team',
+            'slug' => 'other-simulate-team',
+            'owner_id' => $otherUser->id,
+            'settings' => [],
+        ]);
+        $workflow = $this->linearWorkflow($otherTeam);
+
+        $response = (new WorkflowSimulateTool)->handle(new Request(['workflow_id' => $workflow->id]));
+
+        $this->assertTrue($response->isError());
+        $payload = json_decode((string) $response->content(), true);
+        $this->assertSame('NOT_FOUND', $payload['error']['code']);
+    }
+
+    public function test_missing_team_returns_permission_denied(): void
+    {
+        app()->forgetInstance('mcp.team_id');
+        Auth::logout();
+
+        $workflow = $this->linearWorkflow($this->team);
+
+        $response = (new WorkflowSimulateTool)->handle(new Request(['workflow_id' => $workflow->id]));
+
+        $this->assertTrue($response->isError());
+        $payload = json_decode((string) $response->content(), true);
+        $this->assertSame('PERMISSION_DENIED', $payload['error']['code']);
+    }
+}


### PR DESCRIPTION
## UI-Gap Backlog — Wave-3 partials + backend completions

Second batch (off `develop`, after PR #100 merged). **Draft — review before merge; not for auto-merge.**

### Wave-3 surgical partials (existing pages extended)
- **AgentDetailPage** — editable heartbeat schedule (cron/interval+prompt) + Dry Run button (`DryRunAgentAction`, no side effects)
- **EditProjectForm** — dependency repeater (view/add/remove upstream deps post-creation)
- **HumanTaskForm** — escalation settings (sla_hours + escalation_chain, members constrained to task team)
- Done-condition gate toggle — already existed (verified, no change)

### Backend completions (finish shipped features)
- **Broadcast** — `SendBroadcastJob` now chunks recipients into `Bus::batch` of `SendBroadcastChunkJob` (outbound queue), finalizing once. Fixes the 600s-timeout / mid-flight partial-send risk.
- **Outbound** — Matrix / SignalProtocol / SupabaseRealtime connectors now read creds via `OutboundCredentialResolver` (config is real), re-registered as core drivers with config pages. **All 8 outbound chat channels are now live.**

### Security
Two HIGH cross-tenant findings from the automated review — **both fixed**:
- EditProjectForm dependency dropdown/lookup now explicitly `->where('team_id', …)` (was relying on TeamScope).

### Quality
Per-action authz, team-scoped (no `withoutGlobalScopes()->when()`), pint clean, ~10 new/updated feature tests green locally.

### ⚠️ Review carefully
The 3 newly-completed outbound channels are **real send paths** — Supabase `testConnection()` sends a real broadcast (BYO project, metered on the team's Supabase plan); Matrix/Signal are self-hosted/free. Confirm before prod.

### Still deferred (not in this PR)
- ~10 MCP read-tool gaps for the new features.
- Cloud: sidebar entries for the new pages (prod discoverability), Team-export **download controller** (GDPR).
- Wave 4: Partner portal, Marketplace earnings (needs backend model), Fleet (needs product spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
