### PR TITLE
fix(budget): spend queries matched a nonexistent 'spend' LedgerType

### DIFF
--- a/app/Domain/Budget/Models/CreditLedger.php
+++ b/app/Domain/Budget/Models/CreditLedger.php
@@ -8,6 +8,7 @@ use App\Domain\Experiment\Models\Experiment;
 use App\Domain\Shared\Traits\BelongsToTeam;
 use App\Models\User;
 use Database\Factories\Domain\Budget\CreditLedgerFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -73,5 +74,21 @@ class CreditLedger extends Model
             ->where('team_id', $teamId)
             ->whereIn('type', [LedgerType::Purchase->value, LedgerType::Refund->value])
             ->exists();
+    }
+
+    /**
+     * Credit-consumption entries: the reservation hold plus its settlement
+     * (release of the unused part / deduction of any over-run). The signed
+     * amounts net to the actual credits consumed, so callers take
+     * abs(sum(amount)) for the spend in a period. (There is no 'spend'
+     * LedgerType — that was a long-standing bug that matched zero rows.)
+     */
+    public function scopeSpend(Builder $query): Builder
+    {
+        return $query->whereIn('type', [
+            LedgerType::Reservation->value,
+            LedgerType::Release->value,
+            LedgerType::Deduction->value,
+        ]);
     }
 }

--- a/app/Domain/Budget/Services/SpendForecaster.php
+++ b/app/Domain/Budget/Services/SpendForecaster.php
@@ -23,14 +23,14 @@ class SpendForecaster
     public function forecast(): array
     {
         $budgetCap = (int) GlobalSetting::get('global_budget_cap', 0);
-        $totalSpent = abs((int) CreditLedger::withoutGlobalScopes()->where('type', 'spend')->sum('amount'));
+        $totalSpent = abs((int) CreditLedger::withoutGlobalScopes()->spend()->sum('amount'));
 
         // Get daily spend for the past 30 days
         $since30 = now()->subDays(30)->startOfDay();
         $since7 = now()->subDays(7)->startOfDay();
 
         $dailySeries = CreditLedger::withoutGlobalScopes()
-            ->where('type', 'spend')
+            ->spend()
             ->where('created_at', '>=', $since30)
             ->selectRaw('DATE(created_at) as day, ABS(SUM(amount)) as spend')
             ->groupByRaw('DATE(created_at)')

--- a/app/Domain/Experiment/Services/StuckDetector.php
+++ b/app/Domain/Experiment/Services/StuckDetector.php
@@ -236,7 +236,7 @@ class StuckDetector
         // Get spend in the last 10 minutes
         $recentSpend = abs((int) CreditLedger::withoutGlobalScopes()
             ->where('experiment_id', $experiment->id)
-            ->where('type', 'spend')
+            ->spend()
             ->where('created_at', '>=', now()->subMinutes(10))
             ->sum('amount'));
 
@@ -247,7 +247,7 @@ class StuckDetector
         // Get total spend and total runtime to compute average rate
         $totalSpend = abs((int) CreditLedger::withoutGlobalScopes()
             ->where('experiment_id', $experiment->id)
-            ->where('type', 'spend')
+            ->spend()
             ->sum('amount'));
 
         $runtimeMinutes = max(1, $experiment->created_at->diffInMinutes(now()));
@@ -333,13 +333,13 @@ class StuckDetector
     {
         $recentSpend = abs((int) CreditLedger::withoutGlobalScopes()
             ->where('experiment_id', $experiment->id)
-            ->where('type', 'spend')
+            ->spend()
             ->where('created_at', '>=', now()->subMinutes(10))
             ->sum('amount'));
 
         $totalSpend = abs((int) CreditLedger::withoutGlobalScopes()
             ->where('experiment_id', $experiment->id)
-            ->where('type', 'spend')
+            ->spend()
             ->sum('amount'));
 
         $runtimeMinutes = max(1, $experiment->created_at->diffInMinutes(now()));

--- a/app/Livewire/Dashboard/DashboardPage.php
+++ b/app/Livewire/Dashboard/DashboardPage.php
@@ -123,7 +123,7 @@ class DashboardPage extends Component
                     ->count(),
                 'pendingApprovals' => ApprovalRequest::where('status', 'pending')->count(),
                 'successRate' => $total > 0 ? round(($completed / $total) * 100, 1) : 0,
-                'totalSpend' => abs((float) CreditLedger::where('type', 'spend')->sum('amount')),
+                'totalSpend' => abs((float) CreditLedger::query()->spend()->sum('amount')),
                 'activeSkills' => Skill::where('status', 'active')->count(),
                 'activeAgents' => Agent::where('status', 'active')->count(),
                 'skillExecutions24h' => SkillExecution::where('created_at', '>=', now()->subDay())->count(),

--- a/app/Livewire/Health/HealthPage.php
+++ b/app/Livewire/Health/HealthPage.php
@@ -257,11 +257,11 @@ class HealthPage extends Component
 
     private function getSpendStats(): array
     {
-        $today = CreditLedger::where('type', 'spend')
+        $today = CreditLedger::query()->spend()
             ->where('created_at', '>=', now()->startOfDay())
             ->sum('amount');
 
-        $thisHour = CreditLedger::where('type', 'spend')
+        $thisHour = CreditLedger::query()->spend()
             ->where('created_at', '>=', now()->startOfHour())
             ->sum('amount');
 

--- a/tests/Feature/Domain/Budget/SpendForecasterTest.php
+++ b/tests/Feature/Domain/Budget/SpendForecasterTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Domain\Budget;
+
+use App\Domain\Budget\Enums\LedgerType;
+use App\Domain\Budget\Models\CreditLedger;
+use App\Domain\Budget\Services\SpendForecaster;
+use App\Domain\Shared\Models\Team;
+use App\Models\GlobalSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SpendForecasterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Test', 'slug' => 't-'.bin2hex(random_bytes(3)),
+            'owner_id' => $this->user->id, 'settings' => [],
+        ]);
+    }
+
+    private function entry(LedgerType $type, int $amount): void
+    {
+        CreditLedger::withoutGlobalScopes()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->user->id,
+            'type' => $type,
+            'amount' => $amount,
+            'balance_after' => 0,
+            'description' => 'test',
+            'metadata' => [],
+        ]);
+    }
+
+    public function test_forecast_counts_consumption_entries_not_a_nonexistent_spend_type(): void
+    {
+        // Net consumed = |(-100) + (-20) + (+30)| = 90. Purchase must be ignored.
+        $this->entry(LedgerType::Reservation, -100);
+        $this->entry(LedgerType::Deduction, -20);
+        $this->entry(LedgerType::Release, 30);
+        $this->entry(LedgerType::Purchase, 5000);
+
+        GlobalSetting::set('global_budget_cap', 1000);
+
+        $forecast = app(SpendForecaster::class)->forecast();
+
+        $this->assertSame(90, $forecast['total_spent']);
+        $this->assertGreaterThan(0, $forecast['daily_avg_7d']);
+        $this->assertNotNull($forecast['days_until_cap']); // was always null while spend read 0
+    }
+
+    public function test_forecast_is_zero_without_consumption(): void
+    {
+        $this->entry(LedgerType::Purchase, 5000); // credit only, no consumption
+
+        $forecast = app(SpendForecaster::class)->forecast();
+
+        $this->assertSame(0, $forecast['total_spent']);
+        $this->assertSame(0, $forecast['daily_avg_7d']);
+    }
+}


### PR DESCRIPTION
## Problem
`CreditLedger` has no `spend` type (values: purchase, deduction, refund, reservation, release, marketplace_*, platform_fee). Every `->where('type', 'spend')` matched **zero rows**, silently zeroing spend across:
- `SpendForecaster` (daily series, total_spent, days_until_cap) → `budget_forecast` MCP tool + dashboard widget
- `HealthPage` spend stats (today / this hour)
- `DashboardPage` `totalSpend` KPI
- `StuckDetector::detectBudgetDrain` — **dead code**: recentSpend always 0 → always returned null, so budget-drain stuck detection never fired

## Fix
Credits consumed = the reservation hold + its settlement (release of unused / deduction of over-run); signed amounts net to actual spend. Added `CreditLedger::scopeSpend()` as the single source of truth and routed all 9 call sites through it. Per-call scoping (`withoutGlobalScopes` vs team scope) and `abs()` handling preserved.

## Tests
New `SpendForecasterTest` (consumption counted, purchases ignored, zero without consumption). Budget/Experiment/Livewire regression green; pint + phpstan clean.

Found while wrapping the upstream-credit-alerts sprint (#105/#59), where the new UpstreamSpendForecaster correctly sources from LlmRequestLog.