### PR TITLE
feat: ProductGraph — product/feature dependency graph (VibeGraph-borrowed)

### DIFF
--- a/app/Domain/ProductGraph/Actions/ApplyApprovedChangeAction.php
+++ b/app/Domain/ProductGraph/Actions/ApplyApprovedChangeAction.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Enums\ChangeType;
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Enums\NodeStatus;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Domain\ProductGraph\Models\ProductNode;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+/**
+ * Materialises an approved proposal into the graph. Idempotent: re-applying an
+ * already-applied change is a no-op.
+ */
+class ApplyApprovedChangeAction
+{
+    public function __construct(
+        private readonly CreateNodeAction $createNode,
+        private readonly UpdateNodeAction $updateNode,
+        private readonly DeleteNodeAction $deleteNode,
+        private readonly UpsertEdgeAction $upsertEdge,
+        private readonly DeleteEdgeAction $deleteEdge,
+    ) {}
+
+    public function execute(ProductGraphChange $change): ProductGraphChange
+    {
+        if ($change->status === ChangeStatus::Applied) {
+            return $change;
+        }
+
+        if ($change->status !== ChangeStatus::Approved) {
+            throw new RuntimeException('Only approved changes can be applied.');
+        }
+
+        return DB::transaction(function () use ($change) {
+            $refId = match ($change->change_type) {
+                ChangeType::CreateNode => $this->applyCreateNode($change),
+                ChangeType::UpdateNode => $this->applyUpdateNode($change),
+                ChangeType::DeleteNode => $this->applyDeleteNode($change),
+                ChangeType::CreateEdge => $this->applyCreateEdge($change),
+                ChangeType::DeleteEdge => $this->applyDeleteEdge($change),
+            };
+
+            $change->update([
+                'status' => ChangeStatus::Applied->value,
+                'applied_ref_id' => $refId,
+            ]);
+
+            return $change->refresh();
+        });
+    }
+
+    private function applyCreateNode(ProductGraphChange $change): string
+    {
+        $p = $change->payload;
+
+        $node = $this->createNode->execute(
+            teamId: $change->team_id,
+            type: NodeType::from((string) $p['node_type']),
+            name: (string) $p['name'],
+            status: NodeStatus::tryFrom((string) ($p['status'] ?? '')) ?? NodeStatus::Planned,
+            description: $p['description'] ?? null,
+            tags: $p['tags'] ?? [],
+            externalRef: $p['external_ref'] ?? null,
+            metadata: $p['metadata'] ?? [],
+        );
+
+        return $node->id;
+    }
+
+    private function applyUpdateNode(ProductGraphChange $change): string
+    {
+        $node = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $change->team_id)
+            ->findOrFail($change->target_id);
+
+        $this->updateNode->execute($node, $change->payload);
+
+        return $node->id;
+    }
+
+    private function applyDeleteNode(ProductGraphChange $change): ?string
+    {
+        $node = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $change->team_id)
+            ->find($change->target_id);
+
+        if ($node !== null) {
+            $this->deleteNode->execute($node);
+        }
+
+        return $change->target_id;
+    }
+
+    private function applyCreateEdge(ProductGraphChange $change): string
+    {
+        $p = $change->payload;
+
+        $edge = $this->upsertEdge->execute(
+            teamId: $change->team_id,
+            sourceNodeId: (string) $p['source_node_id'],
+            targetNodeId: (string) $p['target_node_id'],
+            type: EdgeType::from((string) $p['edge_type']),
+            description: $p['description'] ?? null,
+        );
+
+        return $edge->id;
+    }
+
+    private function applyDeleteEdge(ProductGraphChange $change): ?string
+    {
+        $edge = ProductEdge::withoutGlobalScopes()
+            ->where('team_id', $change->team_id)
+            ->find($change->target_id);
+
+        if ($edge !== null) {
+            $this->deleteEdge->execute($edge);
+        }
+
+        return $change->target_id;
+    }
+}

--- a/app/Domain/ProductGraph/Actions/CreateNodeAction.php
+++ b/app/Domain/ProductGraph/Actions/CreateNodeAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Enums\NodeStatus;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductNode;
+use Illuminate\Support\Str;
+
+/**
+ * Idempotent node upsert keyed on (team, type, slug) — safe for seeding/import.
+ */
+class CreateNodeAction
+{
+    /**
+     * @param  string[]  $tags
+     * @param  array<string, mixed>  $metadata
+     */
+    public function execute(
+        string $teamId,
+        NodeType $type,
+        string $name,
+        NodeStatus $status = NodeStatus::Planned,
+        ?string $description = null,
+        array $tags = [],
+        ?string $externalRef = null,
+        array $metadata = [],
+    ): ProductNode {
+        $slug = Str::slug($name);
+
+        return ProductNode::withoutGlobalScopes()->updateOrCreate(
+            ['team_id' => $teamId, 'node_type' => $type->value, 'slug' => $slug],
+            [
+                'name' => $name,
+                'status' => $status->value,
+                'description' => $description,
+                'tags' => array_values(array_unique($tags)),
+                'external_ref' => $externalRef,
+                'metadata' => $metadata,
+            ],
+        );
+    }
+}

--- a/app/Domain/ProductGraph/Actions/DeleteEdgeAction.php
+++ b/app/Domain/ProductGraph/Actions/DeleteEdgeAction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Models\ProductEdge;
+
+class DeleteEdgeAction
+{
+    public function execute(ProductEdge $edge): void
+    {
+        $edge->delete();
+    }
+}

--- a/app/Domain/ProductGraph/Actions/DeleteNodeAction.php
+++ b/app/Domain/ProductGraph/Actions/DeleteNodeAction.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Models\ProductNode;
+
+class DeleteNodeAction
+{
+    /** Connected edges are removed by the cascading FK. */
+    public function execute(ProductNode $node): void
+    {
+        $node->delete();
+    }
+}

--- a/app/Domain/ProductGraph/Actions/ImportFromInventoryAction.php
+++ b/app/Domain/ProductGraph/Actions/ImportFromInventoryAction.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Enums\NodeStatus;
+use App\Domain\ProductGraph\Enums\NodeType;
+
+/**
+ * Seeds an initial product graph from the FleetQ feature-inventory markdown.
+ *
+ * Pure string parsing (no LLM — "the map, not the territory"). Tolerates format
+ * drift: unparseable lines are skipped rather than aborting the import. Idempotent
+ * via {@see CreateNodeAction}/{@see UpsertEdgeAction}, so re-running is safe.
+ *
+ * It extracts two things:
+ *   1. The "base domain list" comma line  → one `feature` node per domain (implemented),
+ *      each `part_of` a root `product` node.
+ *   2. The "BACKLOG" table rows           → `feature` nodes (planned), tagged `backlog`.
+ */
+class ImportFromInventoryAction
+{
+    public function __construct(
+        private readonly CreateNodeAction $createNode,
+        private readonly UpsertEdgeAction $upsertEdge,
+    ) {}
+
+    /**
+     * @return array{nodes_created: int, edges_created: int}
+     */
+    public function execute(string $teamId, string $markdown, string $rootName = 'Platform'): array
+    {
+        $nodesCreated = 0;
+        $edgesCreated = 0;
+
+        $root = $this->createNode->execute(
+            teamId: $teamId,
+            type: NodeType::Product,
+            name: $rootName,
+            status: NodeStatus::Implemented,
+            description: 'Root product node (imported from feature inventory).',
+            tags: ['imported'],
+        );
+        $nodesCreated += $root->wasRecentlyCreated ? 1 : 0;
+
+        foreach ($this->parseDomains($markdown) as $domain) {
+            $node = $this->createNode->execute(
+                teamId: $teamId,
+                type: NodeType::Feature,
+                name: $domain,
+                status: NodeStatus::Implemented,
+                tags: ['domain', 'imported'],
+            );
+            $nodesCreated += $node->wasRecentlyCreated ? 1 : 0;
+
+            $edge = $this->upsertEdge->execute($teamId, $node->id, $root->id, EdgeType::PartOf);
+            $edgesCreated += $edge->wasRecentlyCreated ? 1 : 0;
+        }
+
+        foreach ($this->parseBacklog($markdown) as $item) {
+            $tags = ['backlog', 'imported'];
+            if ($item['domain'] !== '') {
+                $tags[] = $item['domain'];
+            }
+
+            $node = $this->createNode->execute(
+                teamId: $teamId,
+                type: NodeType::Feature,
+                name: $item['name'],
+                status: NodeStatus::Planned,
+                tags: $tags,
+            );
+            $nodesCreated += $node->wasRecentlyCreated ? 1 : 0;
+
+            $edge = $this->upsertEdge->execute($teamId, $node->id, $root->id, EdgeType::PartOf);
+            $edgesCreated += $edge->wasRecentlyCreated ? 1 : 0;
+        }
+
+        return ['nodes_created' => $nodesCreated, 'edges_created' => $edgesCreated];
+    }
+
+    /**
+     * Extract domain names from a "... domain list: A, B, C" line.
+     *
+     * @return string[]
+     */
+    private function parseDomains(string $markdown): array
+    {
+        if (! preg_match('/(?:base )?domain list[^:]*:\s*(.+)/i', $markdown, $m)) {
+            return [];
+        }
+
+        $tokens = array_map('trim', explode(',', $m[1]));
+
+        return array_values(array_filter($tokens, function (string $t): bool {
+            // Domain names are single PascalCase identifiers; reject prose/markdown.
+            return $t !== '' && preg_match('/^[A-Za-z][A-Za-z0-9 ]{0,38}$/', $t) === 1
+                && ! str_contains($t, '(') && ! str_contains($t, '*');
+        }));
+    }
+
+    /**
+     * Extract backlog capability rows from the markdown table under a BACKLOG heading.
+     *
+     * @return list<array{name: string, domain: string}>
+     */
+    private function parseBacklog(string $markdown): array
+    {
+        $lines = preg_split('/\r?\n/', $markdown) ?: [];
+        $inBacklog = false;
+        $items = [];
+
+        foreach ($lines as $line) {
+            $trimmed = trim($line);
+
+            if (preg_match('/^#{1,6}.*backlog/i', $trimmed)) {
+                $inBacklog = true;
+
+                continue;
+            }
+
+            // A new heading ends the backlog section.
+            if ($inBacklog && preg_match('/^#{1,6}\s/', $trimmed) && ! preg_match('/backlog/i', $trimmed)) {
+                break;
+            }
+
+            if (! $inBacklog || ! str_starts_with($trimmed, '|')) {
+                continue;
+            }
+
+            $cells = array_map('trim', explode('|', trim($trimmed, '|')));
+
+            // Expected: # | Capability | Domain | exists | missing | Priority
+            if (count($cells) < 3) {
+                continue;
+            }
+
+            // Skip header + separator rows.
+            if (str_contains(strtolower($cells[1]), 'capability') || str_contains($cells[0], '---')) {
+                continue;
+            }
+
+            if (! preg_match('/\*\*(.+?)\*\*/', $cells[1], $nameMatch)) {
+                continue;
+            }
+
+            $name = trim(preg_replace('/\s*\(.+?\)\s*/', '', $nameMatch[1]) ?? $nameMatch[1]);
+            if ($name === '') {
+                continue;
+            }
+
+            $items[] = ['name' => $name, 'domain' => $cells[2]];
+        }
+
+        return $items;
+    }
+}

--- a/app/Domain/ProductGraph/Actions/ProposeChangeAction.php
+++ b/app/Domain/ProductGraph/Actions/ProposeChangeAction.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Enums\ChangeType;
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use InvalidArgumentException;
+
+/**
+ * Records a proposed graph mutation in the pending review queue WITHOUT touching
+ * the graph. "Agents propose. Humans decide." The change is applied only after a
+ * human approves it via {@see ReviewChangeAction}.
+ */
+class ProposeChangeAction
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function execute(
+        string $teamId,
+        ChangeType $type,
+        ?string $targetId,
+        array $payload,
+        string $proposedByLabel = 'user',
+        ?string $proposedByUserId = null,
+    ): ProductGraphChange {
+        $this->validate($type, $targetId, $payload);
+
+        return ProductGraphChange::withoutGlobalScopes()->create([
+            'team_id' => $teamId,
+            'change_type' => $type->value,
+            'target_id' => $targetId,
+            'payload' => $payload,
+            'status' => ChangeStatus::Pending->value,
+            'proposed_by_label' => $proposedByLabel,
+            'proposed_by_user_id' => $proposedByUserId,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validate(ChangeType $type, ?string $targetId, array $payload): void
+    {
+        switch ($type) {
+            case ChangeType::CreateNode:
+                $this->require($payload, ['node_type', 'name']);
+                if (NodeType::tryFrom((string) $payload['node_type']) === null) {
+                    throw new InvalidArgumentException('Invalid node_type in payload.');
+                }
+                break;
+
+            case ChangeType::UpdateNode:
+            case ChangeType::DeleteNode:
+            case ChangeType::DeleteEdge:
+                if ($targetId === null || $targetId === '') {
+                    throw new InvalidArgumentException($type->value.' requires a target_id.');
+                }
+                break;
+
+            case ChangeType::CreateEdge:
+                $this->require($payload, ['source_node_id', 'target_node_id', 'edge_type']);
+                if (EdgeType::tryFrom((string) $payload['edge_type']) === null) {
+                    throw new InvalidArgumentException('Invalid edge_type in payload.');
+                }
+                break;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  string[]  $keys
+     */
+    private function require(array $payload, array $keys): void
+    {
+        foreach ($keys as $key) {
+            if (! isset($payload[$key]) || $payload[$key] === '') {
+                throw new InvalidArgumentException("Missing required payload field: {$key}.");
+            }
+        }
+    }
+}

--- a/app/Domain/ProductGraph/Actions/ReviewChangeAction.php
+++ b/app/Domain/ProductGraph/Actions/ReviewChangeAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use RuntimeException;
+
+/**
+ * Human approve/reject of a pending proposal. Approval immediately applies the
+ * change to the graph via {@see ApplyApprovedChangeAction}.
+ */
+class ReviewChangeAction
+{
+    public function __construct(private readonly ApplyApprovedChangeAction $apply) {}
+
+    public function execute(
+        ProductGraphChange $change,
+        bool $approve,
+        ?string $reviewerUserId = null,
+        ?string $note = null,
+    ): ProductGraphChange {
+        if ($change->status !== ChangeStatus::Pending) {
+            throw new RuntimeException('Only pending changes can be reviewed.');
+        }
+
+        if (! $approve) {
+            $change->update([
+                'status' => ChangeStatus::Rejected->value,
+                'reviewed_by_user_id' => $reviewerUserId,
+                'review_note' => $note,
+            ]);
+
+            return $change->refresh();
+        }
+
+        $change->update([
+            'status' => ChangeStatus::Approved->value,
+            'reviewed_by_user_id' => $reviewerUserId,
+            'review_note' => $note,
+        ]);
+
+        return $this->apply->execute($change->refresh());
+    }
+}

--- a/app/Domain/ProductGraph/Actions/UpdateNodeAction.php
+++ b/app/Domain/ProductGraph/Actions/UpdateNodeAction.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Models\ProductNode;
+use Illuminate\Support\Arr;
+
+class UpdateNodeAction
+{
+    /**
+     * Slug is intentionally left stable on rename — it is only a dedup key.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function execute(ProductNode $node, array $attributes): ProductNode
+    {
+        $node->fill(Arr::only($attributes, [
+            'name',
+            'status',
+            'description',
+            'tags',
+            'external_ref',
+            'metadata',
+        ]));
+        $node->save();
+
+        return $node->refresh();
+    }
+}

--- a/app/Domain/ProductGraph/Actions/UpsertEdgeAction.php
+++ b/app/Domain/ProductGraph/Actions/UpsertEdgeAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Domain\ProductGraph\Actions;
+
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductNode;
+use InvalidArgumentException;
+
+/**
+ * Idempotent edge upsert. Guards self-loops and cross-tenant node references.
+ */
+class UpsertEdgeAction
+{
+    public function execute(
+        string $teamId,
+        string $sourceNodeId,
+        string $targetNodeId,
+        EdgeType $type,
+        ?string $description = null,
+    ): ProductEdge {
+        if ($sourceNodeId === $targetNodeId) {
+            throw new InvalidArgumentException('An edge cannot connect a node to itself.');
+        }
+
+        $belong = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->whereIn('id', [$sourceNodeId, $targetNodeId])
+            ->count();
+
+        if ($belong !== 2) {
+            throw new InvalidArgumentException('Both nodes must exist and belong to the team.');
+        }
+
+        return ProductEdge::withoutGlobalScopes()->updateOrCreate(
+            [
+                'team_id' => $teamId,
+                'source_node_id' => $sourceNodeId,
+                'target_node_id' => $targetNodeId,
+                'edge_type' => $type->value,
+            ],
+            ['description' => $description],
+        );
+    }
+}

--- a/app/Domain/ProductGraph/Enums/ChangeStatus.php
+++ b/app/Domain/ProductGraph/Enums/ChangeStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Domain\ProductGraph\Enums;
+
+enum ChangeStatus: string
+{
+    case Pending = 'pending';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+    case Applied = 'applied';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Approved => 'Approved',
+            self::Rejected => 'Rejected',
+            self::Applied => 'Applied',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::Pending => 'bg-amber-100 text-amber-800',
+            self::Approved => 'bg-blue-100 text-blue-800',
+            self::Rejected => 'bg-red-100 text-red-700',
+            self::Applied => 'bg-emerald-100 text-emerald-800',
+        };
+    }
+
+    /** @return string[] */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Domain/ProductGraph/Enums/ChangeType.php
+++ b/app/Domain/ProductGraph/Enums/ChangeType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Domain\ProductGraph\Enums;
+
+enum ChangeType: string
+{
+    case CreateNode = 'create_node';
+    case UpdateNode = 'update_node';
+    case DeleteNode = 'delete_node';
+    case CreateEdge = 'create_edge';
+    case DeleteEdge = 'delete_edge';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CreateNode => 'Create node',
+            self::UpdateNode => 'Update node',
+            self::DeleteNode => 'Delete node',
+            self::CreateEdge => 'Create edge',
+            self::DeleteEdge => 'Delete edge',
+        };
+    }
+
+    public function isEdgeChange(): bool
+    {
+        return $this === self::CreateEdge || $this === self::DeleteEdge;
+    }
+
+    /** @return string[] */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public static function validationRule(): string
+    {
+        return 'in:'.implode(',', self::values());
+    }
+}

--- a/app/Domain/ProductGraph/Enums/EdgeType.php
+++ b/app/Domain/ProductGraph/Enums/EdgeType.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Domain\ProductGraph\Enums;
+
+/**
+ * Typed structural relationships between product nodes. The {@see impactDirection()}
+ * of each type drives blast-radius analysis: which way a change propagates.
+ */
+enum EdgeType: string
+{
+    case DependsOn = 'depends_on';
+    case PartOf = 'part_of';
+    case Uses = 'uses';
+    case IntegratesWith = 'integrates_with';
+    case Serves = 'serves';
+    case Triggers = 'triggers';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::DependsOn => 'depends on',
+            self::PartOf => 'part of',
+            self::Uses => 'uses',
+            self::IntegratesWith => 'integrates with',
+            self::Serves => 'serves',
+            self::Triggers => 'triggers',
+        };
+    }
+
+    /**
+     * Which neighbours are affected when a node changes, relative to this edge.
+     *
+     * - `incoming`: A {depends_on|uses|part_of} B → a change to B (target) affects A (source).
+     *   Impact traversal from a node follows edges where it is the TARGET.
+     * - `outgoing`: A {serves|triggers} B → a change to A (source) affects B (target).
+     *   Impact traversal from a node follows edges where it is the SOURCE.
+     * - `both`: integrates_with is bidirectional.
+     */
+    public function impactDirection(): string
+    {
+        return match ($this) {
+            self::DependsOn, self::Uses, self::PartOf => 'incoming',
+            self::Serves, self::Triggers => 'outgoing',
+            self::IntegratesWith => 'both',
+        };
+    }
+
+    /** @return string[] */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public static function validationRule(): string
+    {
+        return 'in:'.implode(',', self::values());
+    }
+}

--- a/app/Domain/ProductGraph/Enums/NodeStatus.php
+++ b/app/Domain/ProductGraph/Enums/NodeStatus.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Domain\ProductGraph\Enums;
+
+enum NodeStatus: string
+{
+    case Planned = 'planned';
+    case InProgress = 'in_progress';
+    case Implemented = 'implemented';
+    case Deprecated = 'deprecated';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Planned => 'Planned',
+            self::InProgress => 'In progress',
+            self::Implemented => 'Implemented',
+            self::Deprecated => 'Deprecated',
+        };
+    }
+
+    /** Tailwind badge classes for UI rendering. */
+    public function color(): string
+    {
+        return match ($this) {
+            self::Planned => 'bg-gray-100 text-gray-700',
+            self::InProgress => 'bg-amber-100 text-amber-800',
+            self::Implemented => 'bg-emerald-100 text-emerald-800',
+            self::Deprecated => 'bg-red-100 text-red-700',
+        };
+    }
+
+    /** @return string[] */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public static function validationRule(): string
+    {
+        return 'in:'.implode(',', self::values());
+    }
+}

--- a/app/Domain/ProductGraph/Enums/NodeType.php
+++ b/app/Domain/ProductGraph/Enums/NodeType.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Domain\ProductGraph\Enums;
+
+/**
+ * Typed nodes in the product graph — the "what we're building" vocabulary.
+ * Deliberately product-layer (above code, below wiki), not implementation detail.
+ */
+enum NodeType: string
+{
+    case Product = 'product';
+    case Feature = 'feature';
+    case SubFeature = 'sub_feature';
+    case SharedComponent = 'shared_component';
+    case AgentSkill = 'agent_skill';
+    case Standard = 'standard';
+    case Persona = 'persona';
+    case TechComponent = 'tech_component';
+    case Release = 'release';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Product => 'Product',
+            self::Feature => 'Feature',
+            self::SubFeature => 'Sub-feature',
+            self::SharedComponent => 'Shared Component',
+            self::AgentSkill => 'Agent Skill',
+            self::Standard => 'Standard',
+            self::Persona => 'Persona',
+            self::TechComponent => 'Tech Component',
+            self::Release => 'Release',
+        };
+    }
+
+    /** @return string[] */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public static function validationRule(): string
+    {
+        return 'in:'.implode(',', self::values());
+    }
+}

--- a/app/Domain/ProductGraph/Models/ProductEdge.php
+++ b/app/Domain/ProductGraph/Models/ProductEdge.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Domain\ProductGraph\Models;
+
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\Shared\Traits\BelongsToTeam;
+use Database\Factories\Domain\ProductGraph\ProductEdgeFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $team_id
+ * @property string $source_node_id
+ * @property string $target_node_id
+ * @property EdgeType $edge_type
+ * @property string|null $description
+ * @property array<string, mixed> $metadata
+ * @property-read ProductNode|null $source
+ * @property-read ProductNode|null $target
+ */
+class ProductEdge extends Model
+{
+    use BelongsToTeam, HasFactory, HasUuids;
+
+    protected $fillable = [
+        'team_id',
+        'source_node_id',
+        'target_node_id',
+        'edge_type',
+        'description',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'edge_type' => EdgeType::class,
+            'metadata' => 'array',
+        ];
+    }
+
+    protected static function newFactory(): ProductEdgeFactory
+    {
+        return ProductEdgeFactory::new();
+    }
+
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(ProductNode::class, 'source_node_id');
+    }
+
+    public function target(): BelongsTo
+    {
+        return $this->belongsTo(ProductNode::class, 'target_node_id');
+    }
+}

--- a/app/Domain/ProductGraph/Models/ProductGraphChange.php
+++ b/app/Domain/ProductGraph/Models/ProductGraphChange.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Domain\ProductGraph\Models;
+
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Enums\ChangeType;
+use App\Domain\Shared\Traits\BelongsToTeam;
+use Database\Factories\Domain\ProductGraph\ProductGraphChangeFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $team_id
+ * @property ChangeType $change_type
+ * @property string|null $target_id
+ * @property array<string, mixed> $payload
+ * @property ChangeStatus $status
+ * @property string $proposed_by_label
+ * @property string|null $proposed_by_user_id
+ * @property string|null $reviewed_by_user_id
+ * @property string|null $review_note
+ * @property string|null $applied_ref_id
+ * @property-read Carbon|null $created_at
+ */
+class ProductGraphChange extends Model
+{
+    use BelongsToTeam, HasFactory, HasUuids;
+
+    protected $fillable = [
+        'team_id',
+        'change_type',
+        'target_id',
+        'payload',
+        'status',
+        'proposed_by_label',
+        'proposed_by_user_id',
+        'reviewed_by_user_id',
+        'review_note',
+        'applied_ref_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'change_type' => ChangeType::class,
+            'status' => ChangeStatus::class,
+            'payload' => 'array',
+        ];
+    }
+
+    protected static function newFactory(): ProductGraphChangeFactory
+    {
+        return ProductGraphChangeFactory::new();
+    }
+
+    public function scopePending(Builder $query): Builder
+    {
+        return $query->where('status', ChangeStatus::Pending->value);
+    }
+}

--- a/app/Domain/ProductGraph/Models/ProductNode.php
+++ b/app/Domain/ProductGraph/Models/ProductNode.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Domain\ProductGraph\Models;
+
+use App\Domain\ProductGraph\Enums\NodeStatus;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\Shared\Traits\BelongsToTeam;
+use Database\Factories\Domain\ProductGraph\ProductNodeFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property string $id
+ * @property string $team_id
+ * @property NodeType $node_type
+ * @property string $name
+ * @property string $slug
+ * @property NodeStatus $status
+ * @property string|null $description
+ * @property array<int, string> $tags
+ * @property string|null $external_ref
+ * @property array<string, mixed> $metadata
+ * @property-read int|null $outgoing_edges_count
+ * @property-read int|null $incoming_edges_count
+ */
+class ProductNode extends Model
+{
+    use BelongsToTeam, HasFactory, HasUuids;
+
+    protected $fillable = [
+        'team_id',
+        'node_type',
+        'name',
+        'slug',
+        'status',
+        'description',
+        'tags',
+        'external_ref',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'node_type' => NodeType::class,
+            'status' => NodeStatus::class,
+            'tags' => 'array',
+            'metadata' => 'array',
+        ];
+    }
+
+    protected static function newFactory(): ProductNodeFactory
+    {
+        return ProductNodeFactory::new();
+    }
+
+    public function scopeOfType(Builder $query, NodeType $type): Builder
+    {
+        return $query->where('node_type', $type->value);
+    }
+
+    public function outgoingEdges(): HasMany
+    {
+        return $this->hasMany(ProductEdge::class, 'source_node_id');
+    }
+
+    public function incomingEdges(): HasMany
+    {
+        return $this->hasMany(ProductEdge::class, 'target_node_id');
+    }
+}

--- a/app/Domain/ProductGraph/Services/ImpactAnalyzer.php
+++ b/app/Domain/ProductGraph/Services/ImpactAnalyzer.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Domain\ProductGraph\Services;
+
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductNode;
+
+/**
+ * Blast-radius / impact analysis: "what is affected if this node changes?"
+ *
+ * Directed BFS over edges, where the traversal direction per edge type is given
+ * by {@see EdgeType::impactDirection()}. Cycle-safe
+ * (visited set), keeps the shallowest depth per affected node.
+ */
+class ImpactAnalyzer
+{
+    /**
+     * @return list<array{node_id: string, name: ?string, node_type: ?string, depth: int, via_edge_type: string}>
+     */
+    public function blastRadius(ProductNode $node, ?int $maxDepth = null): array
+    {
+        $maxDepth = $maxDepth ?? (int) config('productgraph.max_impact_depth', 5);
+        $teamId = $node->team_id;
+
+        $visited = [$node->id => true];
+        $queue = [[$node->id, 0]];
+        $result = [];
+
+        while ($queue !== []) {
+            [$currentId, $depth] = array_shift($queue);
+
+            if ($depth >= $maxDepth) {
+                continue;
+            }
+
+            foreach ($this->affectedNeighbors($teamId, $currentId) as $neighbor) {
+                if (isset($visited[$neighbor['node_id']])) {
+                    continue;
+                }
+
+                $visited[$neighbor['node_id']] = true;
+                $result[] = [
+                    'node_id' => $neighbor['node_id'],
+                    'depth' => $depth + 1,
+                    'via_edge_type' => $neighbor['via_edge_type'],
+                ];
+                $queue[] = [$neighbor['node_id'], $depth + 1];
+            }
+        }
+
+        return $this->hydrateNames($teamId, $result);
+    }
+
+    /**
+     * Neighbours affected when $nodeId changes.
+     *
+     * @return list<array{node_id: string, via_edge_type: string}>
+     */
+    private function affectedNeighbors(string $teamId, string $nodeId): array
+    {
+        $affected = [];
+
+        $incoming = ProductEdge::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->where('target_node_id', $nodeId)
+            ->get();
+
+        foreach ($incoming as $edge) {
+            if (in_array($edge->edge_type->impactDirection(), ['incoming', 'both'], true)) {
+                $affected[] = ['node_id' => $edge->source_node_id, 'via_edge_type' => $edge->edge_type->value];
+            }
+        }
+
+        $outgoing = ProductEdge::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->where('source_node_id', $nodeId)
+            ->get();
+
+        foreach ($outgoing as $edge) {
+            if (in_array($edge->edge_type->impactDirection(), ['outgoing', 'both'], true)) {
+                $affected[] = ['node_id' => $edge->target_node_id, 'via_edge_type' => $edge->edge_type->value];
+            }
+        }
+
+        return $affected;
+    }
+
+    /**
+     * @param  list<array{node_id: string, depth: int, via_edge_type: string}>  $rows
+     * @return list<array{node_id: string, name: ?string, node_type: ?string, depth: int, via_edge_type: string}>
+     */
+    private function hydrateNames(string $teamId, array $rows): array
+    {
+        if ($rows === []) {
+            return [];
+        }
+
+        $nodes = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->whereIn('id', array_column($rows, 'node_id'))
+            ->get()
+            ->keyBy('id');
+
+        return array_map(function (array $row) use ($nodes): array {
+            $node = $nodes->get($row['node_id']);
+
+            return [
+                'node_id' => $row['node_id'],
+                'name' => $node?->name,
+                'node_type' => $node?->node_type->value,
+                'depth' => $row['depth'],
+                'via_edge_type' => $row['via_edge_type'],
+            ];
+        }, $rows);
+    }
+}

--- a/app/Livewire/ProductGraph/ProductGraphBrowserPage.php
+++ b/app/Livewire/ProductGraph/ProductGraphBrowserPage.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace App\Livewire\ProductGraph;
+
+use App\Domain\ProductGraph\Actions\CreateNodeAction;
+use App\Domain\ProductGraph\Actions\DeleteNodeAction;
+use App\Domain\ProductGraph\Actions\ImportFromInventoryAction;
+use App\Domain\ProductGraph\Actions\UpsertEdgeAction;
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Enums\NodeStatus;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Domain\ProductGraph\Models\ProductNode;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+class ProductGraphBrowserPage extends Component
+{
+    use AuthorizesRequests;
+
+    #[Url]
+    public string $tab = 'map';
+
+    #[Url]
+    public string $nodeTypeFilter = '';
+
+    #[Url]
+    public string $statusFilter = '';
+
+    #[Url]
+    public string $search = '';
+
+    public ?string $selectedNodeId = null;
+
+    public bool $showAddNode = false;
+
+    public string $newName = '';
+
+    public string $newNodeType = 'feature';
+
+    public string $newStatus = 'planned';
+
+    public string $newDescription = '';
+
+    public string $newTags = '';
+
+    public bool $showAddEdge = false;
+
+    public string $edgeSource = '';
+
+    public string $edgeTarget = '';
+
+    public string $edgeType = 'depends_on';
+
+    public ?string $error = null;
+
+    public ?string $success = null;
+
+    private function teamId(): string
+    {
+        return auth()->user()->current_team_id;
+    }
+
+    public function addNode(): void
+    {
+        $this->authorize('edit-content');
+
+        $this->validate([
+            'newName' => ['required', 'string', 'max:255'],
+            'newNodeType' => ['required', NodeType::validationRule()],
+            'newStatus' => ['required', NodeStatus::validationRule()],
+            'newDescription' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $tags = array_values(array_filter(array_map('trim', explode(',', $this->newTags))));
+
+        app(CreateNodeAction::class)->execute(
+            teamId: $this->teamId(),
+            type: NodeType::from($this->newNodeType),
+            name: $this->newName,
+            status: NodeStatus::from($this->newStatus),
+            description: $this->newDescription ?: null,
+            tags: $tags,
+        );
+
+        $this->reset(['newName', 'newDescription', 'newTags', 'error']);
+        $this->showAddNode = false;
+        $this->success = 'Node added.';
+    }
+
+    public function addEdge(): void
+    {
+        $this->authorize('edit-content');
+
+        $this->validate([
+            'edgeSource' => ['required', 'string'],
+            'edgeTarget' => ['required', 'string'],
+            'edgeType' => ['required', EdgeType::validationRule()],
+        ]);
+
+        try {
+            app(UpsertEdgeAction::class)->execute(
+                teamId: $this->teamId(),
+                sourceNodeId: $this->edgeSource,
+                targetNodeId: $this->edgeTarget,
+                type: EdgeType::from($this->edgeType),
+            );
+            $this->reset(['edgeSource', 'edgeTarget', 'error']);
+            $this->showAddEdge = false;
+            $this->success = 'Edge added.';
+        } catch (\Throwable $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
+    public function deleteNode(string $id): void
+    {
+        $this->authorize('edit-content');
+
+        $node = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $this->teamId())
+            ->find($id);
+
+        if ($node) {
+            app(DeleteNodeAction::class)->execute($node);
+            $this->success = 'Node deleted.';
+            if ($this->selectedNodeId === $id) {
+                $this->selectedNodeId = null;
+            }
+        }
+    }
+
+    public function selectNode(string $id): void
+    {
+        $this->selectedNodeId = $id;
+    }
+
+    public function closeDrawer(): void
+    {
+        $this->selectedNodeId = null;
+    }
+
+    public function importInventory(): void
+    {
+        $this->authorize('edit-content');
+
+        $markdown = $this->resolveInventoryMarkdown();
+
+        if ($markdown === null) {
+            $this->error = 'No feature-inventory document found to import from.';
+
+            return;
+        }
+
+        $result = app(ImportFromInventoryAction::class)->execute($this->teamId(), $markdown);
+        $this->success = "Imported: {$result['nodes_created']} nodes, {$result['edges_created']} edges.";
+    }
+
+    private function resolveInventoryMarkdown(): ?string
+    {
+        // Cloud: parent repo docs/ sits one level above base_path(); community: base/docs.
+        $candidates = glob(dirname(base_path()).'/docs/feature-inventory-full_*.md') ?: [];
+        $candidates[] = base_path('docs/capabilities.md');
+
+        foreach ($candidates as $path) {
+            if (is_file($path)) {
+                return (string) file_get_contents($path);
+            }
+        }
+
+        return null;
+    }
+
+    public function render()
+    {
+        if (! config('productgraph.enabled')) {
+            return view('livewire.product-graph.product-graph-browser-page', ['disabled' => true]);
+        }
+
+        $teamId = $this->teamId();
+
+        $nodesQuery = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->withCount(['outgoingEdges', 'incomingEdges']);
+
+        if ($this->nodeTypeFilter !== '') {
+            $nodesQuery->where('node_type', $this->nodeTypeFilter);
+        }
+        if ($this->statusFilter !== '') {
+            $nodesQuery->where('status', $this->statusFilter);
+        }
+        if ($this->search !== '') {
+            $nodesQuery->where('name', 'ilike', '%'.$this->search.'%');
+        }
+
+        $nodes = $nodesQuery->orderBy('node_type')->orderBy('name')->get();
+
+        $selected = null;
+        if ($this->selectedNodeId !== null) {
+            $selected = ProductNode::withoutGlobalScopes()
+                ->where('team_id', $teamId)
+                ->find($this->selectedNodeId);
+        }
+
+        return view('livewire.product-graph.product-graph-browser-page', [
+            'disabled' => false,
+            'nodes' => $nodes,
+            'graph' => $this->buildLayout($nodes),
+            'releases' => ProductNode::withoutGlobalScopes()
+                ->where('team_id', $teamId)
+                ->where('node_type', NodeType::Release->value)
+                ->orderByDesc('created_at')
+                ->get(),
+            'selected' => $selected,
+            'selectedEdges' => $selected ? $this->edgesFor($teamId, $selected) : ['out' => collect(), 'in' => collect()],
+            'pendingCount' => ProductGraphChange::withoutGlobalScopes()
+                ->where('team_id', $teamId)->pending()->count(),
+            'allNodes' => $nodes,
+            'nodeTypes' => NodeType::cases(),
+            'statuses' => NodeStatus::cases(),
+            'edgeTypes' => EdgeType::cases(),
+        ]);
+    }
+
+    /**
+     * Server-computed columnar layout (one column per node type). Capped for SVG sanity.
+     *
+     * @param  Collection<int, ProductNode>  $nodes
+     * @return array{nodes: list<array<string, mixed>>, edges: list<array<string, mixed>>}
+     */
+    private function buildLayout($nodes): array
+    {
+        $capped = $nodes->take(80);
+        $columns = array_values(NodeType::values());
+        $colCounts = [];
+        $positions = [];
+        $svgNodes = [];
+
+        foreach ($capped as $node) {
+            $col = array_search($node->node_type->value, $columns, true) ?: 0;
+            $row = $colCounts[$col] ?? 0;
+            $colCounts[$col] = $row + 1;
+
+            $x = $col * 200 + 70;
+            $y = $row * 64 + 50;
+            $positions[$node->id] = [$x, $y];
+
+            $svgNodes[] = [
+                'id' => $node->id,
+                'name' => $node->name,
+                'type' => $node->node_type->value,
+                'status' => $node->status->value,
+                'x' => $x,
+                'y' => $y,
+            ];
+        }
+
+        $edges = ProductEdge::withoutGlobalScopes()
+            ->where('team_id', $this->teamId())
+            ->whereIn('source_node_id', array_keys($positions))
+            ->whereIn('target_node_id', array_keys($positions))
+            ->get();
+
+        $svgEdges = [];
+        foreach ($edges as $edge) {
+            [$x1, $y1] = $positions[$edge->source_node_id];
+            [$x2, $y2] = $positions[$edge->target_node_id];
+            $svgEdges[] = [
+                'x1' => $x1, 'y1' => $y1, 'x2' => $x2, 'y2' => $y2,
+                'type' => $edge->edge_type->value,
+            ];
+        }
+
+        return ['nodes' => $svgNodes, 'edges' => $svgEdges];
+    }
+
+    /**
+     * @return array{out: Collection<int, ProductEdge>, in: Collection<int, ProductEdge>}
+     */
+    private function edgesFor(string $teamId, ProductNode $node): array
+    {
+        return [
+            'out' => ProductEdge::withoutGlobalScopes()->where('team_id', $teamId)
+                ->where('source_node_id', $node->id)->with('target')->get(),
+            'in' => ProductEdge::withoutGlobalScopes()->where('team_id', $teamId)
+                ->where('target_node_id', $node->id)->with('source')->get(),
+        ];
+    }
+}

--- a/app/Livewire/ProductGraph/ProductGraphChangesPage.php
+++ b/app/Livewire/ProductGraph/ProductGraphChangesPage.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Livewire\ProductGraph;
+
+use App\Domain\ProductGraph\Actions\ReviewChangeAction;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+class ProductGraphChangesPage extends Component
+{
+    use AuthorizesRequests;
+
+    #[Url]
+    public string $statusFilter = 'pending';
+
+    public ?string $error = null;
+
+    public ?string $success = null;
+
+    private function teamId(): string
+    {
+        return auth()->user()->current_team_id;
+    }
+
+    public function approve(string $id): void
+    {
+        $this->review($id, true);
+    }
+
+    public function reject(string $id): void
+    {
+        $this->review($id, false);
+    }
+
+    private function review(string $id, bool $approve): void
+    {
+        $this->authorize('edit-content');
+
+        $change = ProductGraphChange::withoutGlobalScopes()
+            ->where('team_id', $this->teamId())
+            ->find($id);
+
+        if (! $change) {
+            $this->error = 'Change not found.';
+
+            return;
+        }
+
+        try {
+            app(ReviewChangeAction::class)->execute(
+                change: $change,
+                approve: $approve,
+                reviewerUserId: auth()->id(),
+            );
+            $this->success = $approve ? 'Change approved and applied.' : 'Change rejected.';
+            $this->error = null;
+        } catch (\Throwable $e) {
+            $this->error = $e->getMessage();
+        }
+    }
+
+    public function render()
+    {
+        if (! config('productgraph.enabled')) {
+            return view('livewire.product-graph.product-graph-changes-page', ['disabled' => true]);
+        }
+
+        $changes = ProductGraphChange::withoutGlobalScopes()
+            ->where('team_id', $this->teamId())
+            ->when($this->statusFilter !== '', fn ($q) => $q->where('status', $this->statusFilter))
+            ->latest()
+            ->limit(100)
+            ->get();
+
+        return view('livewire.product-graph.product-graph-changes-page', [
+            'disabled' => false,
+            'changes' => $changes,
+        ]);
+    }
+}

--- a/app/Livewire/ProductGraph/ProductGraphImpactPage.php
+++ b/app/Livewire/ProductGraph/ProductGraphImpactPage.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Livewire\ProductGraph;
+
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\ProductGraph\Services\ImpactAnalyzer;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+class ProductGraphImpactPage extends Component
+{
+    #[Url]
+    public ?string $nodeId = null;
+
+    public function selectNode(string $id): void
+    {
+        $this->nodeId = $id;
+    }
+
+    private function teamId(): string
+    {
+        return auth()->user()->current_team_id;
+    }
+
+    public function render()
+    {
+        if (! config('productgraph.enabled')) {
+            return view('livewire.product-graph.product-graph-impact-page', ['disabled' => true]);
+        }
+
+        $teamId = $this->teamId();
+
+        $nodes = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->orderBy('node_type')->orderBy('name')
+            ->get();
+
+        $selected = null;
+        $impact = [];
+
+        if ($this->nodeId !== null) {
+            $selected = ProductNode::withoutGlobalScopes()
+                ->where('team_id', $teamId)
+                ->find($this->nodeId);
+
+            if ($selected) {
+                $impact = app(ImpactAnalyzer::class)->blastRadius($selected);
+            }
+        }
+
+        return view('livewire.product-graph.product-graph-impact-page', [
+            'disabled' => false,
+            'nodes' => $nodes,
+            'selected' => $selected,
+            'impact' => collect($impact)->groupBy('depth'),
+        ]);
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -381,6 +381,12 @@ use App\Mcp\Tools\Phoenix\PhoenixProjectListTool;
 use App\Mcp\Tools\Phoenix\PhoenixSpanSearchTool;
 use App\Mcp\Tools\Phoenix\PhoenixTraceGetTool;
 use App\Mcp\Tools\Phoenix\PhoenixTraceListTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphChangesListTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphImpactTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphNodeTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphProposeTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphQueryTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphReviewTool;
 use App\Mcp\Tools\Profile\ProfileConnectedAccountsTool;
 use App\Mcp\Tools\Profile\ProfileGetTool;
 use App\Mcp\Tools\Profile\ProfileTwoFactorStatusTool;
@@ -1149,6 +1155,14 @@ class AgentFleetServer extends Server
         KgCommunitySearchTool::class,
         KgSuggestMergesTool::class,
         KgMergeEntitiesTool::class,
+
+        // ProductGraph (6)
+        ProductGraphQueryTool::class,
+        ProductGraphNodeTool::class,
+        ProductGraphImpactTool::class,
+        ProductGraphChangesListTool::class,
+        ProductGraphProposeTool::class,
+        ProductGraphReviewTool::class,
 
         // Budget (8)
         BudgetSummaryTool::class,

--- a/app/Mcp/Tools/ProductGraph/ProductGraphChangesListTool.php
+++ b/app/Mcp/Tools/ProductGraph/ProductGraphChangesListTool.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Mcp\Tools\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class ProductGraphChangesListTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'product_graph_changes_list';
+
+    protected string $description = 'List proposed product-graph changes (the human review queue). Defaults to pending proposals awaiting approval.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'status' => $schema->string()
+                ->description('Filter by status: pending | approved | rejected | applied (default pending)'),
+            'limit' => $schema->integer()
+                ->description('Max changes to return (default 50, max 200)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $validated = $request->validate([
+            'status' => 'nullable|string|in:pending,approved,rejected,applied',
+            'limit' => 'nullable|integer|min:1|max:200',
+        ]);
+
+        $changes = ProductGraphChange::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->where('status', $validated['status'] ?? ChangeStatus::Pending->value)
+            ->latest()
+            ->limit($validated['limit'] ?? 50)
+            ->get();
+
+        return Response::text(json_encode([
+            'count' => $changes->count(),
+            'changes' => $changes->map(fn (ProductGraphChange $c) => [
+                'id' => $c->id,
+                'change_type' => $c->change_type->value,
+                'target_id' => $c->target_id,
+                'payload' => $c->payload,
+                'status' => $c->status->value,
+                'proposed_by' => $c->proposed_by_label,
+                'created_at' => $c->created_at?->toIso8601String(),
+            ])->values()->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/ProductGraph/ProductGraphImpactTool.php
+++ b/app/Mcp/Tools/ProductGraph/ProductGraphImpactTool.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Mcp\Tools\ProductGraph;
+
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\ProductGraph\Services\ImpactAnalyzer;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class ProductGraphImpactTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'product_graph_impact';
+
+    protected string $description = 'Blast-radius analysis: given a node, return every node potentially affected if it changes, with depth and the edge type each impact propagates through. Answers "what breaks if this changes".';
+
+    public function __construct(private readonly ImpactAnalyzer $analyzer) {}
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'node_id' => $schema->string()
+                ->description('UUID of the node to analyse')
+                ->required(),
+            'max_depth' => $schema->integer()
+                ->description('Maximum propagation depth (default from config, typically 5)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $validated = $request->validate([
+            'node_id' => 'required|string',
+            'max_depth' => 'nullable|integer|min:1|max:20',
+        ]);
+
+        $node = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['node_id']);
+
+        if (! $node) {
+            return $this->notFoundError('product node', $validated['node_id']);
+        }
+
+        $impact = $this->analyzer->blastRadius($node, $validated['max_depth'] ?? null);
+
+        return Response::text(json_encode([
+            'node_id' => $node->id,
+            'node_name' => $node->name,
+            'affected_count' => count($impact),
+            'affected' => $impact,
+        ]));
+    }
+}

--- a/app/Mcp/Tools/ProductGraph/ProductGraphNodeTool.php
+++ b/app/Mcp/Tools/ProductGraph/ProductGraphNodeTool.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Mcp\Tools\ProductGraph;
+
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class ProductGraphNodeTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'product_graph_node';
+
+    protected string $description = 'Get one product-graph node with its full upstream and downstream edges (what it connects to). Answers "what does this connect to".';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'node_id' => $schema->string()
+                ->description('UUID of the node to fetch')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $validated = $request->validate([
+            'node_id' => 'required|string',
+        ]);
+
+        $node = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['node_id']);
+
+        if (! $node) {
+            return $this->notFoundError('product node', $validated['node_id']);
+        }
+
+        $outgoing = ProductEdge::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->where('source_node_id', $node->id)
+            ->with('target')
+            ->get();
+
+        $incoming = ProductEdge::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->where('target_node_id', $node->id)
+            ->with('source')
+            ->get();
+
+        return Response::text(json_encode([
+            'id' => $node->id,
+            'name' => $node->name,
+            'node_type' => $node->node_type->value,
+            'status' => $node->status->value,
+            'description' => $node->description,
+            'tags' => $node->tags,
+            'external_ref' => $node->external_ref,
+            'outgoing_edges' => $outgoing->map(fn (ProductEdge $e) => [
+                'edge_type' => $e->edge_type->value,
+                'target_id' => $e->target_node_id,
+                'target_name' => $e->target?->name,
+                'description' => $e->description,
+            ])->values()->toArray(),
+            'incoming_edges' => $incoming->map(fn (ProductEdge $e) => [
+                'edge_type' => $e->edge_type->value,
+                'source_id' => $e->source_node_id,
+                'source_name' => $e->source?->name,
+                'description' => $e->description,
+            ])->values()->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/ProductGraph/ProductGraphProposeTool.php
+++ b/app/Mcp/Tools/ProductGraph/ProductGraphProposeTool.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Mcp\Tools\ProductGraph;
+
+use App\Domain\ProductGraph\Actions\ProposeChangeAction;
+use App\Domain\ProductGraph\Enums\ChangeType;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use InvalidArgumentException;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+/**
+ * Agents propose graph changes through this tool — the change enters a human
+ * review queue and does NOT mutate the graph until a human approves it.
+ */
+#[IsDestructive]
+#[AssistantTool('write')]
+class ProductGraphProposeTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'product_graph_propose';
+
+    protected string $description = 'Propose a change to the product graph (create/update/delete a node or edge). The proposal lands in a human review queue and is NOT applied until approved. Use this to keep the graph current as you build.';
+
+    public function __construct(private readonly ProposeChangeAction $action) {}
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'change_type' => $schema->string()
+                ->description('One of: create_node | update_node | delete_node | create_edge | delete_edge')
+                ->required(),
+            'target_id' => $schema->string()
+                ->description('UUID of the existing node/edge (required for update_node, delete_node, delete_edge)'),
+            'payload' => $schema->object()
+                ->description('Proposed state. create_node: {node_type,name,status?,description?,tags?,external_ref?}. create_edge: {source_node_id,target_node_id,edge_type,description?}. update_node: changed fields.'),
+            'proposed_by_label' => $schema->string()
+                ->description('Who is proposing, e.g. "agent:claude-code" (default "agent")'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $validated = $request->validate([
+            'change_type' => 'required|string|in:'.implode(',', ChangeType::values()),
+            'target_id' => 'nullable|string',
+            'payload' => 'nullable|array',
+            'proposed_by_label' => 'nullable|string|max:120',
+        ]);
+
+        try {
+            $change = $this->action->execute(
+                teamId: $teamId,
+                type: ChangeType::from($validated['change_type']),
+                targetId: $validated['target_id'] ?? null,
+                payload: $validated['payload'] ?? [],
+                proposedByLabel: $validated['proposed_by_label'] ?? 'agent',
+            );
+        } catch (InvalidArgumentException $e) {
+            return $this->invalidArgumentError($e->getMessage());
+        }
+
+        return Response::text(json_encode([
+            'id' => $change->id,
+            'status' => $change->status->value,
+            'change_type' => $change->change_type->value,
+            'message' => 'Proposal queued for human review. The graph is unchanged until approved.',
+        ]));
+    }
+}

--- a/app/Mcp/Tools/ProductGraph/ProductGraphQueryTool.php
+++ b/app/Mcp/Tools/ProductGraph/ProductGraphQueryTool.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Mcp\Tools\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\NodeStatus;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class ProductGraphQueryTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'product_graph_query';
+
+    protected string $description = 'Search the product graph: list typed nodes (features, shared components, agent skills, standards, releases, etc.) filtered by type, status, tag or name. Returns each node with its inbound/outbound edge counts. Answers "where does this fit / what exists".';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'node_type' => $schema->string()
+                ->description('Filter by node type: product | feature | sub_feature | shared_component | agent_skill | standard | persona | tech_component | release'),
+            'status' => $schema->string()
+                ->description('Filter by status: planned | in_progress | implemented | deprecated'),
+            'tag' => $schema->string()
+                ->description('Filter to nodes carrying this tag'),
+            'search' => $schema->string()
+                ->description('Case-insensitive substring match on node name'),
+            'limit' => $schema->integer()
+                ->description('Max nodes to return (default 50, max 200)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $validated = $request->validate([
+            'node_type' => 'nullable|string|in:'.implode(',', NodeType::values()),
+            'status' => 'nullable|string|in:'.implode(',', NodeStatus::values()),
+            'tag' => 'nullable|string|max:80',
+            'search' => 'nullable|string|max:255',
+            'limit' => 'nullable|integer|min:1|max:200',
+        ]);
+
+        $query = ProductNode::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->withCount(['outgoingEdges', 'incomingEdges']);
+
+        if (! empty($validated['node_type'])) {
+            $query->where('node_type', $validated['node_type']);
+        }
+
+        if (! empty($validated['status'])) {
+            $query->where('status', $validated['status']);
+        }
+
+        if (! empty($validated['search'])) {
+            $query->where('name', 'ilike', '%'.$validated['search'].'%');
+        }
+
+        if (! empty($validated['tag'])) {
+            $query->whereJsonContains('tags', $validated['tag']);
+        }
+
+        $nodes = $query->orderBy('node_type')->orderBy('name')
+            ->limit($validated['limit'] ?? 50)
+            ->get();
+
+        return Response::text(json_encode([
+            'count' => $nodes->count(),
+            'nodes' => $nodes->map(fn (ProductNode $n) => [
+                'id' => $n->id,
+                'name' => $n->name,
+                'node_type' => $n->node_type->value,
+                'status' => $n->status->value,
+                'description' => $n->description,
+                'tags' => $n->tags,
+                'external_ref' => $n->external_ref,
+                'depends_on_count' => $n->outgoing_edges_count,
+                'depended_by_count' => $n->incoming_edges_count,
+            ])->values()->toArray(),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/ProductGraph/ProductGraphReviewTool.php
+++ b/app/Mcp/Tools/ProductGraph/ProductGraphReviewTool.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Mcp\Tools\ProductGraph;
+
+use App\Domain\ProductGraph\Actions\ReviewChangeAction;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+use RuntimeException;
+
+/**
+ * Approve or reject a pending product-graph proposal. Approval applies the change.
+ */
+#[IsDestructive]
+#[AssistantTool('write')]
+class ProductGraphReviewTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'product_graph_review';
+
+    protected string $description = 'Approve or reject a pending product-graph proposal. Approving applies the change to the graph; rejecting discards it. Reserved for human/admin decisions.';
+
+    public function __construct(private readonly ReviewChangeAction $action) {}
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'change_id' => $schema->string()
+                ->description('UUID of the pending change to review')
+                ->required(),
+            'decision' => $schema->string()
+                ->description('approve | reject')
+                ->required(),
+            'note' => $schema->string()
+                ->description('Optional review note'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $validated = $request->validate([
+            'change_id' => 'required|string',
+            'decision' => 'required|string|in:approve,reject',
+            'note' => 'nullable|string|max:255',
+        ]);
+
+        $change = ProductGraphChange::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->find($validated['change_id']);
+
+        if (! $change) {
+            return $this->notFoundError('product graph change', $validated['change_id']);
+        }
+
+        try {
+            $change = $this->action->execute(
+                change: $change,
+                approve: $validated['decision'] === 'approve',
+                reviewerUserId: null,
+                note: $validated['note'] ?? null,
+            );
+        } catch (RuntimeException $e) {
+            return $this->failedPreconditionError($e->getMessage());
+        }
+
+        return Response::text(json_encode([
+            'id' => $change->id,
+            'status' => $change->status->value,
+            'applied_ref_id' => $change->applied_ref_id,
+        ]));
+    }
+}

--- a/config/productgraph.php
+++ b/config/productgraph.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    /*
+     | Master switch for the ProductGraph capability (UI routes + MCP tools
+     | still load, but pages short-circuit to a disabled notice and seeding
+     | is gated). Flip via PRODUCT_GRAPH_ENABLED=true.
+     */
+    'enabled' => (bool) env('PRODUCT_GRAPH_ENABLED', false),
+
+    /*
+     | Maximum traversal depth for blast-radius / impact analysis.
+     */
+    'max_impact_depth' => (int) env('PRODUCT_GRAPH_MAX_IMPACT_DEPTH', 5),
+];

--- a/database/factories/Domain/ProductGraph/ProductEdgeFactory.php
+++ b/database/factories/Domain/ProductGraph/ProductEdgeFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories\Domain\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProductEdgeFactory extends Factory
+{
+    protected $model = ProductEdge::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'source_node_id' => fn (array $attributes) => ProductNode::factory()->create(['team_id' => $attributes['team_id']]),
+            'target_node_id' => fn (array $attributes) => ProductNode::factory()->create(['team_id' => $attributes['team_id']]),
+            'edge_type' => EdgeType::DependsOn,
+            'description' => null,
+            'metadata' => [],
+        ];
+    }
+
+    public function edgeType(EdgeType $type): static
+    {
+        return $this->state(['edge_type' => $type]);
+    }
+}

--- a/database/factories/Domain/ProductGraph/ProductGraphChangeFactory.php
+++ b/database/factories/Domain/ProductGraph/ProductGraphChangeFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories\Domain\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Enums\ChangeType;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProductGraphChangeFactory extends Factory
+{
+    protected $model = ProductGraphChange::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'change_type' => ChangeType::CreateNode,
+            'target_id' => null,
+            'payload' => [
+                'node_type' => 'feature',
+                'name' => fake()->unique()->words(2, true),
+                'status' => 'planned',
+            ],
+            'status' => ChangeStatus::Pending,
+            'proposed_by_label' => 'agent:test',
+        ];
+    }
+}

--- a/database/factories/Domain/ProductGraph/ProductNodeFactory.php
+++ b/database/factories/Domain/ProductGraph/ProductNodeFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories\Domain\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\NodeStatus;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class ProductNodeFactory extends Factory
+{
+    protected $model = ProductNode::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'team_id' => Team::factory(),
+            'node_type' => NodeType::Feature,
+            'name' => Str::title($name),
+            'slug' => Str::slug($name),
+            'status' => NodeStatus::Planned,
+            'description' => fake()->sentence(),
+            'tags' => [],
+            'external_ref' => null,
+            'metadata' => [],
+        ];
+    }
+
+    public function type(NodeType $type): static
+    {
+        return $this->state(['node_type' => $type]);
+    }
+
+    public function status(NodeStatus $status): static
+    {
+        return $this->state(['status' => $status]);
+    }
+}

--- a/database/migrations/2026_06_21_100000_create_product_graph_tables.php
+++ b/database/migrations/2026_06_21_100000_create_product_graph_tables.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_nodes', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+            $table->string('node_type');
+            $table->string('name');
+            $table->string('slug');
+            $table->string('status')->default('planned');
+            $table->text('description')->nullable();
+            $table->jsonb('tags')->default('[]');
+            $table->string('external_ref')->nullable();
+            $table->jsonb('metadata')->default('{}');
+            $table->timestamps();
+
+            $table->unique(['team_id', 'node_type', 'slug']);
+            $table->index(['team_id', 'node_type']);
+            $table->index(['team_id', 'status']);
+        });
+
+        Schema::create('product_edges', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('source_node_id')->constrained('product_nodes')->cascadeOnDelete();
+            $table->foreignUuid('target_node_id')->constrained('product_nodes')->cascadeOnDelete();
+            $table->string('edge_type');
+            $table->string('description')->nullable();
+            $table->jsonb('metadata')->default('{}');
+            $table->timestamps();
+
+            $table->unique(['team_id', 'source_node_id', 'target_node_id', 'edge_type'], 'product_edges_unique');
+            $table->index(['team_id', 'source_node_id']);
+            $table->index(['team_id', 'target_node_id']);
+        });
+
+        Schema::create('product_graph_changes', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+            $table->string('change_type');
+            $table->uuid('target_id')->nullable();
+            $table->jsonb('payload')->default('{}');
+            $table->string('status')->default('pending');
+            $table->string('proposed_by_label')->default('user');
+            $table->foreignUuid('proposed_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignUuid('reviewed_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('review_note')->nullable();
+            $table->uuid('applied_ref_id')->nullable();
+            $table->timestamps();
+
+            $table->index(['team_id', 'status']);
+        });
+
+        // PostgreSQL-only GIN index on tags for @>/? operators. SQLite (tests) skips it.
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('CREATE INDEX product_nodes_tags_gin_idx ON product_nodes USING gin (tags)');
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_graph_changes');
+        Schema::dropIfExists('product_edges');
+        Schema::dropIfExists('product_nodes');
+    }
+};

--- a/resources/views/components/sidebar.blade.php
+++ b/resources/views/components/sidebar.blade.php
@@ -1,7 +1,7 @@
 @php
     $activeRailGroup = match(true) {
         request()->routeIs('dashboard', 'projects.*', 'experiments.*', 'agents.*', 'agent-sessions.*', 'crews.*', 'approvals.*', 'chatbots.*') => 'fleet',
-        request()->routeIs('workflows.*', 'skills.*', 'memory.*', 'knowledge.*', 'knowledge-graph.*', 'evaluation.*', 'evaluations.*', 'triggers.*', 'evolution.*', 'websites.*', 'reasoning-bank.*', 'error-modes.*', 'testing.*') => 'build',
+        request()->routeIs('workflows.*', 'skills.*', 'memory.*', 'knowledge.*', 'knowledge-graph.*', 'product-graph.*', 'evaluation.*', 'evaluations.*', 'triggers.*', 'evolution.*', 'websites.*', 'reasoning-bank.*', 'error-modes.*', 'testing.*') => 'build',
         request()->routeIs('signals.*', 'bug-reports.*', 'contacts.*', 'imports.*', 'email.*', 'outbound.*', 'audiences.*', 'broadcasts.*', 'health', 'audit', 'audit-console.*', 'metrics.*') => 'monitor',
         request()->routeIs('app.marketplace.*', 'marketplace.*', 'plugins', 'telegram.*') => 'marketplace',
         request()->routeIs('tools.*', 'credentials.*', 'releases.*', 'integrations.*', 'git-repositories.*', 'team.*', 'settings', 'settings.git-sync', 'profile', 'notifications.*') => 'settings',
@@ -147,6 +147,7 @@
                 <x-sidebar-link href="{{ route('knowledge.index') }}" :active="request()->routeIs('knowledge.*') && !request()->routeIs('knowledge-graph.*')" icon="book-open">Knowledge</x-sidebar-link>
                 <x-sidebar-link href="{{ route('knowledge-graph.index') }}" :active="request()->routeIs('knowledge-graph.index')" icon="share">Knowledge Graph</x-sidebar-link>
                 <x-sidebar-link href="{{ route('knowledge-graph.communities') }}" :active="request()->routeIs('knowledge-graph.communities')" icon="share">KG Communities</x-sidebar-link>
+                <x-sidebar-link href="{{ route('product-graph.index') }}" :active="request()->routeIs('product-graph.*')" icon="sitemap">Product Graph</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluation.index') }}" :active="request()->routeIs('evaluation.index')" icon="scale">Evaluation</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluation.drift') }}" :active="request()->routeIs('evaluation.drift')" icon="scale">Drift Signals</x-sidebar-link>
                 <x-sidebar-link href="{{ route('evaluation.monitor') }}" :active="request()->routeIs('evaluation.monitor')" icon="chart-bar">Eval Monitor</x-sidebar-link>

--- a/resources/views/livewire/product-graph/product-graph-browser-page.blade.php
+++ b/resources/views/livewire/product-graph/product-graph-browser-page.blade.php
@@ -1,0 +1,244 @@
+<div class="space-y-6">
+    @if ($disabled)
+        <div class="rounded-lg border border-amber-300 bg-amber-50 p-6 text-amber-800">
+            <h2 class="text-lg font-semibold">Product Graph is disabled</h2>
+            <p class="mt-1 text-sm">Set <code>PRODUCT_GRAPH_ENABLED=true</code> to enable the product graph.</p>
+        </div>
+    @else
+        <div class="flex items-center justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-gray-900">Product Graph</h1>
+                <p class="text-sm text-gray-500">The map of what you're building and how it connects.</p>
+            </div>
+            <div class="flex items-center gap-2">
+                <a href="{{ route('product-graph.changes') }}"
+                   class="relative rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                    Review queue
+                    @if ($pendingCount > 0)
+                        <span class="ml-1 rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">{{ $pendingCount }}</span>
+                    @endif
+                </a>
+                <a href="{{ route('product-graph.impact') }}"
+                   class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50">Blast radius</a>
+                @can('edit-content')
+                    <button wire:click="importInventory" wire:loading.attr="disabled"
+                            class="rounded-lg border border-violet-300 bg-violet-50 px-3 py-1.5 text-sm font-medium text-violet-700 hover:bg-violet-100">
+                        Import from inventory
+                    </button>
+                    <button wire:click="$toggle('showAddNode')"
+                            class="rounded-lg bg-primary-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-700">Add node</button>
+                @endcan
+            </div>
+        </div>
+
+        @if ($success)
+            <div class="rounded-lg bg-emerald-50 px-4 py-2 text-sm text-emerald-800">{{ $success }}</div>
+        @endif
+        @if ($error)
+            <div class="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-700">{{ $error }}</div>
+        @endif
+
+        @can('edit-content')
+            @if ($showAddNode)
+                <div class="grid gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 md:grid-cols-2">
+                    <x-form-input wire:model="newName" label="Name" />
+                    <x-form-select wire:model="newNodeType" label="Type">
+                        @foreach ($nodeTypes as $t)
+                            <option value="{{ $t->value }}">{{ $t->label() }}</option>
+                        @endforeach
+                    </x-form-select>
+                    <x-form-select wire:model="newStatus" label="Status">
+                        @foreach ($statuses as $s)
+                            <option value="{{ $s->value }}">{{ $s->label() }}</option>
+                        @endforeach
+                    </x-form-select>
+                    <x-form-input wire:model="newTags" label="Tags (comma-separated)" />
+                    <div class="md:col-span-2">
+                        <x-form-textarea wire:model="newDescription" label="Description" />
+                    </div>
+                    <div class="md:col-span-2 flex gap-2">
+                        <button wire:click="addNode" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700">Save node</button>
+                        <button wire:click="$set('showAddNode', false)" class="rounded-lg border border-gray-300 px-4 py-2 text-sm">Cancel</button>
+                        <button wire:click="$toggle('showAddEdge')" class="ml-auto rounded-lg border border-gray-300 px-4 py-2 text-sm">Add edge…</button>
+                    </div>
+                    @if ($showAddEdge)
+                        <div class="md:col-span-2 grid gap-3 rounded-lg border border-gray-200 bg-white p-3 md:grid-cols-3">
+                            <x-form-select wire:model="edgeSource" label="Source">
+                                <option value="">—</option>
+                                @foreach ($allNodes as $n)
+                                    <option value="{{ $n->id }}">{{ $n->name }}</option>
+                                @endforeach
+                            </x-form-select>
+                            <x-form-select wire:model="edgeType" label="Relationship">
+                                @foreach ($edgeTypes as $e)
+                                    <option value="{{ $e->value }}">{{ $e->label() }}</option>
+                                @endforeach
+                            </x-form-select>
+                            <x-form-select wire:model="edgeTarget" label="Target">
+                                <option value="">—</option>
+                                @foreach ($allNodes as $n)
+                                    <option value="{{ $n->id }}">{{ $n->name }}</option>
+                                @endforeach
+                            </x-form-select>
+                            <div class="md:col-span-3">
+                                <button wire:click="addEdge" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700">Save edge</button>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            @endif
+        @endcan
+
+        {{-- Filters + tabs --}}
+        <div class="flex flex-wrap items-center gap-2">
+            <div class="flex rounded-lg border border-gray-200 p-0.5 text-sm">
+                @foreach (['map' => 'Map', 'list' => 'List', 'releases' => 'Releases'] as $key => $label)
+                    <button wire:click="$set('tab', '{{ $key }}')"
+                            class="rounded-md px-3 py-1 {{ $tab === $key ? 'bg-primary-600 text-white' : 'text-gray-600' }}">{{ $label }}</button>
+                @endforeach
+            </div>
+            <input wire:model.live.debounce.300ms="search" placeholder="Search name…"
+                   class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm" />
+            <select wire:model.live="nodeTypeFilter" class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm">
+                <option value="">All types</option>
+                @foreach ($nodeTypes as $t)
+                    <option value="{{ $t->value }}">{{ $t->label() }}</option>
+                @endforeach
+            </select>
+            <select wire:model.live="statusFilter" class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm">
+                <option value="">All statuses</option>
+                @foreach ($statuses as $s)
+                    <option value="{{ $s->value }}">{{ $s->label() }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div class="grid gap-4 {{ $selected ? 'lg:grid-cols-3' : '' }}">
+            <div class="{{ $selected ? 'lg:col-span-2' : '' }}">
+                @if ($tab === 'map')
+                    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white"
+                         x-data="{ scale: 1, tx: 0, ty: 0, drag: false, sx: 0, sy: 0 }">
+                        <div class="flex items-center gap-2 border-b border-gray-100 px-3 py-1.5 text-xs text-gray-500">
+                            <button @click="scale = Math.min(2, scale + 0.1)" class="rounded border px-2">+</button>
+                            <button @click="scale = Math.max(0.4, scale - 0.1)" class="rounded border px-2">−</button>
+                            <button @click="scale = 1; tx = 0; ty = 0" class="rounded border px-2">reset</button>
+                            <span>drag to pan · scroll node count: {{ count($graph['nodes']) }}</span>
+                        </div>
+                        <svg class="h-[60vh] w-full cursor-move select-none"
+                             @mousedown="drag = true; sx = $event.clientX - tx; sy = $event.clientY - ty"
+                             @mousemove="drag && (tx = $event.clientX - sx, ty = $event.clientY - sy)"
+                             @mouseup="drag = false" @mouseleave="drag = false">
+                            <g :transform="`translate(${tx},${ty}) scale(${scale})`">
+                                @foreach ($graph['edges'] as $e)
+                                    <line x1="{{ $e['x1'] }}" y1="{{ $e['y1'] }}" x2="{{ $e['x2'] }}" y2="{{ $e['y2'] }}"
+                                          stroke="#cbd5e1" stroke-width="1" />
+                                @endforeach
+                                @foreach ($graph['nodes'] as $n)
+                                    <g wire:click="selectNode('{{ $n['id'] }}')" class="cursor-pointer">
+                                        <rect x="{{ $n['x'] - 60 }}" y="{{ $n['y'] - 14 }}" width="120" height="28" rx="6"
+                                              fill="{{ $selected && $selected->id === $n['id'] ? '#4f46e5' : '#fff' }}"
+                                              stroke="#94a3b8" stroke-width="1" />
+                                        <text x="{{ $n['x'] }}" y="{{ $n['y'] + 4 }}" text-anchor="middle"
+                                              font-size="10" fill="{{ $selected && $selected->id === $n['id'] ? '#fff' : '#334155' }}">
+                                            {{ \Illuminate\Support\Str::limit($n['name'], 18) }}
+                                        </text>
+                                    </g>
+                                @endforeach
+                            </g>
+                        </svg>
+                    </div>
+                @elseif ($tab === 'releases')
+                    <div class="space-y-2">
+                        @forelse ($releases as $r)
+                            <div class="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2">
+                                <div>
+                                    <span class="font-medium text-gray-900">{{ $r->name }}</span>
+                                    <span class="ml-2 rounded px-2 py-0.5 text-xs {{ $r->status->color() }}">{{ $r->status->label() }}</span>
+                                </div>
+                                <span class="text-xs text-gray-400">{{ $r->created_at?->format('Y-m-d') }}</span>
+                            </div>
+                        @empty
+                            <p class="text-sm text-gray-500">No release nodes yet.</p>
+                        @endforelse
+                    </div>
+                @else
+                    <div class="overflow-hidden rounded-lg border border-gray-200">
+                        <table class="min-w-full divide-y divide-gray-200 text-sm">
+                            <thead class="bg-gray-50 text-left text-xs uppercase text-gray-500">
+                                <tr>
+                                    <th class="px-4 py-2">Name</th>
+                                    <th class="px-4 py-2">Type</th>
+                                    <th class="px-4 py-2">Status</th>
+                                    <th class="px-4 py-2">Edges</th>
+                                    <th class="px-4 py-2"></th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-gray-100 bg-white">
+                                @forelse ($nodes as $n)
+                                    <tr class="hover:bg-gray-50">
+                                        <td class="px-4 py-2">
+                                            <button wire:click="selectNode('{{ $n->id }}')" class="font-medium text-primary-700 hover:underline">{{ $n->name }}</button>
+                                        </td>
+                                        <td class="px-4 py-2 text-gray-600">{{ $n->node_type->label() }}</td>
+                                        <td class="px-4 py-2"><span class="rounded px-2 py-0.5 text-xs {{ $n->status->color() }}">{{ $n->status->label() }}</span></td>
+                                        <td class="px-4 py-2 text-gray-500">{{ $n->outgoing_edges_count }}↑ / {{ $n->incoming_edges_count }}↓</td>
+                                        <td class="px-4 py-2 text-right">
+                                            @can('edit-content')
+                                                <button wire:click="deleteNode('{{ $n->id }}')" wire:confirm="Delete this node and its edges?" class="text-xs text-red-600 hover:underline">delete</button>
+                                            @endcan
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr><td colspan="5" class="px-4 py-6 text-center text-gray-400">No nodes. Add one or import from inventory.</td></tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
+            </div>
+
+            @if ($selected)
+                <div class="rounded-lg border border-gray-200 bg-white p-4">
+                    <div class="flex items-start justify-between">
+                        <div>
+                            <h3 class="font-semibold text-gray-900">{{ $selected->name }}</h3>
+                            <p class="text-xs text-gray-500">{{ $selected->node_type->label() }} · <span class="rounded px-1.5 py-0.5 {{ $selected->status->color() }}">{{ $selected->status->label() }}</span></p>
+                        </div>
+                        <button wire:click="closeDrawer" class="text-gray-400 hover:text-gray-600">✕</button>
+                    </div>
+                    @if ($selected->description)
+                        <p class="mt-2 text-sm text-gray-600">{{ $selected->description }}</p>
+                    @endif
+                    @if (! empty($selected->tags))
+                        <div class="mt-2 flex flex-wrap gap-1">
+                            @foreach ($selected->tags as $tag)
+                                <span class="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600">{{ $tag }}</span>
+                            @endforeach
+                        </div>
+                    @endif
+                    <a href="{{ route('product-graph.impact', ['nodeId' => $selected->id]) }}"
+                       class="mt-3 inline-block text-xs font-medium text-primary-700 hover:underline">View blast radius →</a>
+
+                    <div class="mt-4 space-y-3 text-sm">
+                        <div>
+                            <p class="text-xs font-semibold uppercase text-gray-400">Depends on / connects to</p>
+                            @forelse ($selectedEdges['out'] as $e)
+                                <p class="text-gray-700">{{ $e->edge_type->label() }} → <span class="font-medium">{{ $e->target?->name }}</span></p>
+                            @empty
+                                <p class="text-gray-400">—</p>
+                            @endforelse
+                        </div>
+                        <div>
+                            <p class="text-xs font-semibold uppercase text-gray-400">Depended on by</p>
+                            @forelse ($selectedEdges['in'] as $e)
+                                <p class="text-gray-700"><span class="font-medium">{{ $e->source?->name }}</span> {{ $e->edge_type->label() }} this</p>
+                            @empty
+                                <p class="text-gray-400">—</p>
+                            @endforelse
+                        </div>
+                    </div>
+                </div>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/product-graph/product-graph-changes-page.blade.php
+++ b/resources/views/livewire/product-graph/product-graph-changes-page.blade.php
@@ -1,0 +1,62 @@
+<div class="space-y-6">
+    @if ($disabled)
+        <div class="rounded-lg border border-amber-300 bg-amber-50 p-6 text-amber-800">
+            <h2 class="text-lg font-semibold">Product Graph is disabled</h2>
+            <p class="mt-1 text-sm">Set <code>PRODUCT_GRAPH_ENABLED=true</code> to enable.</p>
+        </div>
+    @else
+        <div class="flex items-center justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-gray-900">Review Queue</h1>
+                <p class="text-sm text-gray-500">Agents propose. Humans decide.</p>
+            </div>
+            <a href="{{ route('product-graph.index') }}" class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50">← Back to graph</a>
+        </div>
+
+        @if ($success)
+            <div class="rounded-lg bg-emerald-50 px-4 py-2 text-sm text-emerald-800">{{ $success }}</div>
+        @endif
+        @if ($error)
+            <div class="rounded-lg bg-red-50 px-4 py-2 text-sm text-red-700">{{ $error }}</div>
+        @endif
+
+        <select wire:model.live="statusFilter" class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm">
+            <option value="pending">Pending</option>
+            <option value="applied">Applied</option>
+            <option value="rejected">Rejected</option>
+            <option value="">All</option>
+        </select>
+
+        <div class="space-y-2">
+            @forelse ($changes as $change)
+                <div class="rounded-lg border border-gray-200 bg-white p-4">
+                    <div class="flex items-start justify-between gap-4">
+                        <div class="min-w-0">
+                            <div class="flex items-center gap-2">
+                                <span class="rounded px-2 py-0.5 text-xs font-medium {{ $change->status->color() }}">{{ $change->status->label() }}</span>
+                                <span class="font-medium text-gray-900">{{ $change->change_type->label() }}</span>
+                                <span class="text-xs text-gray-400">by {{ $change->proposed_by_label }}</span>
+                            </div>
+                            <pre class="mt-2 overflow-x-auto rounded bg-gray-50 p-2 text-xs text-gray-600">{{ json_encode($change->payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                            @if ($change->review_note)
+                                <p class="mt-1 text-xs text-gray-500">Note: {{ $change->review_note }}</p>
+                            @endif
+                        </div>
+                        @if ($change->status === \App\Domain\ProductGraph\Enums\ChangeStatus::Pending)
+                            @can('edit-content')
+                                <div class="flex flex-shrink-0 gap-2">
+                                    <button wire:click="approve('{{ $change->id }}')"
+                                            class="rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700">Approve</button>
+                                    <button wire:click="reject('{{ $change->id }}')"
+                                            class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50">Reject</button>
+                                </div>
+                            @endcan
+                        @endif
+                    </div>
+                </div>
+            @empty
+                <p class="text-sm text-gray-500">No proposals.</p>
+            @endforelse
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/product-graph/product-graph-impact-page.blade.php
+++ b/resources/views/livewire/product-graph/product-graph-impact-page.blade.php
@@ -1,0 +1,51 @@
+<div class="space-y-6">
+    @if ($disabled)
+        <div class="rounded-lg border border-amber-300 bg-amber-50 p-6 text-amber-800">
+            <h2 class="text-lg font-semibold">Product Graph is disabled</h2>
+            <p class="mt-1 text-sm">Set <code>PRODUCT_GRAPH_ENABLED=true</code> to enable.</p>
+        </div>
+    @else
+        <div class="flex items-center justify-between">
+            <div>
+                <h1 class="text-2xl font-semibold text-gray-900">Blast Radius</h1>
+                <p class="text-sm text-gray-500">What is affected if a node changes.</p>
+            </div>
+            <a href="{{ route('product-graph.index') }}" class="rounded-lg border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50">← Back to graph</a>
+        </div>
+
+        <div class="max-w-md">
+            <select wire:model.live="nodeId" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm">
+                <option value="">Select a node…</option>
+                @foreach ($nodes as $n)
+                    <option value="{{ $n->id }}">{{ $n->name }} ({{ $n->node_type->label() }})</option>
+                @endforeach
+            </select>
+        </div>
+
+        @if ($selected)
+            <div class="rounded-lg border border-gray-200 bg-white p-5">
+                <p class="text-sm text-gray-500">If <span class="font-semibold text-gray-900">{{ $selected->name }}</span> changes, the following are potentially affected:</p>
+
+                @if ($impact->isEmpty())
+                    <p class="mt-4 text-sm text-gray-400">Nothing depends on this node — changing it is low-risk.</p>
+                @else
+                    <div class="mt-4 space-y-4">
+                        @foreach ($impact as $depth => $rows)
+                            <div>
+                                <p class="mb-1 text-xs font-semibold uppercase text-gray-400">Depth {{ $depth }} — {{ count($rows) }} affected</p>
+                                <div class="flex flex-wrap gap-2">
+                                    @foreach ($rows as $row)
+                                        <span class="rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-sm text-gray-700">
+                                            {{ $row['name'] ?? '—' }}
+                                            <span class="text-xs text-gray-400">via {{ str_replace('_', ' ', $row['via_edge_type']) }}</span>
+                                        </span>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        @endif
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -120,6 +120,9 @@ use App\Livewire\OutboundConnectors\WhatsAppOutboundPage;
 use App\Livewire\Policies\CreatePolicyForm;
 use App\Livewire\Policies\PolicyDetailPage;
 use App\Livewire\Policies\PolicyListPage;
+use App\Livewire\ProductGraph\ProductGraphBrowserPage;
+use App\Livewire\ProductGraph\ProductGraphChangesPage;
+use App\Livewire\ProductGraph\ProductGraphImpactPage;
 use App\Livewire\Profile\ProfilePage;
 use App\Livewire\Projects\CreateProjectForm as CreateProjectFormPage;
 use App\Livewire\Projects\EditProjectForm;
@@ -465,6 +468,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/knowledge', KnowledgeSourcesPage::class)->name('knowledge.index');
     Route::get('/knowledge-graph', KnowledgeGraphBrowserPage::class)->name('knowledge-graph.index');
     Route::get('/knowledge-graph/communities', KgCommunitiesPage::class)->name('knowledge-graph.communities');
+
+    Route::get('/product-graph', ProductGraphBrowserPage::class)->name('product-graph.index');
+    Route::get('/product-graph/impact', ProductGraphImpactPage::class)->name('product-graph.impact');
+    Route::get('/product-graph/changes', ProductGraphChangesPage::class)->name('product-graph.changes');
 
     Route::get('/signals', SignalBrowserPage::class)->name('signals.index');
     Route::get('/signals/new', ManualSignalForm::class)->name('signals.create');

--- a/tests/Feature/Domain/ProductGraph/ImpactAnalyzerTest.php
+++ b/tests/Feature/Domain/ProductGraph/ImpactAnalyzerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Domain\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\ProductGraph\Services\ImpactAnalyzer;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ImpactAnalyzerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private ImpactAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Test Team',
+            'slug' => 'test-team',
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $this->analyzer = app(ImpactAnalyzer::class);
+    }
+
+    private function node(string $name, NodeType $type = NodeType::Feature): ProductNode
+    {
+        return ProductNode::factory()->type($type)->create([
+            'team_id' => $this->team->id,
+            'name' => $name,
+        ]);
+    }
+
+    private function edge(ProductNode $source, ProductNode $target, EdgeType $type): void
+    {
+        ProductEdge::factory()->edgeType($type)->create([
+            'team_id' => $this->team->id,
+            'source_node_id' => $source->id,
+            'target_node_id' => $target->id,
+        ]);
+    }
+
+    public function test_impact_direction_per_edge_type(): void
+    {
+        $this->assertSame('incoming', EdgeType::DependsOn->impactDirection());
+        $this->assertSame('incoming', EdgeType::Uses->impactDirection());
+        $this->assertSame('incoming', EdgeType::PartOf->impactDirection());
+        $this->assertSame('outgoing', EdgeType::Serves->impactDirection());
+        $this->assertSame('outgoing', EdgeType::Triggers->impactDirection());
+        $this->assertSame('both', EdgeType::IntegratesWith->impactDirection());
+    }
+
+    public function test_depends_on_chain_propagates_upstream(): void
+    {
+        $a = $this->node('A');
+        $b = $this->node('B');
+        $c = $this->node('C');
+        $this->edge($a, $b, EdgeType::DependsOn); // A depends_on B
+        $this->edge($b, $c, EdgeType::DependsOn); // B depends_on C
+
+        $impact = collect($this->analyzer->blastRadius($c));
+
+        $this->assertEqualsCanonicalizing(['B', 'A'], $impact->pluck('name')->all());
+        $this->assertSame(1, $impact->firstWhere('name', 'B')['depth']);
+        $this->assertSame(2, $impact->firstWhere('name', 'A')['depth']);
+    }
+
+    public function test_integrates_with_cycle_terminates(): void
+    {
+        $a = $this->node('A');
+        $b = $this->node('B');
+        $this->edge($a, $b, EdgeType::IntegratesWith);
+
+        $impact = collect($this->analyzer->blastRadius($a));
+
+        $this->assertSame(['B'], $impact->pluck('name')->all());
+    }
+
+    public function test_max_depth_is_respected(): void
+    {
+        $a = $this->node('A');
+        $b = $this->node('B');
+        $c = $this->node('C');
+        $this->edge($a, $b, EdgeType::DependsOn);
+        $this->edge($b, $c, EdgeType::DependsOn);
+
+        $impact = collect($this->analyzer->blastRadius($c, maxDepth: 1));
+
+        $this->assertSame(['B'], $impact->pluck('name')->all());
+    }
+
+    public function test_serves_propagates_downstream(): void
+    {
+        $scoreReport = $this->node('Score Report', NodeType::SharedComponent);
+        $p1 = $this->node('Product One', NodeType::Product);
+        $p2 = $this->node('Product Two', NodeType::Product);
+        $this->edge($scoreReport, $p1, EdgeType::Serves);
+        $this->edge($scoreReport, $p2, EdgeType::Serves);
+
+        $impact = collect($this->analyzer->blastRadius($scoreReport));
+
+        $this->assertEqualsCanonicalizing(['Product One', 'Product Two'], $impact->pluck('name')->all());
+    }
+}

--- a/tests/Feature/Domain/ProductGraph/ProductGraphActionsTest.php
+++ b/tests/Feature/Domain/ProductGraph/ProductGraphActionsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature\Domain\ProductGraph;
+
+use App\Domain\ProductGraph\Actions\ApplyApprovedChangeAction;
+use App\Domain\ProductGraph\Actions\CreateNodeAction;
+use App\Domain\ProductGraph\Actions\ImportFromInventoryAction;
+use App\Domain\ProductGraph\Actions\ProposeChangeAction;
+use App\Domain\ProductGraph\Actions\ReviewChangeAction;
+use App\Domain\ProductGraph\Actions\UpsertEdgeAction;
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Enums\ChangeType;
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Enums\NodeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class ProductGraphActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Test Team',
+            'slug' => 'test-team',
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+    }
+
+    public function test_create_node_is_idempotent_on_type_and_slug(): void
+    {
+        $action = app(CreateNodeAction::class);
+        $action->execute($this->team->id, NodeType::Feature, 'Score Report');
+        $action->execute($this->team->id, NodeType::Feature, 'Score Report');
+
+        $this->assertSame(1, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_upsert_edge_is_idempotent(): void
+    {
+        [$a, $b] = $this->twoNodes();
+        $action = app(UpsertEdgeAction::class);
+        $action->execute($this->team->id, $a->id, $b->id, EdgeType::DependsOn);
+        $action->execute($this->team->id, $a->id, $b->id, EdgeType::DependsOn);
+
+        $this->assertSame(1, ProductEdge::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_upsert_edge_rejects_self_loop(): void
+    {
+        [$a] = $this->twoNodes();
+        $this->expectException(InvalidArgumentException::class);
+        app(UpsertEdgeAction::class)->execute($this->team->id, $a->id, $a->id, EdgeType::DependsOn);
+    }
+
+    public function test_upsert_edge_rejects_cross_team_node(): void
+    {
+        [$a] = $this->twoNodes();
+        $otherTeam = Team::create(['name' => 'Other', 'slug' => 'other', 'owner_id' => $this->team->owner_id, 'settings' => []]);
+        $foreign = ProductNode::factory()->create(['team_id' => $otherTeam->id]);
+
+        $this->expectException(InvalidArgumentException::class);
+        app(UpsertEdgeAction::class)->execute($this->team->id, $a->id, $foreign->id, EdgeType::DependsOn);
+    }
+
+    public function test_propose_change_does_not_mutate_graph(): void
+    {
+        app(ProposeChangeAction::class)->execute(
+            $this->team->id,
+            ChangeType::CreateNode,
+            null,
+            ['node_type' => 'feature', 'name' => 'Proposed Feature'],
+            'agent:test',
+        );
+
+        $this->assertSame(1, ProductGraphChange::withoutGlobalScopes()->where('team_id', $this->team->id)->pending()->count());
+        $this->assertSame(0, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_approving_create_node_proposal_applies_it(): void
+    {
+        $change = app(ProposeChangeAction::class)->execute(
+            $this->team->id,
+            ChangeType::CreateNode,
+            null,
+            ['node_type' => 'feature', 'name' => 'Approved Feature'],
+            'agent:test',
+        );
+
+        $reviewed = app(ReviewChangeAction::class)->execute($change, approve: true);
+
+        $this->assertSame(ChangeStatus::Applied, $reviewed->status);
+        $this->assertNotNull($reviewed->applied_ref_id);
+        $this->assertSame(1, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_rejecting_proposal_does_not_mutate_graph(): void
+    {
+        $change = app(ProposeChangeAction::class)->execute(
+            $this->team->id,
+            ChangeType::CreateNode,
+            null,
+            ['node_type' => 'feature', 'name' => 'Rejected Feature'],
+        );
+
+        $reviewed = app(ReviewChangeAction::class)->execute($change, approve: false, note: 'no');
+
+        $this->assertSame(ChangeStatus::Rejected, $reviewed->status);
+        $this->assertSame(0, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_apply_approved_change_is_idempotent(): void
+    {
+        $change = ProductGraphChange::factory()->create([
+            'team_id' => $this->team->id,
+            'change_type' => ChangeType::CreateNode,
+            'payload' => ['node_type' => 'feature', 'name' => 'Once Only'],
+            'status' => ChangeStatus::Approved,
+        ]);
+
+        $apply = app(ApplyApprovedChangeAction::class);
+        $apply->execute($change);
+        $apply->execute($change->refresh());
+
+        $this->assertSame(1, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_propose_change_with_invalid_payload_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        app(ProposeChangeAction::class)->execute(
+            $this->team->id,
+            ChangeType::CreateNode,
+            null,
+            ['node_type' => 'feature'], // missing name
+        );
+    }
+
+    public function test_import_from_inventory_seeds_graph_idempotently(): void
+    {
+        $markdown = <<<'MD'
+        # Inventory
+
+        Full base domain list: Agent, Crew, Experiment, Signal, Workflow
+
+        ## ⭐ BACKLOG: Capabilities that need a UI
+
+        | # | Capability | Domain | exists | missing | Priority |
+        |---|---|---|---|---|---|
+        | 1 | **Release signing-key management** (key mgmt) | Release | code | UI | High |
+        | 2 | **Drift dashboard** | Evaluation | code | UI | Medium |
+
+        ## Next section
+        MD;
+
+        $action = app(ImportFromInventoryAction::class);
+        $first = $action->execute($this->team->id, $markdown);
+
+        // 1 root product + 5 domains + 2 backlog = 8 nodes; 7 part_of edges.
+        $this->assertSame(8, $first['nodes_created']);
+        $this->assertSame(7, $first['edges_created']);
+        $this->assertSame(8, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+
+        // Re-run is idempotent: no new rows.
+        $second = $action->execute($this->team->id, $markdown);
+        $this->assertSame(0, $second['nodes_created']);
+        $this->assertSame(8, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    /**
+     * @return array{0: ProductNode, 1: ProductNode}
+     */
+    private function twoNodes(): array
+    {
+        return [
+            ProductNode::factory()->create(['team_id' => $this->team->id, 'name' => 'Node A']),
+            ProductNode::factory()->create(['team_id' => $this->team->id, 'name' => 'Node B']),
+        ];
+    }
+}

--- a/tests/Feature/Domain/ProductGraph/ProductGraphMcpTest.php
+++ b/tests/Feature/Domain/ProductGraph/ProductGraphMcpTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\Domain\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\ProductGraph\ProductGraphImpactTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphProposeTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphQueryTool;
+use App\Mcp\Tools\ProductGraph\ProductGraphReviewTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Tests\TestCase;
+
+class ProductGraphMcpTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Test Team',
+            'slug' => 'test-team',
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    public function test_query_returns_only_caller_team_nodes(): void
+    {
+        ProductNode::factory()->create(['team_id' => $this->team->id, 'name' => 'Mine']);
+
+        $otherTeam = Team::create(['name' => 'Other', 'slug' => 'other', 'owner_id' => $this->team->owner_id, 'settings' => []]);
+        ProductNode::factory()->create(['team_id' => $otherTeam->id, 'name' => 'Theirs']);
+
+        $response = app(ProductGraphQueryTool::class)->handle(new Request([]));
+        $data = json_decode((string) $response->content(), true);
+
+        $this->assertSame(1, $data['count']);
+        $this->assertSame('Mine', $data['nodes'][0]['name']);
+    }
+
+    public function test_impact_tool_returns_blast_radius(): void
+    {
+        $a = ProductNode::factory()->create(['team_id' => $this->team->id, 'name' => 'A']);
+        $b = ProductNode::factory()->create(['team_id' => $this->team->id, 'name' => 'B']);
+        ProductEdge::factory()->edgeType(EdgeType::DependsOn)->create([
+            'team_id' => $this->team->id,
+            'source_node_id' => $a->id,
+            'target_node_id' => $b->id,
+        ]);
+
+        $response = app(ProductGraphImpactTool::class)->handle(new Request(['node_id' => $b->id]));
+        $data = json_decode((string) $response->content(), true);
+
+        $this->assertSame(1, $data['affected_count']);
+        $this->assertSame('A', $data['affected'][0]['name']);
+    }
+
+    public function test_propose_tool_queues_without_mutating_graph(): void
+    {
+        $response = app(ProductGraphProposeTool::class)->handle(new Request([
+            'change_type' => 'create_node',
+            'payload' => ['node_type' => 'feature', 'name' => 'Proposed'],
+            'proposed_by_label' => 'agent:test',
+        ]));
+        $data = json_decode((string) $response->content(), true);
+
+        $this->assertSame('pending', $data['status']);
+        $this->assertSame(0, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+        $this->assertSame(1, ProductGraphChange::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_review_tool_approve_applies_change(): void
+    {
+        $change = ProductGraphChange::factory()->create([
+            'team_id' => $this->team->id,
+            'payload' => ['node_type' => 'feature', 'name' => 'Approved Via Mcp'],
+        ]);
+
+        $response = app(ProductGraphReviewTool::class)->handle(new Request([
+            'change_id' => $change->id,
+            'decision' => 'approve',
+        ]));
+        $data = json_decode((string) $response->content(), true);
+
+        $this->assertSame('applied', $data['status']);
+        $this->assertSame(1, ProductNode::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
+    public function test_tool_without_team_context_is_permission_denied(): void
+    {
+        app()->instance('mcp.team_id', null);
+
+        $response = app(ProductGraphQueryTool::class)->handle(new Request([]));
+
+        $this->assertTrue($response->isError());
+    }
+}

--- a/tests/Feature/Domain/ProductGraph/ProductGraphPageTest.php
+++ b/tests/Feature/Domain/ProductGraph/ProductGraphPageTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Domain\ProductGraph;
+
+use App\Domain\ProductGraph\Enums\ChangeStatus;
+use App\Domain\ProductGraph\Enums\ChangeType;
+use App\Domain\ProductGraph\Enums\EdgeType;
+use App\Domain\ProductGraph\Models\ProductEdge;
+use App\Domain\ProductGraph\Models\ProductGraphChange;
+use App\Domain\ProductGraph\Models\ProductNode;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\ProductGraph\ProductGraphBrowserPage;
+use App\Livewire\ProductGraph\ProductGraphChangesPage;
+use App\Livewire\ProductGraph\ProductGraphImpactPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ProductGraphPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'Test Team',
+            'slug' => 'test-team',
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+
+        $this->actingAs($this->user);
+    }
+
+    public function test_browser_shows_disabled_notice_when_flag_off(): void
+    {
+        config(['productgraph.enabled' => false]);
+
+        Livewire::test(ProductGraphBrowserPage::class)
+            ->assertSee('Product Graph is disabled');
+    }
+
+    public function test_owner_can_add_a_node(): void
+    {
+        config(['productgraph.enabled' => true]);
+
+        Livewire::test(ProductGraphBrowserPage::class)
+            ->set('newName', 'New Feature')
+            ->set('newNodeType', 'feature')
+            ->set('newStatus', 'planned')
+            ->call('addNode')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('product_nodes', [
+            'team_id' => $this->team->id,
+            'name' => 'New Feature',
+        ]);
+    }
+
+    public function test_changes_page_approve_applies_proposal(): void
+    {
+        config(['productgraph.enabled' => true]);
+
+        $change = ProductGraphChange::factory()->create([
+            'team_id' => $this->team->id,
+            'change_type' => ChangeType::CreateNode,
+            'payload' => ['node_type' => 'feature', 'name' => 'From Queue'],
+            'status' => ChangeStatus::Pending,
+        ]);
+
+        Livewire::test(ProductGraphChangesPage::class)
+            ->call('approve', $change->id);
+
+        $this->assertDatabaseHas('product_nodes', [
+            'team_id' => $this->team->id,
+            'name' => 'From Queue',
+        ]);
+    }
+
+    public function test_impact_page_renders_blast_radius(): void
+    {
+        config(['productgraph.enabled' => true]);
+
+        $a = ProductNode::factory()->create(['team_id' => $this->team->id, 'name' => 'Dependent A']);
+        $b = ProductNode::factory()->create(['team_id' => $this->team->id, 'name' => 'Core B']);
+        ProductEdge::factory()->edgeType(EdgeType::DependsOn)->create([
+            'team_id' => $this->team->id,
+            'source_node_id' => $a->id,
+            'target_node_id' => $b->id,
+        ]);
+
+        Livewire::test(ProductGraphImpactPage::class)
+            ->set('nodeId', $b->id)
+            ->assertSee('Dependent A');
+    }
+}


### PR DESCRIPTION
## What

New **ProductGraph** base domain — a typed, team-scoped *product-layer* graph (above code, below wiki), borrowed from VibeGraph (VibeLevel AI). Distinct from the existing `KnowledgeGraph` domain, which is a *temporal memory* graph.

- **Nodes** (typed): product, feature, sub_feature, shared_component, agent_skill, standard, persona, tech_component, release
- **Edges** (typed): depends_on, part_of, uses, integrates_with, serves, triggers
- **Blast-radius / impact analysis** — "what breaks if this changes?" via directed BFS keyed on `EdgeType::impactDirection()`
- **Agents propose → humans approve** governance queue (`product_graph_changes`)
- **ImportFromInventoryAction** — seed the graph from the feature-inventory markdown (LLM-free parser, idempotent)
- **6 MCP tools** (query / node / impact / changes_list / propose / review) registered in `AgentFleetServer`
- **Livewire UI**: interactive inline-SVG map + blast-radius dashboard + review queue (no new JS bundle → deployable without a frontend rebuild)

## Flag
`PRODUCT_GRAPH_ENABLED` (default **false**). `PRODUCT_GRAPH_MAX_IMPACT_DEPTH` (default 5).

## Tests
24 feature/unit tests (actions, ImpactAnalyzer, MCP tenant-isolation, Livewire) + `ToolAnnotationCoverageTest` pass. pint clean; phpstan scoped clean (new models carry `@property` docblocks — no baseline churn).

## Notes
- Migrations: `product_nodes`, `product_edges`, `product_graph_changes` (UUIDv7, team-scoped, GIN on tags for pgsql).
- Every MCP tool declares `#[IsReadOnly]`/`#[IsDestructive]` + `#[AssistantTool]`.

🤖 Draft — human merge only (no auto-merge).