### PR TITLE
feat(budget): upstream credit runway alerts + flag-gated BYOK access gate

### DIFF
--- a/app/Console/Commands/CheckUpstreamCredits.php
+++ b/app/Console/Commands/CheckUpstreamCredits.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Budget\Actions\CheckUpstreamCreditRunwayAction;
+use Illuminate\Console\Command;
+
+class CheckUpstreamCredits extends Command
+{
+    protected $signature = 'credits:check-upstream {--dry-run : Compute and print runway without sending alerts}';
+
+    protected $description = 'Check upstream (platform-funded) credit runway per sub-program/provider and email the platform owner when low.';
+
+    public function handle(CheckUpstreamCreditRunwayAction $action): int
+    {
+        $summaries = $action->execute(dryRun: (bool) $this->option('dry-run'));
+
+        if ($summaries === []) {
+            $this->info('No upstream budgets configured (or alerts disabled). Nothing to check.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['Sub-program', 'Provider', 'Remaining', 'Avg/day (7d)', 'Days left', 'Bucket', 'Alerted'],
+            array_map(fn (array $s): array => [
+                $s['sub_program'],
+                $s['provider'],
+                number_format($s['remaining']),
+                number_format($s['daily_avg_7d']),
+                $s['days_until_depletion'] ?? '∞',
+                $s['alert_bucket'] ?? '—',
+                $s['alerted'] ? 'yes' : 'no',
+            ], $summaries),
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/Budget/Actions/CheckUpstreamCreditRunwayAction.php
+++ b/app/Domain/Budget/Actions/CheckUpstreamCreditRunwayAction.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Domain\Budget\Actions;
+
+use App\Domain\Budget\Notifications\UpstreamCreditLowNotification;
+use App\Domain\Budget\Services\UpstreamSpendForecaster;
+use App\Models\GlobalSetting;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * Evaluates upstream credit runway per configured (sub_program, provider) budget
+ * and emails the platform owner when the forecasted days-to-depletion crosses a
+ * threshold. Runtime config (budgets/recipient/thresholds/cooldown) is read from
+ * GlobalSetting first, falling back to config/credit_alerts.php.
+ */
+class CheckUpstreamCreditRunwayAction
+{
+    public function __construct(private readonly UpstreamSpendForecaster $forecaster) {}
+
+    /**
+     * @return array<int, array<string, mixed>> One forecast summary per evaluated budget.
+     */
+    public function execute(bool $dryRun = false): array
+    {
+        if (! (bool) config('credit_alerts.enabled', true)) {
+            return [];
+        }
+
+        $budgets = $this->budgets();
+        $thresholds = $this->thresholds();
+        $recipient = $this->recipient();
+        $cooldownHours = (int) (GlobalSetting::get('upstream_credit_alert_cooldown_hours')
+            ?? config('credit_alerts.cooldown_hours', 24));
+
+        $summaries = [];
+
+        foreach ($budgets as $subProgram => $providers) {
+            if (! is_array($providers)) {
+                continue;
+            }
+
+            foreach ($providers as $provider => $entry) {
+                if (! is_array($entry)) {
+                    continue;
+                }
+                $credits = (int) ($entry['credits'] ?? 0);
+                if ($credits <= 0) {
+                    continue;
+                }
+                $since = (string) ($entry['since'] ?? now()->subDays(30)->toDateString());
+
+                $forecast = $this->forecaster->forecast((string) $subProgram, (string) $provider, $credits, $since);
+                $bucket = $this->crossedBucket($forecast['days_until_depletion'], $thresholds);
+
+                $alerted = false;
+                if ($bucket !== null && $recipient && ! $dryRun
+                    && $this->reserveAlertSlot((string) $subProgram, (string) $provider, $bucket, $cooldownHours)) {
+                    Notification::route('mail', $recipient)->notify(new UpstreamCreditLowNotification(
+                        subProgram: (string) $subProgram,
+                        provider: (string) $provider,
+                        remaining: $forecast['remaining'],
+                        dailyAvg7d: $forecast['daily_avg_7d'],
+                        daysUntilDepletion: $forecast['days_until_depletion'],
+                        budgetCredits: $credits,
+                    ));
+                    $alerted = true;
+                }
+
+                unset($forecast['daily_series']);
+                $summaries[] = $forecast + ['alert_bucket' => $bucket, 'alerted' => $alerted];
+            }
+        }
+
+        return $summaries;
+    }
+
+    /**
+     * The tightest threshold the runway is at or below (most critical), or null
+     * when the runway is safe or cannot be computed.
+     *
+     * @param  array<int, int>  $thresholds
+     */
+    private function crossedBucket(?int $days, array $thresholds): ?int
+    {
+        if ($days === null) {
+            return null;
+        }
+
+        sort($thresholds); // ascending: smallest (most critical) first
+        foreach ($thresholds as $threshold) {
+            if ($days <= $threshold) {
+                return $threshold;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Atomically claim the alert slot for this (sub_program, provider, bucket).
+     * Returns true the first time within the cooldown window, false thereafter,
+     * so a smaller bucket (different key) can still alert immediately.
+     */
+    private function reserveAlertSlot(string $subProgram, string $provider, int $bucket, int $cooldownHours): bool
+    {
+        $key = "upstream_credit_alert:{$subProgram}:{$provider}:{$bucket}";
+
+        return Cache::add($key, true, now()->addHours(max(1, $cooldownHours)));
+    }
+
+    /**
+     * Budgets may come from GlobalSetting (untrusted runtime JSON), so the inner
+     * shape is validated per-entry by the caller rather than asserted here.
+     *
+     * @return array<string, mixed>
+     */
+    private function budgets(): array
+    {
+        $override = GlobalSetting::get('upstream_credit_budgets');
+
+        return is_array($override) ? $override : (array) config('credit_alerts.budgets', []);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function thresholds(): array
+    {
+        $override = GlobalSetting::get('upstream_credit_alert_threshold_days');
+        $values = is_array($override) ? $override : (array) config('credit_alerts.threshold_days', [14, 7, 3]);
+
+        return array_values(array_map('intval', $values));
+    }
+
+    private function recipient(): ?string
+    {
+        $value = GlobalSetting::get('upstream_credit_alert_email') ?? config('credit_alerts.recipient');
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/app/Domain/Budget/Notifications/UpstreamCreditLowNotification.php
+++ b/app/Domain/Budget/Notifications/UpstreamCreditLowNotification.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Domain\Budget\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class UpstreamCreditLowNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly string $subProgram,
+        public readonly string $provider,
+        public readonly int $remaining,
+        public readonly int $dailyAvg7d,
+        public readonly ?int $daysUntilDepletion,
+        public readonly int $budgetCredits,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $creditValueUsd = (float) config('llm_pricing.credit_value_usd', 0.001);
+        $remainingUsd = number_format($this->remaining * $creditValueUsd, 2);
+        $dailyUsd = number_format($this->dailyAvg7d * $creditValueUsd, 2);
+        $days = $this->daysUntilDepletion ?? 0;
+
+        return (new MailMessage)
+            ->subject(sprintf(
+                '[FleetQ] Upstream credits low: %s / %s (~%d day%s left)',
+                $this->subProgram,
+                $this->provider,
+                $days,
+                $days === 1 ? '' : 's',
+            ))
+            ->greeting('Upstream credit runway warning')
+            ->line(sprintf(
+                'The platform-funded LLM credits for sub-program "%s" on provider "%s" are running low.',
+                $this->subProgram,
+                $this->provider,
+            ))
+            ->line(sprintf('Estimated runway: ~%d day%s until depletion.', $days, $days === 1 ? '' : 's'))
+            ->line(sprintf('Remaining: %s credits (≈ $%s).', number_format($this->remaining), $remainingUsd))
+            ->line(sprintf('Recent burn (7d avg): %s credits/day (≈ $%s/day).', number_format($this->dailyAvg7d), $dailyUsd))
+            ->line(sprintf('Configured allotment: %s credits.', number_format($this->budgetCredits)))
+            ->line('Action: top up the provider account, then update the budget entry (credits + since) in config/GlobalSetting so the runway resets.');
+    }
+}

--- a/app/Domain/Budget/Services/UpstreamSpendForecaster.php
+++ b/app/Domain/Budget/Services/UpstreamSpendForecaster.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Domain\Budget\Services;
+
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\Models\LlmRequestLog;
+use Illuminate\Support\Carbon;
+
+/**
+ * Forecasts upstream (platform-funded) credit runway for a single
+ * (sub_program, provider) pair, from LlmRequestLog spend.
+ *
+ * "Platform-funded" = requests served by a platform/sub-program API key
+ * (byok_source = 'platform'), as opposed to a team's own BYOK key.
+ */
+class UpstreamSpendForecaster
+{
+    /**
+     * @return array{
+     *   sub_program: string,
+     *   provider: string,
+     *   budget_credits: int,
+     *   since: string,
+     *   spent_since: int,
+     *   remaining: int,
+     *   daily_avg_7d: int,
+     *   daily_avg_30d: int,
+     *   days_until_depletion: int|null,
+     *   daily_series: array<int, array{date: string, spend: int}>
+     * }
+     */
+    public function forecast(string $subProgram, string $provider, int $budgetCredits, string $since): array
+    {
+        $sinceDate = Carbon::parse($since)->startOfDay();
+        $window30 = now()->subDays(30)->startOfDay();
+
+        $teamIds = Team::withoutGlobalScopes()
+            ->where('sub_program_slug', $subProgram)
+            ->pluck('id');
+
+        $base = fn () => LlmRequestLog::withoutGlobalScopes()
+            ->whereIn('team_id', $teamIds)
+            ->where('provider', $provider)
+            ->where('byok_source', 'platform');
+
+        if ($teamIds->isEmpty()) {
+            return $this->emptyResult($subProgram, $provider, $budgetCredits, $sinceDate->toDateString());
+        }
+
+        $dailySpend = $base()
+            ->where('completed_at', '>=', $window30)
+            ->selectRaw('DATE(completed_at) as day, SUM(cost_credits) as spend')
+            ->groupByRaw('DATE(completed_at)')
+            ->pluck('spend', 'day');
+
+        // Fill the 30-day window with zeros for missing days.
+        $series = [];
+        for ($i = 29; $i >= 0; $i--) {
+            $date = now()->subDays($i)->format('Y-m-d');
+            $series[] = ['date' => $date, 'spend' => (int) ($dailySpend[$date] ?? 0)];
+        }
+
+        $avg7 = collect($series)->slice(-7)->avg('spend') ?? 0.0;
+        $avg30 = collect($series)->avg('spend') ?? 0.0;
+
+        $spentSince = (int) $base()->where('completed_at', '>=', $sinceDate)->sum('cost_credits');
+        $remaining = max(0, $budgetCredits - $spentSince);
+
+        $daysUntilDepletion = null;
+        if ($avg7 > 0) {
+            $daysUntilDepletion = $remaining > 0 ? (int) ceil($remaining / $avg7) : 0;
+        }
+
+        return [
+            'sub_program' => $subProgram,
+            'provider' => $provider,
+            'budget_credits' => $budgetCredits,
+            'since' => $sinceDate->toDateString(),
+            'spent_since' => $spentSince,
+            'remaining' => $remaining,
+            'daily_avg_7d' => (int) round($avg7),
+            'daily_avg_30d' => (int) round($avg30),
+            'days_until_depletion' => $daysUntilDepletion,
+            'daily_series' => $series,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function emptyResult(string $subProgram, string $provider, int $budgetCredits, string $since): array
+    {
+        $series = [];
+        for ($i = 29; $i >= 0; $i--) {
+            $series[] = ['date' => now()->subDays($i)->format('Y-m-d'), 'spend' => 0];
+        }
+
+        return [
+            'sub_program' => $subProgram,
+            'provider' => $provider,
+            'budget_credits' => $budgetCredits,
+            'since' => $since,
+            'spent_since' => 0,
+            'remaining' => max(0, $budgetCredits),
+            'daily_avg_7d' => 0,
+            'daily_avg_30d' => 0,
+            'days_until_depletion' => null,
+            'daily_series' => $series,
+        ];
+    }
+}

--- a/app/Domain/Experiment/Actions/CreateExperimentAction.php
+++ b/app/Domain/Experiment/Actions/CreateExperimentAction.php
@@ -4,6 +4,8 @@ namespace App\Domain\Experiment\Actions;
 
 use App\Domain\Experiment\Enums\ExperimentStatus;
 use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Shared\Models\Team;
+use App\Domain\Shared\Services\TeamAiAccessChecker;
 use App\Domain\Workflow\Actions\MaterializeWorkflowAction;
 use App\Domain\Workflow\Models\Workflow;
 
@@ -27,6 +29,13 @@ class CreateExperimentAction
         ?string $workflowId = null,
         ?string $agentId = null,
     ): Experiment {
+        if ($teamId && (bool) config('experiments.require_team_ai_access', false)) {
+            $team = Team::withoutGlobalScopes()->find($teamId);
+            if ($team) {
+                app(TeamAiAccessChecker::class)->assertCanUseAi($team);
+            }
+        }
+
         $experiment = Experiment::create([
             'user_id' => $userId,
             'team_id' => $teamId,

--- a/app/Domain/Shared/Exceptions/AiAccessUnavailableException.php
+++ b/app/Domain/Shared/Exceptions/AiAccessUnavailableException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Domain\Shared\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when a team has no usable path to run AI: no BYOK key, no platform
+ * fallback entitlement, and no local/bridge agent — and it is not an internal
+ * sub-program. Surfaced early (e.g. on experiment creation) so the team gets an
+ * actionable message instead of a mid-run failure.
+ */
+class AiAccessUnavailableException extends RuntimeException
+{
+    public static function forTeam(): self
+    {
+        return new self(
+            'Your plan does not include platform AI keys. '
+            .'Please add your own API key in Team Settings, or upgrade your plan.',
+        );
+    }
+}

--- a/app/Domain/Shared/Services/TeamAiAccessChecker.php
+++ b/app/Domain/Shared/Services/TeamAiAccessChecker.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Domain\Shared\Services;
+
+use App\Domain\Bridge\Models\BridgeConnection;
+use App\Domain\Shared\Exceptions\AiAccessUnavailableException;
+use App\Domain\Shared\Models\Team;
+
+/**
+ * Determines whether a team has any usable path to run AI work.
+ *
+ * Policy: teams are BYOK by default; internal sub-programs and enterprise-tier
+ * teams (platform_llm_fallback) are the exceptions. Conservative by design —
+ * returns true whenever ANY path exists, so it never blocks a team that could
+ * actually run (BYOK, sub-program, local agents, or a connected bridge).
+ */
+class TeamAiAccessChecker
+{
+    public function canUseAi(Team $team): bool
+    {
+        // Internal sub-program (e.g. finance) — funded via sub_program_api_keys.
+        if (($team->sub_program_slug ?? 'cloud') !== 'cloud') {
+            return true;
+        }
+
+        // Plan grants platform AI keys (community edition always returns true here).
+        if ($team->hasFeature('platform_llm_fallback')) {
+            return true;
+        }
+
+        // Team brought its own provider key.
+        if ($team->providerCredentials()->where('is_active', true)->exists()) {
+            return true;
+        }
+
+        // Local CLI agents are enabled at the deployment level.
+        if ((bool) config('local_agents.enabled')) {
+            return true;
+        }
+
+        // A bridge daemon is connected, exposing the team's local agents/LLMs.
+        if (BridgeConnection::withoutGlobalScopes()->where('team_id', $team->id)->active()->exists()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function assertCanUseAi(Team $team): void
+    {
+        if (! $this->canUseAi($team)) {
+            throw AiAccessUnavailableException::forTeam();
+        }
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -162,6 +162,7 @@ use App\Mcp\Tools\Budget\BudgetForecastTool;
 use App\Mcp\Tools\Budget\BudgetLedgerTool;
 use App\Mcp\Tools\Budget\BudgetSummaryTool;
 use App\Mcp\Tools\Budget\BudgetTransferTool;
+use App\Mcp\Tools\Budget\UpstreamCreditRunwayTool;
 use App\Mcp\Tools\Cache\SemanticCachePurgeTool;
 use App\Mcp\Tools\Cache\SemanticCacheStatsTool;
 use App\Mcp\Tools\Chatbot\ChatbotAnalyticsSummaryTool;
@@ -1149,7 +1150,7 @@ class AgentFleetServer extends Server
         KgSuggestMergesTool::class,
         KgMergeEntitiesTool::class,
 
-        // Budget (7)
+        // Budget (8)
         BudgetSummaryTool::class,
         BudgetCheckTool::class,
         BudgetForecastTool::class,
@@ -1157,6 +1158,7 @@ class AgentFleetServer extends Server
         BudgetAddCreditsTool::class,
         BudgetTransferTool::class,
         BudgetCostBreakdownTool::class,
+        UpstreamCreditRunwayTool::class,
 
         // Evaluation (10)
         EvaluationDatasetManageTool::class,

--- a/app/Mcp/Tools/Budget/UpstreamCreditRunwayTool.php
+++ b/app/Mcp/Tools/Budget/UpstreamCreditRunwayTool.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Mcp\Tools\Budget;
+
+use App\Domain\Budget\Actions\CheckUpstreamCreditRunwayAction;
+use App\Domain\Shared\Services\DeploymentMode;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+class UpstreamCreditRunwayTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'budget_upstream_runway';
+
+    protected string $description = 'Platform owner view: forecasted upstream (platform-funded) credit runway per configured sub-program/provider — remaining credits, 7d daily burn, and estimated days until depletion. Read-only; does not send alerts.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    public function handle(Request $request): Response
+    {
+        if (app(DeploymentMode::class)->isCloud() && ! auth()->user()?->is_super_admin) {
+            return $this->permissionDeniedError('Access denied: super admin privileges required.');
+        }
+
+        $summaries = app(CheckUpstreamCreditRunwayAction::class)->execute(dryRun: true);
+
+        return Response::text(json_encode([
+            'budgets_evaluated' => count($summaries),
+            'runway' => $summaries,
+        ]));
+    }
+}

--- a/config/credit_alerts.php
+++ b/config/credit_alerts.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Upstream credit runway alerts
+    |--------------------------------------------------------------------------
+    |
+    | Monitors platform-funded (sub-program) LLM spend per (sub_program, provider)
+    | and emails the platform owner when the forecasted days-to-depletion crosses
+    | a threshold. Budgets/recipient/thresholds/cooldown can be overridden at
+    | runtime via the matching GlobalSetting keys (see CheckUpstreamCreditRunwayAction).
+    |
+    */
+
+    'enabled' => (bool) env('UPSTREAM_CREDIT_ALERTS_ENABLED', true),
+
+    // Where the alert email goes. Falls back to the app's from-address.
+    'recipient' => env('UPSTREAM_CREDIT_ALERT_EMAIL') ?: env('MAIL_FROM_ADDRESS'),
+
+    // Days-to-depletion ladder. An alert fires for the tightest bucket the runway
+    // is at or below; a smaller bucket re-alerts even within cooldown of a larger one.
+    'threshold_days' => [14, 7, 3],
+
+    // Minimum hours between identical (sub_program, provider, bucket) alerts.
+    'cooldown_hours' => (int) env('UPSTREAM_CREDIT_ALERT_COOLDOWN_HOURS', 24),
+
+    // Upstream allotments. 'credits' = amount topped up at the provider (1 credit =
+    // $0.001); 'since' = the date the allotment started (spend counted from then).
+    // After reloading the provider, bump 'credits' and 'since'. Prefer the
+    // GlobalSetting 'upstream_credit_budgets' for runtime edits without a deploy.
+    //
+    // 'budgets' => [
+    //     'finance' => [
+    //         'anthropic' => ['credits' => 5_000_000, 'since' => '2026-06-01'],
+    //         'openai'    => ['credits' => 2_000_000, 'since' => '2026-06-01'],
+    //     ],
+    // ],
+    'budgets' => [],
+];

--- a/config/experiments.php
+++ b/config/experiments.php
@@ -130,4 +130,15 @@ return [
         'tail_stages' => 2,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Require team AI access on experiment creation
+    |--------------------------------------------------------------------------
+    | When enabled, CreateExperimentAction rejects teams that have no usable AI
+    | path (no BYOK key, no platform_llm_fallback, no local/bridge agent, and not
+    | an internal sub-program) with an actionable message — instead of letting the
+    | run fail mid-pipeline. Default off so it can be flipped per environment.
+    */
+    'require_team_ai_access' => (bool) env('EXPERIMENTS_REQUIRE_TEAM_AI_ACCESS', false),
+
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -77,6 +77,9 @@ Schedule::command('credentials:refresh-reddit')->hourly()->withoutOverlapping(5)
 // Project scheduling & budget enforcement
 Schedule::command('projects:check-budgets')->hourly();
 
+// Upstream (platform-funded) credit runway alerts — emails the owner when low
+Schedule::command('credits:check-upstream')->dailyAt('08:00')->withoutOverlapping(30);
+
 // Relationship health scoring (daily)
 Schedule::command('contacts:score-health')->dailyAt('03:30')->withoutOverlapping(60);
 

--- a/tests/Feature/Domain/Budget/UpstreamCreditRunwayTest.php
+++ b/tests/Feature/Domain/Budget/UpstreamCreditRunwayTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\Domain\Budget;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Budget\Actions\CheckUpstreamCreditRunwayAction;
+use App\Domain\Budget\Notifications\UpstreamCreditLowNotification;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\Models\LlmRequestLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class UpstreamCreditRunwayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private Agent $agent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Notification::fake();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Finance',
+            'slug' => 'fin-'.bin2hex(random_bytes(3)),
+            'owner_id' => $user->id,
+            'sub_program_slug' => 'finance',
+            'settings' => [],
+        ]);
+        $this->agent = Agent::factory()->create(['team_id' => $this->team->id]);
+
+        config([
+            'credit_alerts.enabled' => true,
+            'credit_alerts.recipient' => 'ops@fleetq.test',
+            'credit_alerts.threshold_days' => [14, 7, 3],
+            'credit_alerts.cooldown_hours' => 24,
+        ]);
+    }
+
+    private function seedDailyPlatformSpend(int $perDay, int $days): void
+    {
+        for ($d = 0; $d < $days; $d++) {
+            LlmRequestLog::withoutGlobalScopes()->create([
+                'team_id' => $this->team->id,
+                'agent_id' => $this->agent->id,
+                'idempotency_key' => (string) Str::uuid(),
+                'provider' => 'anthropic',
+                'model' => 'claude-haiku-4-5',
+                'status' => 'completed',
+                'byok_source' => 'platform',
+                'cost_credits' => $perDay,
+                'completed_at' => now()->subDays($d)->setTime(12, 0),
+            ]);
+        }
+    }
+
+    private function setBudget(int $credits): void
+    {
+        config(['credit_alerts.budgets' => [
+            'finance' => ['anthropic' => ['credits' => $credits, 'since' => now()->subDays(7)->toDateString()]],
+        ]]);
+    }
+
+    private function action(): CheckUpstreamCreditRunwayAction
+    {
+        return app(CheckUpstreamCreditRunwayAction::class);
+    }
+
+    public function test_sends_alert_when_runway_low(): void
+    {
+        $this->seedDailyPlatformSpend(100, 7); // avg7 = 100, spent_since = 700
+        $this->setBudget(1200);                // remaining 500 -> ~5 days -> bucket 7
+
+        $summaries = $this->action()->execute();
+
+        $this->assertTrue($summaries[0]['alerted']);
+        $this->assertSame(7, $summaries[0]['alert_bucket']);
+        Notification::assertSentOnDemand(
+            UpstreamCreditLowNotification::class,
+            fn (UpstreamCreditLowNotification $n) => $n->subProgram === 'finance' && $n->provider === 'anthropic',
+        );
+    }
+
+    public function test_no_alert_when_runway_safe(): void
+    {
+        $this->seedDailyPlatformSpend(100, 7);
+        $this->setBudget(1_000_000); // years of runway
+
+        $summaries = $this->action()->execute();
+
+        $this->assertNull($summaries[0]['alert_bucket']);
+        Notification::assertNothingSent();
+    }
+
+    public function test_dedups_within_cooldown(): void
+    {
+        $this->seedDailyPlatformSpend(100, 7);
+        $this->setBudget(1200);
+
+        $this->action()->execute();
+        $this->action()->execute(); // same bucket, within cooldown
+
+        Notification::assertCount(1);
+    }
+
+    public function test_dry_run_sends_nothing(): void
+    {
+        $this->seedDailyPlatformSpend(100, 7);
+        $this->setBudget(1200);
+
+        $summaries = $this->action()->execute(dryRun: true);
+
+        $this->assertNotEmpty($summaries);
+        Notification::assertNothingSent();
+    }
+
+    public function test_disabled_is_noop(): void
+    {
+        $this->seedDailyPlatformSpend(100, 7);
+        $this->setBudget(1200);
+        config(['credit_alerts.enabled' => false]);
+
+        $this->assertSame([], $this->action()->execute());
+        Notification::assertNothingSent();
+    }
+}

--- a/tests/Feature/Domain/Budget/UpstreamSpendForecasterTest.php
+++ b/tests/Feature/Domain/Budget/UpstreamSpendForecasterTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\Domain\Budget;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Budget\Services\UpstreamSpendForecaster;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\Models\LlmRequestLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class UpstreamSpendForecasterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private Agent $agent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Finance',
+            'slug' => 'fin-'.bin2hex(random_bytes(3)),
+            'owner_id' => $user->id,
+            'sub_program_slug' => 'finance',
+            'settings' => [],
+        ]);
+        $this->agent = Agent::factory()->create(['team_id' => $this->team->id]);
+    }
+
+    private function log(string $provider, string $byokSource, int $credits, int $daysAgo, ?string $teamId = null): void
+    {
+        LlmRequestLog::withoutGlobalScopes()->create([
+            'team_id' => $teamId ?? $this->team->id,
+            'agent_id' => $this->agent->id,
+            'idempotency_key' => (string) Str::uuid(),
+            'provider' => $provider,
+            'model' => 'claude-haiku-4-5',
+            'status' => 'completed',
+            'byok_source' => $byokSource,
+            'cost_credits' => $credits,
+            'completed_at' => now()->subDays($daysAgo)->setTime(12, 0),
+        ]);
+    }
+
+    private function forecaster(): UpstreamSpendForecaster
+    {
+        return app(UpstreamSpendForecaster::class);
+    }
+
+    public function test_forecasts_platform_funded_runway(): void
+    {
+        for ($d = 0; $d <= 9; $d++) {
+            $this->log('anthropic', 'platform', 50, $d);
+        }
+
+        $f = $this->forecaster()->forecast('finance', 'anthropic', 10000, now()->subDays(60)->toDateString());
+
+        $this->assertSame(50, $f['daily_avg_7d']);
+        $this->assertSame(500, $f['spent_since']); // 10 days * 50
+        $this->assertSame(9500, $f['remaining']);
+        $this->assertSame(190, $f['days_until_depletion']); // ceil(9500 / 50)
+    }
+
+    public function test_excludes_byok_override_and_other_subprograms(): void
+    {
+        for ($d = 0; $d <= 6; $d++) {
+            $this->log('anthropic', 'platform', 50, $d);
+        }
+        $this->log('anthropic', 'team', 9999, 0);             // team BYOK — excluded
+        $this->log('anthropic', 'request_override', 9999, 0); // per-request override — excluded
+
+        $user = User::factory()->create();
+        $other = Team::create([
+            'name' => 'Other', 'slug' => 'oth-'.bin2hex(random_bytes(3)),
+            'owner_id' => $user->id, 'sub_program_slug' => 'crm', 'settings' => [],
+        ]);
+        $this->log('anthropic', 'platform', 9999, 0, $other->id); // other sub-program — excluded
+
+        $f = $this->forecaster()->forecast('finance', 'anthropic', 10000, now()->subDays(60)->toDateString());
+
+        $this->assertSame(350, $f['spent_since']); // only the 7 finance/platform rows
+    }
+
+    public function test_null_runway_when_no_recent_spend(): void
+    {
+        $this->log('anthropic', 'platform', 50, 15); // outside the 7-day window
+
+        $f = $this->forecaster()->forecast('finance', 'anthropic', 10000, now()->subDays(60)->toDateString());
+
+        $this->assertSame(0, $f['daily_avg_7d']);
+        $this->assertNull($f['days_until_depletion']);
+    }
+
+    public function test_zero_result_when_no_teams_for_subprogram(): void
+    {
+        $f = $this->forecaster()->forecast('nonexistent', 'anthropic', 10000, now()->subDays(60)->toDateString());
+
+        $this->assertSame(0, $f['spent_since']);
+        $this->assertSame(10000, $f['remaining']);
+        $this->assertNull($f['days_until_depletion']);
+    }
+}


### PR DESCRIPTION
## Scope A — upstream credit runway alerts
Email the platform owner before a sub-program's (Finance etc.) upstream LLM funding runs out.
- `UpstreamSpendForecaster` — per (sub_program, provider) platform-funded spend from `LlmRequestLog` (`byok_source='platform'`), runway-in-days vs a configured budget.
- `CheckUpstreamCreditRunwayAction` + `credits:check-upstream` (daily 08:00), 14/7/3-day ladder, atomic per-bucket cooldown, configurable founder email.
- `UpstreamCreditLowNotification` (mail). `budget_upstream_runway` MCP tool (read-only, super-admin gated in cloud). `config/credit_alerts.php` + GlobalSetting overrides.

## Scope B — BYOK access gate (flag, default OFF)
`TeamAiAccessChecker` + `AiAccessUnavailableException`: stop non-enterprise, non-sub-program teams with no BYOK/local/bridge at experiment creation with an actionable message instead of a mid-run failure. Gated by `experiments.require_team_ai_access` (default OFF) for flag-flip rollout.

## Tests
Forecaster (4) + runway action (5) here; access checker (4) + create gate (3) in the parent repo's cloud suite. pint + phpstan clean.

## Notes
No-op until budgets are configured (Scope A) / the flag is flipped (Scope B). Companion parent PR carries docs, cloud tests, and the base pointer.