### PR TITLE
fix(ai): team-aware BYOK provider gate

### DIFF
--- a/app/Infrastructure/AI/Gateways/FallbackAiGateway.php
+++ b/app/Infrastructure/AI/Gateways/FallbackAiGateway.php
@@ -2,6 +2,7 @@
 
 namespace App\Infrastructure\AI\Gateways;
 
+use App\Domain\Shared\Models\TeamProviderCredential;
 use App\Infrastructure\AI\Contracts\AiGatewayInterface;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
 use App\Infrastructure\AI\DTOs\AiResponseDTO;
@@ -141,7 +142,7 @@ class FallbackAiGateway implements AiGatewayInterface
                 }
             }
 
-            if (! $this->providerHasApiKey($providerName)) {
+            if (! $this->providerHasApiKey($providerName, $request->teamId)) {
                 Log::debug("AI Gateway: skipping {$providerName} (no API key configured)");
 
                 continue;
@@ -346,7 +347,7 @@ class FallbackAiGateway implements AiGatewayInterface
                 }
             }
 
-            if (! $this->providerHasApiKey($providerName)) {
+            if (! $this->providerHasApiKey($providerName, $request->teamId)) {
                 continue;
             }
 
@@ -504,9 +505,21 @@ class FallbackAiGateway implements AiGatewayInterface
      * provider-specific config (config/ai.php) and the generic services config —
      * either is enough to satisfy Prism. An empty string is treated as missing.
      */
-    private function providerHasApiKey(string $providerName): bool
+    private function providerHasApiKey(string $providerName, ?string $teamId = null): bool
     {
         if ($this->isBridgeProvider($providerName) || $this->isLocalProvider($providerName)) {
+            return true;
+        }
+
+        // A team's active BYOK credential satisfies the gate: applyTeamCredentials()
+        // injects it into the prism config before the actual provider call. Without
+        // this, a BYOK-only provider (e.g. openrouter) that the platform has no key
+        // for is skipped here, and the chain exhausts to "No available providers"
+        // even though the team can reach the provider.
+        if ($teamId !== null && TeamProviderCredential::where('team_id', $teamId)
+            ->where('provider', $providerName)
+            ->where('is_active', true)
+            ->exists()) {
             return true;
         }
 

--- a/tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php
+++ b/tests/Unit/Infrastructure/AI/ProviderHasApiKeyTest.php
@@ -2,14 +2,19 @@
 
 namespace Tests\Unit\Infrastructure\AI;
 
+use App\Domain\Shared\Models\Team;
+use App\Domain\Shared\Models\TeamProviderCredential;
 use App\Infrastructure\AI\Gateways\FallbackAiGateway;
 use App\Infrastructure\AI\Gateways\PrismAiGateway;
 use App\Infrastructure\AI\Services\CircuitBreaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use ReflectionClass;
 use Tests\TestCase;
 
 class ProviderHasApiKeyTest extends TestCase
 {
+    use RefreshDatabase;
+
     private FallbackAiGateway $gateway;
 
     protected function setUp(): void
@@ -42,13 +47,13 @@ class ProviderHasApiKeyTest extends TestCase
         ]);
     }
 
-    private function invoke(string $provider): bool
+    private function invoke(string $provider, ?string $teamId = null): bool
     {
         $reflection = new ReflectionClass($this->gateway);
         $method = $reflection->getMethod('providerHasApiKey');
         $method->setAccessible(true);
 
-        return (bool) $method->invoke($this->gateway, $provider);
+        return (bool) $method->invoke($this->gateway, $provider, $teamId);
     }
 
     public function test_returns_true_when_provider_has_key_in_ai_providers_config(): void
@@ -111,6 +116,36 @@ class ProviderHasApiKeyTest extends TestCase
         // Local agents (claude-code, codex) and bridge providers don't need API keys.
         $this->assertTrue($this->invoke('claude-code'));
         $this->assertTrue($this->invoke('codex'));
+    }
+
+    public function test_returns_true_when_team_has_active_byok_credential_without_platform_key(): void
+    {
+        // Regression: a BYOK-only provider (openrouter) the platform has no key
+        // for must still pass the gate when the team has an active credential —
+        // otherwise the fallback chain exhausts to "No available providers".
+        $team = Team::factory()->create();
+        TeamProviderCredential::create([
+            'team_id' => $team->id,
+            'provider' => 'openrouter',
+            'credentials' => ['api_key' => 'sk-or-team-key'],
+            'is_active' => true,
+        ]);
+
+        $this->assertFalse($this->invoke('openrouter'), 'team-blind check must still fail without a team id');
+        $this->assertTrue($this->invoke('openrouter', $team->id));
+    }
+
+    public function test_returns_false_when_team_credential_is_inactive(): void
+    {
+        $team = Team::factory()->create();
+        TeamProviderCredential::create([
+            'team_id' => $team->id,
+            'provider' => 'openrouter',
+            'credentials' => ['api_key' => 'sk-or-team-key'],
+            'is_active' => false,
+        ]);
+
+        $this->assertFalse($this->invoke('openrouter', $team->id));
     }
 
     /**


### PR DESCRIPTION
## Problem

`FallbackAiGateway::providerHasApiKey()` only checked platform-level config keys (`ai.providers.*`, `services.*`, `sub_program_api_keys.*`). A BYOK-only provider the platform has no key for (e.g. `openrouter`) was skipped at this gate **before** `applyTeamCredentials()` could inject the team's key. The fallback chain then exhausted to `No available providers in fallback chain`, blocking the **scoring** stage for any team whose default provider isn't also platform-keyed.

Found in prod: team *PriceX Ltd.* (`default_llm_provider = openrouter`) — every debug-track repair run failed at scoring with this exact error, despite a valid active openrouter BYOK credential.

## Fix

The gate now also returns true when the request's team has an **active** `TeamProviderCredential` for the provider (both `complete` + `stream` paths). `applyTeamCredentials()` then injects the team key as before. If the credential is active but missing `api_key`, the meaningful plan/error surfaces instead of the misleading "No available providers".

## Tests

Extended `ProviderHasApiKeyTest` with regression cases (BYOK without platform key → pass; inactive credential → fail). Full AI gateway suite green; pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)