### PR TITLE
feat(feature-flags): Tier-2 runtime flags (Pennant) + agent-native MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,6 +554,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/horizon (HORIZON) - v5
 - laravel/mcp (MCP) - v0
 - laravel/passport (PASSPORT) - v13
+- laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0
 - laravel/pulse (PULSE) - v1
 - laravel/reverb (REVERB) - v1
@@ -688,7 +689,6 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 - When creating models for tests, use the factories for the models. Check if the factory has custom states that can be used before manually setting up the model.
 - Faker: Use methods such as `$this->faker->word()` or `fake()->randomDigit()`. Follow existing conventions whether to use `$this->faker` or `fake()`.
 - When creating tests, make use of `php artisan make:test [options] {name}` to create a feature test, and pass `--unit` to create a unit test. Most tests should be feature tests.
-- **Run base tests STANDALONE before pushing base-only changes** — `composer test` (or `vendor/bin/phpunit`, exactly what CI runs: SQLite `:memory:`, base migrations only). Running the suite via the *cloud* container (`cd /var/www/base` inside the cloud app) applies cloud migrations and **masks base/cloud coupling** — e.g. a base test that depends on a cloud-only column (`teams.sub_program_slug`) passes in the cloud container but fails red in base CI. Base tests must not depend on cloud-only schema/fillable; if they do, the test belongs in `cloud/tests/`.
 
 ## Vite Error
 

--- a/app/Domain/FeatureFlag/Actions/ArchiveFeatureFlagAction.php
+++ b/app/Domain/FeatureFlag/Actions/ArchiveFeatureFlagAction.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Actions;
+
+use App\Domain\Audit\Models\AuditEntry;
+use App\Domain\Audit\Services\OcsfMapper;
+use App\Domain\FeatureFlag\Concerns\GatesSensitiveFlagChanges;
+use App\Domain\FeatureFlag\DTOs\FeatureFlagResult;
+use App\Domain\FeatureFlag\Models\FeatureFlagRollout;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Models\User;
+use Laravel\Pennant\Feature;
+
+/**
+ * Retire a Tier-2 flag: purge all stored per-team overrides and clear its
+ * rollout percentage. After archiving, resolution falls back to the static
+ * definition default. The definition itself stays in config for history.
+ */
+class ArchiveFeatureFlagAction
+{
+    use GatesSensitiveFlagChanges;
+
+    public function __construct(
+        private readonly FeatureFlagService $service,
+    ) {}
+
+    public function execute(string $key, ?User $actor = null): FeatureFlagResult
+    {
+        $this->service->definition($key);
+        /** @var User|null $actor */
+        $actor ??= auth()->user();
+
+        if ($this->requiresApproval($this->service, $key, $actor)) {
+            $approval = $this->createFlagApproval('archive', $key, [], $actor?->currentTeam?->id, $actor?->id);
+
+            return FeatureFlagResult::pendingApproval($key, $approval);
+        }
+
+        Feature::purge($key);
+        FeatureFlagRollout::query()->where('key', $key)->delete();
+        $this->service->forgetRolloutCache($key);
+
+        $ocsf = OcsfMapper::classify('feature_flag.archived');
+        AuditEntry::create([
+            'team_id' => $actor?->currentTeam?->id,
+            'user_id' => $actor?->id,
+            'event' => 'feature_flag.archived',
+            'ocsf_class_uid' => $ocsf['class_uid'],
+            'ocsf_severity_id' => $ocsf['severity_id'],
+            'subject_type' => 'feature_flag',
+            'subject_id' => $key,
+            'properties' => ['flag_key' => $key],
+            'created_at' => now(),
+        ]);
+
+        return FeatureFlagResult::archived($key);
+    }
+}

--- a/app/Domain/FeatureFlag/Actions/SetFeatureFlagAction.php
+++ b/app/Domain/FeatureFlag/Actions/SetFeatureFlagAction.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Actions;
+
+use App\Domain\FeatureFlag\Concerns\GatesSensitiveFlagChanges;
+use App\Domain\FeatureFlag\DTOs\FeatureFlagResult;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Laravel\Pennant\Feature;
+
+/**
+ * Set an explicit per-team override for a Tier-2 flag (activate/deactivate).
+ * Pennant's stored value takes precedence over the percentage rollout closure.
+ * The applied flip fires Pennant's FeatureUpdated event → RecordFeatureFlagAudit.
+ */
+class SetFeatureFlagAction
+{
+    use GatesSensitiveFlagChanges;
+
+    public function __construct(
+        private readonly FeatureFlagService $service,
+    ) {}
+
+    public function execute(string $key, bool $value, Team $team, ?User $actor = null): FeatureFlagResult
+    {
+        $this->service->definition($key);
+        /** @var User|null $actor */
+        $actor ??= auth()->user();
+
+        if ($this->requiresApproval($this->service, $key, $actor)) {
+            $approval = $this->createFlagApproval('toggle', $key, [
+                'requested_value' => $value,
+                'scope_team_id' => $team->id,
+            ], $team->id, $actor?->id);
+
+            return FeatureFlagResult::pendingApproval($key, $approval);
+        }
+
+        if ($value) {
+            Feature::for($team)->activate($key);
+        } else {
+            Feature::for($team)->deactivate($key);
+        }
+
+        return FeatureFlagResult::applied($key, $value, $team);
+    }
+}

--- a/app/Domain/FeatureFlag/Actions/SetFeatureRolloutAction.php
+++ b/app/Domain/FeatureFlag/Actions/SetFeatureRolloutAction.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Actions;
+
+use App\Domain\Audit\Models\AuditEntry;
+use App\Domain\Audit\Services\OcsfMapper;
+use App\Domain\FeatureFlag\Concerns\GatesSensitiveFlagChanges;
+use App\Domain\FeatureFlag\DTOs\FeatureFlagResult;
+use App\Domain\FeatureFlag\Models\FeatureFlagRollout;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Models\User;
+
+/**
+ * Set the platform-wide percentage rollout for a Tier-2 flag (0..100).
+ * Stored in feature_flag_rollouts (our table, not Pennant), so the change is
+ * audited here rather than via Pennant's FeatureUpdated event.
+ */
+class SetFeatureRolloutAction
+{
+    use GatesSensitiveFlagChanges;
+
+    public function __construct(
+        private readonly FeatureFlagService $service,
+    ) {}
+
+    public function execute(string $key, int $percentage, ?User $actor = null): FeatureFlagResult
+    {
+        $this->service->definition($key);
+        /** @var User|null $actor */
+        $actor ??= auth()->user();
+        $clamped = max(0, min(100, $percentage));
+
+        if ($this->requiresApproval($this->service, $key, $actor)) {
+            $approval = $this->createFlagApproval('rollout', $key, [
+                'requested_percentage' => $clamped,
+            ], $actor?->currentTeam?->id, $actor?->id);
+
+            return FeatureFlagResult::pendingApproval($key, $approval);
+        }
+
+        FeatureFlagRollout::query()->updateOrCreate(
+            ['key' => $key],
+            ['percentage' => $clamped, 'updated_by' => $actor?->id],
+        );
+
+        $this->service->forgetRolloutCache($key);
+
+        $ocsf = OcsfMapper::classify('feature_flag.rollout');
+        AuditEntry::create([
+            'team_id' => $actor?->currentTeam?->id,
+            'user_id' => $actor?->id,
+            'event' => 'feature_flag.rollout',
+            'ocsf_class_uid' => $ocsf['class_uid'],
+            'ocsf_severity_id' => $ocsf['severity_id'],
+            'subject_type' => 'feature_flag',
+            'subject_id' => $key,
+            'properties' => [
+                'flag_key' => $key,
+                'percentage' => $clamped,
+            ],
+            'created_at' => now(),
+        ]);
+
+        return FeatureFlagResult::rollout($key, $clamped);
+    }
+}

--- a/app/Domain/FeatureFlag/Concerns/GatesSensitiveFlagChanges.php
+++ b/app/Domain/FeatureFlag/Concerns/GatesSensitiveFlagChanges.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Concerns;
+
+use App\Domain\Approval\Enums\ApprovalStatus;
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Models\User;
+
+/**
+ * Sensitivity gate shared by the feature-flag mutation actions.
+ *
+ * A sensitive flag (security/billing/destructive) flipped by a non-super-admin
+ * actor — typically an agent acting as team owner over MCP — must not apply
+ * directly; it creates a pending ApprovalRequest instead (mirrors
+ * CreateSecurityReviewRequestAction's context-discriminated approval).
+ */
+trait GatesSensitiveFlagChanges
+{
+    protected function requiresApproval(FeatureFlagService $service, string $key, ?User $actor): bool
+    {
+        if (! $service->isSensitive($key)) {
+            return false;
+        }
+
+        return $actor === null || ! $actor->is_super_admin;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    protected function createFlagApproval(string $changeType, string $key, array $context, ?string $teamId, ?string $actorId): ApprovalRequest
+    {
+        return ApprovalRequest::withoutGlobalScopes()->create([
+            'team_id' => $teamId,
+            'status' => ApprovalStatus::Pending,
+            'context' => array_merge([
+                'type' => 'feature_flag_change',
+                'change_type' => $changeType,
+                'flag_key' => $key,
+                'requested_by' => $actorId,
+            ], $context),
+            'expires_at' => now()->addDays(3),
+        ]);
+    }
+}

--- a/app/Domain/FeatureFlag/DTOs/FeatureFlagResult.php
+++ b/app/Domain/FeatureFlag/DTOs/FeatureFlagResult.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Domain\FeatureFlag\DTOs;
+
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\Shared\Models\Team;
+
+/**
+ * Outcome of a feature-flag mutation. Either the change was applied immediately
+ * (non-sensitive, or actor is super-admin) or it is pending an ApprovalRequest
+ * (sensitive flag flipped by a non-super-admin actor — e.g. an agent).
+ */
+final class FeatureFlagResult
+{
+    private function __construct(
+        public readonly string $status,
+        public readonly ?string $key = null,
+        public readonly ?bool $value = null,
+        public readonly ?int $percentage = null,
+        public readonly ?string $teamId = null,
+        public readonly ?string $approvalId = null,
+    ) {}
+
+    public static function applied(string $key, bool $value, ?Team $team): self
+    {
+        return new self('applied', key: $key, value: $value, teamId: $team?->id);
+    }
+
+    public static function rollout(string $key, int $percentage): self
+    {
+        return new self('rollout', key: $key, percentage: $percentage);
+    }
+
+    public static function archived(string $key): self
+    {
+        return new self('archived', key: $key);
+    }
+
+    public static function pendingApproval(string $key, ApprovalRequest $approval): self
+    {
+        return new self('pending_approval', key: $key, approvalId: $approval->id);
+    }
+
+    public function isPendingApproval(): bool
+    {
+        return $this->status === 'pending_approval';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'status' => $this->status,
+            'flag_key' => $this->key,
+            'value' => $this->value,
+            'percentage' => $this->percentage,
+            'scope_team_id' => $this->teamId,
+            'approval_id' => $this->approvalId,
+        ], fn ($v) => $v !== null);
+    }
+}

--- a/app/Domain/FeatureFlag/Exceptions/UnknownFeatureFlagException.php
+++ b/app/Domain/FeatureFlag/Exceptions/UnknownFeatureFlagException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Exceptions;
+
+use RuntimeException;
+
+class UnknownFeatureFlagException extends RuntimeException
+{
+    public function __construct(string $key)
+    {
+        parent::__construct("Unknown feature flag: {$key}");
+    }
+}

--- a/app/Domain/FeatureFlag/Listeners/RecordFeatureFlagAudit.php
+++ b/app/Domain/FeatureFlag/Listeners/RecordFeatureFlagAudit.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Listeners;
+
+use App\Domain\Audit\Models\AuditEntry;
+use App\Domain\Audit\Services\OcsfMapper;
+use App\Domain\Shared\Models\Team;
+use Laravel\Pennant\Events\FeatureUpdated;
+
+/**
+ * Audits per-team override flips applied through Pennant (SetFeatureFlagAction).
+ * Rollout-percentage and archive changes are audited inside their own actions
+ * because they do not flow through Pennant's FeatureUpdated event.
+ */
+class RecordFeatureFlagAudit
+{
+    public function handle(FeatureUpdated $event): void
+    {
+        $definitions = config('feature_flags.definitions', []);
+
+        if (! array_key_exists($event->feature, $definitions)) {
+            return;
+        }
+
+        $teamId = $event->scope instanceof Team ? $event->scope->getKey() : null;
+        $ocsf = OcsfMapper::classify('feature_flag.updated');
+
+        AuditEntry::create([
+            'team_id' => $teamId,
+            'user_id' => auth()->id(),
+            'event' => 'feature_flag.updated',
+            'ocsf_class_uid' => $ocsf['class_uid'],
+            'ocsf_severity_id' => $ocsf['severity_id'],
+            'subject_type' => 'feature_flag',
+            'subject_id' => $event->feature,
+            'properties' => [
+                'flag_key' => $event->feature,
+                'value' => $event->value,
+                'scope_team_id' => $teamId,
+            ],
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Domain/FeatureFlag/Models/FeatureFlagRollout.php
+++ b/app/Domain/FeatureFlag/Models/FeatureFlagRollout.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * Persisted percentage-rollout setting for a Tier-2 runtime feature flag.
+ *
+ * Not team-scoped: a rollout percentage is a platform-wide default applied by
+ * the FeatureFlagService define() closure to teams that have no explicit
+ * per-team override. Per-team overrides live in Pennant's `features` table.
+ *
+ * @property string $id
+ * @property string $key
+ * @property int $percentage
+ * @property string|null $updated_by
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+class FeatureFlagRollout extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'key',
+        'percentage',
+        'updated_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'percentage' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function updatedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+}

--- a/app/Domain/FeatureFlag/Services/FeatureFlagService.php
+++ b/app/Domain/FeatureFlag/Services/FeatureFlagService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Domain\FeatureFlag\Services;
+
+use App\Domain\FeatureFlag\Exceptions\UnknownFeatureFlagException;
+use App\Domain\FeatureFlag\Models\FeatureFlagRollout;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Pennant\Feature;
+
+/**
+ * Tier-2 runtime feature flags, backed by Laravel Pennant.
+ *
+ * Resolution precedence for a team:
+ *   1. explicit per-team override (Pennant stored value) — set via SetFeatureFlagAction
+ *   2. percentage rollout (deterministic, monotonic bucket) — set via SetFeatureRolloutAction
+ *   3. static definition default
+ *
+ * The whole tier is gated by config('feature_flags.runtime_enabled'): when off,
+ * active() returns the static default and no Pennant override is consulted.
+ */
+class FeatureFlagService
+{
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function definitions(): array
+    {
+        return config('feature_flags.definitions', []);
+    }
+
+    public function runtimeEnabled(): bool
+    {
+        return (bool) config('feature_flags.runtime_enabled', false);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(string $key): array
+    {
+        $def = $this->definitions()[$key] ?? null;
+
+        if ($def === null) {
+            throw new UnknownFeatureFlagException($key);
+        }
+
+        return $def;
+    }
+
+    public function isSensitive(string $key): bool
+    {
+        return (bool) ($this->definition($key)['sensitive'] ?? false);
+    }
+
+    /**
+     * Register every definition with Pennant. Called once at boot.
+     *
+     * The closure implements a deterministic, monotonic rollout bucket: raising
+     * the percentage only ever adds teams (never removes one). Explicit per-team
+     * overrides stored by Pennant take precedence over this closure.
+     */
+    public function defineAll(): void
+    {
+        foreach ($this->definitions() as $key => $def) {
+            Feature::define($key, function (mixed $scope) use ($key, $def): bool {
+                if (! $this->runtimeEnabled()) {
+                    return (bool) ($def['default'] ?? false);
+                }
+
+                $pct = $this->rolloutPercentage($key);
+
+                if ($pct >= 100) {
+                    return true;
+                }
+
+                if ($pct <= 0) {
+                    return (bool) ($def['default'] ?? false);
+                }
+
+                return $this->rolloutBucket($key, $scope) < $pct;
+            });
+        }
+    }
+
+    public function active(string $key, ?Team $team = null): bool
+    {
+        $def = $this->definition($key);
+
+        if (! $this->runtimeEnabled()) {
+            return (bool) ($def['default'] ?? false);
+        }
+
+        $team ??= $this->currentTeam();
+
+        return $team !== null
+            ? Feature::for($team)->active($key)
+            : (bool) ($def['default'] ?? false);
+    }
+
+    public function rolloutPercentage(string $key): int
+    {
+        return (int) Cache::remember(
+            $this->rolloutCacheKey($key),
+            now()->addMinutes(5),
+            fn (): int => (int) (FeatureFlagRollout::query()->where('key', $key)->value('percentage') ?? 0),
+        );
+    }
+
+    public function forgetRolloutCache(string $key): void
+    {
+        Cache::forget($this->rolloutCacheKey($key));
+    }
+
+    public function currentTeam(): ?Team
+    {
+        $team = auth()->user()?->currentTeam;
+
+        return $team instanceof Team ? $team : null;
+    }
+
+    private function rolloutBucket(string $key, mixed $scope): int
+    {
+        $id = $scope instanceof Team ? (string) $scope->getKey() : (string) $scope;
+
+        return (int) hexdec(substr(md5($key.'|'.$id), 0, 8)) % 100;
+    }
+
+    private function rolloutCacheKey(string $key): string
+    {
+        return "feature_flag_rollout:{$key}";
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -288,6 +288,11 @@ use App\Mcp\Tools\Experiment\UncertaintyResolveTool;
 use App\Mcp\Tools\Experiment\WorkflowSnapshotListTool;
 use App\Mcp\Tools\Experiment\WorklogAppendTool;
 use App\Mcp\Tools\Experiment\WorklogReadTool;
+use App\Mcp\Tools\FeatureFlag\FeatureArchiveTool;
+use App\Mcp\Tools\FeatureFlag\FeatureListTool;
+use App\Mcp\Tools\FeatureFlag\FeatureRolloutTool;
+use App\Mcp\Tools\FeatureFlag\FeatureStatusTool;
+use App\Mcp\Tools\FeatureFlag\FeatureToggleTool;
 use App\Mcp\Tools\Feedback\FeedbackListTool;
 use App\Mcp\Tools\Feedback\FeedbackUpdateTool;
 use App\Mcp\Tools\FounderMode\FounderModeInstallTool;
@@ -1377,6 +1382,13 @@ class AgentFleetServer extends Server
 
         // RunPod (1)
         RunPodManageTool::class,
+
+        // Feature Flag — Tier-2 runtime flags (5)
+        FeatureListTool::class,
+        FeatureStatusTool::class,
+        FeatureToggleTool::class,
+        FeatureRolloutTool::class,
+        FeatureArchiveTool::class,
 
         // Email (11)
         EmailThemeListTool::class,

--- a/app/Mcp/Tools/FeatureFlag/FeatureArchiveTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureArchiveTool.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mcp\Tools\FeatureFlag;
+
+use App\Domain\FeatureFlag\Actions\ArchiveFeatureFlagAction;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('destructive')]
+class FeatureArchiveTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'feature_archive';
+
+    protected string $description = 'Retire a Tier-2 runtime feature flag: purge all per-team overrides and clear its rollout. Resolution falls back to the static default. Sensitive flags create a pending approval instead.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('The feature flag key to archive')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(FeatureFlagService::class);
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $key = (string) $request->get('key');
+
+        if (! array_key_exists($key, $service->definitions())) {
+            return $this->invalidArgumentError("Unknown feature flag: {$key}");
+        }
+
+        $result = app(ArchiveFeatureFlagAction::class)->execute($key, auth()->user());
+
+        return Response::text(json_encode($result->toArray()));
+    }
+}

--- a/app/Mcp/Tools/FeatureFlag/FeatureListTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureListTool.php
@@ -38,7 +38,7 @@ class FeatureListTool extends Tool
             return $this->permissionDeniedError('No team context.');
         }
 
-        $team = Team::withoutGlobalScopes()->find($teamId);
+        $team = Team::find($teamId);
 
         $flags = collect($service->definitions())->map(fn (array $def, string $key) => [
             'key' => $key,

--- a/app/Mcp/Tools/FeatureFlag/FeatureListTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureListTool.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Mcp\Tools\FeatureFlag;
+
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class FeatureListTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'feature_list';
+
+    protected string $description = 'List Tier-2 runtime feature flags with their resolved state for the current team, rollout percentage, and sensitivity.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(FeatureFlagService::class);
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $team = Team::withoutGlobalScopes()->find($teamId);
+
+        $flags = collect($service->definitions())->map(fn (array $def, string $key) => [
+            'key' => $key,
+            'label' => $def['label'] ?? $key,
+            'group' => $def['group'] ?? null,
+            'sensitive' => (bool) ($def['sensitive'] ?? false),
+            'default' => (bool) ($def['default'] ?? false),
+            'rollout_percentage' => $service->rolloutPercentage($key),
+            'active_for_team' => $service->active($key, $team),
+        ])->values();
+
+        return Response::text(json_encode([
+            'runtime_enabled' => $service->runtimeEnabled(),
+            'flags' => $flags,
+        ]));
+    }
+}

--- a/app/Mcp/Tools/FeatureFlag/FeatureRolloutTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureRolloutTool.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mcp\Tools\FeatureFlag;
+
+use App\Domain\FeatureFlag\Actions\SetFeatureRolloutAction;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('destructive')]
+class FeatureRolloutTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'feature_rollout';
+
+    protected string $description = 'Set the platform-wide percentage rollout (0-100) for a Tier-2 runtime feature flag. Teams without an explicit override are enabled deterministically as the percentage rises. Sensitive flags create a pending approval instead.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('The feature flag key (e.g. beta_feature)')
+                ->required(),
+            'percentage' => $schema->integer()
+                ->description('Rollout percentage, 0-100')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(FeatureFlagService::class);
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $key = (string) $request->get('key');
+
+        if (! array_key_exists($key, $service->definitions())) {
+            return $this->invalidArgumentError("Unknown feature flag: {$key}");
+        }
+
+        $result = app(SetFeatureRolloutAction::class)->execute($key, (int) $request->get('percentage'), auth()->user());
+
+        return Response::text(json_encode($result->toArray()));
+    }
+}

--- a/app/Mcp/Tools/FeatureFlag/FeatureStatusTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureStatusTool.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mcp\Tools\FeatureFlag;
+
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+#[AssistantTool('read')]
+class FeatureStatusTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'feature_status';
+
+    protected string $description = 'Resolved state of one Tier-2 runtime feature flag for the current team: active value, rollout percentage, default, and sensitivity.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('The feature flag key (e.g. beta_feature)')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(FeatureFlagService::class);
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $key = (string) $request->get('key');
+
+        if (! array_key_exists($key, $service->definitions())) {
+            return $this->invalidArgumentError("Unknown feature flag: {$key}");
+        }
+
+        $team = Team::withoutGlobalScopes()->find($teamId);
+        $def = $service->definition($key);
+
+        return Response::text(json_encode([
+            'key' => $key,
+            'label' => $def['label'] ?? $key,
+            'sensitive' => (bool) ($def['sensitive'] ?? false),
+            'default' => (bool) ($def['default'] ?? false),
+            'runtime_enabled' => $service->runtimeEnabled(),
+            'rollout_percentage' => $service->rolloutPercentage($key),
+            'active_for_team' => $service->active($key, $team),
+        ]));
+    }
+}

--- a/app/Mcp/Tools/FeatureFlag/FeatureStatusTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureStatusTool.php
@@ -48,7 +48,7 @@ class FeatureStatusTool extends Tool
             return $this->invalidArgumentError("Unknown feature flag: {$key}");
         }
 
-        $team = Team::withoutGlobalScopes()->find($teamId);
+        $team = Team::find($teamId);
         $def = $service->definition($key);
 
         return Response::text(json_encode([

--- a/app/Mcp/Tools/FeatureFlag/FeatureToggleTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureToggleTool.php
@@ -50,7 +50,7 @@ class FeatureToggleTool extends Tool
             return $this->invalidArgumentError("Unknown feature flag: {$key}");
         }
 
-        $team = Team::withoutGlobalScopes()->findOrFail($teamId);
+        $team = Team::findOrFail($teamId);
 
         $result = app(SetFeatureFlagAction::class)->execute($key, (bool) $request->get('value'), $team, auth()->user());
 

--- a/app/Mcp/Tools/FeatureFlag/FeatureToggleTool.php
+++ b/app/Mcp/Tools/FeatureFlag/FeatureToggleTool.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Mcp\Tools\FeatureFlag;
+
+use App\Domain\FeatureFlag\Actions\SetFeatureFlagAction;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsDestructive;
+
+#[IsDestructive]
+#[AssistantTool('destructive')]
+class FeatureToggleTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'feature_toggle';
+
+    protected string $description = 'Activate or deactivate a Tier-2 runtime feature flag for the current team. Non-sensitive flags apply immediately; sensitive flags create a pending approval request instead of flipping.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'key' => $schema->string()
+                ->description('The feature flag key (e.g. beta_feature)')
+                ->required(),
+            'value' => $schema->boolean()
+                ->description('true to activate, false to deactivate')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $service = app(FeatureFlagService::class);
+        $teamId = app()->bound('mcp.team_id') ? app('mcp.team_id') : null;
+
+        if (! $teamId) {
+            return $this->permissionDeniedError('No team context.');
+        }
+
+        $key = (string) $request->get('key');
+
+        if (! array_key_exists($key, $service->definitions())) {
+            return $this->invalidArgumentError("Unknown feature flag: {$key}");
+        }
+
+        $team = Team::withoutGlobalScopes()->findOrFail($teamId);
+
+        $result = app(SetFeatureFlagAction::class)->execute($key, (bool) $request->get('value'), $team, auth()->user());
+
+        return Response::text(json_encode($result->toArray()));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,6 +39,8 @@ use App\Domain\Experiment\Listeners\RecordReasoningBankEntry;
 use App\Domain\Experiment\Listeners\RecordTransitionMetrics;
 use App\Domain\Experiment\Listeners\ResumeParentOnSubWorkflowComplete;
 use App\Domain\Experiment\Listeners\SendSentryFixPrOpenedEmailListener;
+use App\Domain\FeatureFlag\Listeners\RecordFeatureFlagAudit;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
 use App\Domain\GitRepository\Listeners\QueueContextGitPush;
 use App\Domain\Integration\Events\IntegrationActionExecuted;
 use App\Domain\Memory\Listeners\CompressAndStoreExecutionMemoryListener;
@@ -181,6 +183,8 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Mcp\Events\SessionInitialized;
 use Laravel\Passport\Passport;
+use Laravel\Pennant\Events\FeatureUpdated;
+use Laravel\Pennant\Feature;
 use Laravel\Pulse\Http\Middleware\Authorize;
 use Laravel\Reverb\Events\MessageReceived;
 use Laravel\Sanctum\Sanctum;
@@ -493,6 +497,14 @@ class AppServiceProvider extends ServiceProvider
         // Blade directives for deployment mode
         Blade::if('cloud', fn () => app(DeploymentMode::class)->isCloud());
         Blade::if('selfhosted', fn () => app(DeploymentMode::class)->isSelfHosted());
+
+        // Tier-2 runtime feature flags (Pennant). Definitions are registered at
+        // boot; resolution is team-scoped; the whole tier is gated by
+        // config('feature_flags.runtime_enabled') inside the service/closure.
+        app(FeatureFlagService::class)->defineAll();
+        Feature::resolveScopeUsing(fn () => app(FeatureFlagService::class)->currentTeam());
+        Blade::if('runtimeFeature', fn (string $key) => app(FeatureFlagService::class)->active($key));
+        Event::listen(FeatureUpdated::class, RecordFeatureFlagAudit::class);
 
         // Plugin lifecycle hook: allows plugins to react to Livewire component events
         Livewire::componentHook(PluginDispatchHook::class);

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "laravel/framework": "^13.0",
         "laravel/horizon": "^5.43",
         "laravel/mcp": "^0.7.0",
+        "laravel/pennant": "^1.23",
         "laravel/passport": "^13.6",
         "laravel/pulse": "^1.7",
         "laravel/reverb": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6406aae460ceb651454dbe3e637415c5",
+    "content-hash": "4f8e7834ceaf0aa524d6da7094ec066d",
     "packages": [
         {
             "name": "asbiin/laravel-webauthn",
@@ -3264,6 +3264,82 @@
                 "source": "https://github.com/laravel/passport"
             },
             "time": "2026-04-16T14:00:29+00:00"
+        },
+        {
+            "name": "laravel/pennant",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pennant.git",
+                "reference": "d3d531d0ba640f9d0bd3580990fb205244e956ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pennant/zipball/d3d531d0ba640f9d0bd3580990fb205244e956ca",
+                "reference": "d3d531d0ba640f9d0bd3580990fb205244e956ca",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/container": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/finder": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "laravel/octane": "^1.4|^2.0",
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Feature": "Laravel\\Pennant\\Feature"
+                    },
+                    "providers": [
+                        "Laravel\\Pennant\\PennantServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Pennant\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "A simple, lightweight library for managing feature flags.",
+            "homepage": "https://github.com/laravel/pennant",
+            "keywords": [
+                "feature",
+                "flags",
+                "laravel",
+                "pennant"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pennant/issues",
+                "source": "https://github.com/laravel/pennant"
+            },
+            "time": "2026-03-19T02:27:39+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/config/feature_flags.php
+++ b/config/feature_flags.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Tier-2 runtime feature flags (Laravel Pennant-backed).
+ *
+ * This is the SECOND flag tier, additive to the existing env/config dark-ship
+ * flags (Tier-1). Tier-1 flags stay as plain env booleans flipped at deploy
+ * time; Tier-2 flags are team-scoped, support percentage rollout, and can be
+ * toggled at runtime without a redeploy.
+ *
+ * The whole tier is dark-shipped behind `runtime_enabled`: when false,
+ * FeatureFlagService::active() returns each definition's static `default` and
+ * applies no Pennant override.
+ *
+ * Each definition:
+ *   - label/description/group: human-readable metadata (admin catalog).
+ *   - sensitive: drives the approval gate. MUST be true for anything touching
+ *     security, billing, or destructive behavior. Agent-driven flips of a
+ *     sensitive flag require an ApprovalRequest; non-sensitive flips are
+ *     applied immediately.
+ *   - default: resolved value when there is no per-team override and the
+ *     rollout percentage does not include the team.
+ */
+
+return [
+
+    'runtime_enabled' => env('FEATURE_FLAGS_RUNTIME_ENABLED', false),
+
+    'definitions' => [
+
+        'beta_feature' => [
+            'label' => 'Beta Feature (demo)',
+            'description' => 'Demonstration Tier-2 flag: per-team beta gating layered over percentage rollout.',
+            'group' => 'Demo',
+            'sensitive' => false,
+            'default' => false,
+        ],
+
+    ],
+
+];

--- a/config/pennant.php
+++ b/config/pennant.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Pennant Store
+    |--------------------------------------------------------------------------
+    |
+    | Here you will specify the default store that Pennant should use when
+    | storing and resolving feature flag values. Pennant ships with the
+    | ability to store flag values in an in-memory array or database.
+    |
+    | Supported: "array", "database"
+    |
+    */
+
+    'default' => env('PENNANT_STORE', 'database'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pennant Stores
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure each of the stores that should be available to
+    | Pennant. These stores shall be used to store resolved feature flag
+    | values - you may configure as many as your application requires.
+    |
+    */
+
+    'stores' => [
+
+        'array' => [
+            'driver' => 'array',
+        ],
+
+        'database' => [
+            'driver' => 'database',
+            'connection' => null,
+            'table' => 'features',
+        ],
+
+    ],
+];

--- a/database/migrations/2026_06_23_100521_create_features_table.php
+++ b/database/migrations/2026_06_23_100521_create_features_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pennant\Migrations\PennantMigration;
+
+return new class extends PennantMigration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('features', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('scope');
+            $table->text('value');
+            $table->timestamps();
+
+            $table->unique(['name', 'scope']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('features');
+    }
+};

--- a/database/migrations/2026_06_23_100522_create_feature_flag_rollouts_table.php
+++ b/database/migrations/2026_06_23_100522_create_feature_flag_rollouts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('feature_flag_rollouts', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('key')->unique();
+            $table->unsignedSmallInteger('percentage')->default(0);
+            $table->foreignUuid('updated_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('feature_flag_rollouts');
+    }
+};

--- a/tests/Feature/FeatureFlag/FeatureFlagActionsTest.php
+++ b/tests/Feature/FeatureFlag/FeatureFlagActionsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\FeatureFlag;
+
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\Audit\Models\AuditEntry;
+use App\Domain\FeatureFlag\Actions\ArchiveFeatureFlagAction;
+use App\Domain\FeatureFlag\Actions\SetFeatureFlagAction;
+use App\Domain\FeatureFlag\Actions\SetFeatureRolloutAction;
+use App\Domain\FeatureFlag\Models\FeatureFlagRollout;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class FeatureFlagActionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['feature_flags.runtime_enabled' => true]);
+    }
+
+    private function makeTeam(): Team
+    {
+        $user = User::factory()->create();
+
+        return Team::create([
+            'name' => 'T',
+            'slug' => 'ff-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+    }
+
+    private function defineSensitiveFlag(): void
+    {
+        config(['feature_flags.definitions.sensitive_demo' => [
+            'label' => 'Sensitive Demo',
+            'description' => 'test',
+            'group' => 'Demo',
+            'sensitive' => true,
+            'default' => false,
+        ]]);
+        app(FeatureFlagService::class)->defineAll();
+    }
+
+    public function test_non_sensitive_toggle_applies_and_is_audited(): void
+    {
+        $team = $this->makeTeam();
+
+        $result = app(SetFeatureFlagAction::class)->execute('beta_feature', true, $team);
+
+        $this->assertSame('applied', $result->status);
+        $this->assertTrue(Feature::for($team)->active('beta_feature'));
+        $this->assertTrue(
+            AuditEntry::withoutGlobalScopes()->where('event', 'feature_flag.updated')->exists(),
+        );
+    }
+
+    public function test_sensitive_flip_by_non_super_admin_creates_approval_and_does_not_apply(): void
+    {
+        $this->defineSensitiveFlag();
+        $team = $this->makeTeam();
+        $actor = User::factory()->create(['is_super_admin' => false]);
+
+        $result = app(SetFeatureFlagAction::class)->execute('sensitive_demo', true, $team, $actor);
+
+        $this->assertTrue($result->isPendingApproval());
+        $this->assertNotNull($result->approvalId);
+        $this->assertFalse(Feature::for($team)->active('sensitive_demo'));
+        $this->assertTrue(
+            ApprovalRequest::withoutGlobalScopes()->where('context->type', 'feature_flag_change')->exists(),
+        );
+    }
+
+    public function test_sensitive_flip_by_super_admin_applies_directly(): void
+    {
+        $this->defineSensitiveFlag();
+        $team = $this->makeTeam();
+        $actor = User::factory()->create(['is_super_admin' => true]);
+
+        $result = app(SetFeatureFlagAction::class)->execute('sensitive_demo', true, $team, $actor);
+
+        $this->assertSame('applied', $result->status);
+        $this->assertTrue(Feature::for($team)->active('sensitive_demo'));
+    }
+
+    public function test_rollout_is_clamped_and_audited(): void
+    {
+        $result = app(SetFeatureRolloutAction::class)->execute('beta_feature', 150);
+
+        $this->assertSame(100, $result->percentage);
+        $this->assertSame(100, (int) FeatureFlagRollout::where('key', 'beta_feature')->value('percentage'));
+        $this->assertTrue(
+            AuditEntry::withoutGlobalScopes()->where('event', 'feature_flag.rollout')->exists(),
+        );
+    }
+
+    public function test_archive_purges_overrides_and_rollout(): void
+    {
+        $team = $this->makeTeam();
+        Feature::for($team)->activate('beta_feature');
+        app(SetFeatureRolloutAction::class)->execute('beta_feature', 50);
+
+        app(ArchiveFeatureFlagAction::class)->execute('beta_feature');
+        Feature::flushCache();
+
+        $this->assertFalse(app(FeatureFlagService::class)->active('beta_feature', $team));
+        $this->assertSame(0, FeatureFlagRollout::where('key', 'beta_feature')->count());
+        $this->assertTrue(
+            AuditEntry::withoutGlobalScopes()->where('event', 'feature_flag.archived')->exists(),
+        );
+    }
+}

--- a/tests/Feature/FeatureFlag/FeatureFlagMcpToolsTest.php
+++ b/tests/Feature/FeatureFlag/FeatureFlagMcpToolsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\FeatureFlag;
+
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\FeatureFlag\FeatureListTool;
+use App\Mcp\Tools\FeatureFlag\FeatureRolloutTool;
+use App\Mcp\Tools\FeatureFlag\FeatureStatusTool;
+use App\Mcp\Tools\FeatureFlag\FeatureToggleTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Tests\TestCase;
+
+class FeatureFlagMcpToolsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['feature_flags.runtime_enabled' => true]);
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'MCP Team',
+            'slug' => 'ff-mcp-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    private function decode($response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    public function test_feature_list_returns_flags_and_runtime_state(): void
+    {
+        $data = $this->decode((new FeatureListTool)->handle(new Request([])));
+
+        $this->assertTrue($data['runtime_enabled']);
+        $this->assertNotEmpty($data['flags']);
+        $this->assertContains('beta_feature', array_column($data['flags'], 'key'));
+    }
+
+    public function test_feature_status_unknown_key_is_invalid_argument(): void
+    {
+        $response = (new FeatureStatusTool)->handle(new Request(['key' => 'nope']));
+
+        $this->assertStringContainsString('Unknown feature flag', (string) $response->content());
+    }
+
+    public function test_feature_toggle_non_sensitive_applies(): void
+    {
+        $data = $this->decode((new FeatureToggleTool)->handle(new Request([
+            'key' => 'beta_feature',
+            'value' => true,
+        ])));
+
+        $this->assertSame('applied', $data['status']);
+        $this->assertTrue(app(FeatureFlagService::class)->active('beta_feature', $this->team));
+    }
+
+    public function test_feature_toggle_sensitive_returns_pending_approval(): void
+    {
+        config(['feature_flags.definitions.sensitive_demo' => [
+            'label' => 'Sensitive Demo',
+            'sensitive' => true,
+            'default' => false,
+        ]]);
+        app(FeatureFlagService::class)->defineAll();
+
+        $data = $this->decode((new FeatureToggleTool)->handle(new Request([
+            'key' => 'sensitive_demo',
+            'value' => true,
+        ])));
+
+        $this->assertSame('pending_approval', $data['status']);
+        $this->assertArrayHasKey('approval_id', $data);
+        $this->assertFalse(app(FeatureFlagService::class)->active('sensitive_demo', $this->team));
+    }
+
+    public function test_feature_rollout_sets_percentage(): void
+    {
+        $this->decode((new FeatureRolloutTool)->handle(new Request([
+            'key' => 'beta_feature',
+            'percentage' => 40,
+        ])));
+
+        $status = $this->decode((new FeatureStatusTool)->handle(new Request(['key' => 'beta_feature'])));
+        $this->assertSame(40, $status['rollout_percentage']);
+    }
+
+    public function test_no_team_context_is_permission_denied(): void
+    {
+        app()->forgetInstance('mcp.team_id');
+
+        $response = (new FeatureListTool)->handle(new Request([]));
+
+        $this->assertStringContainsString('team', strtolower((string) $response->content()));
+    }
+}

--- a/tests/Feature/FeatureFlag/FeatureFlagServiceTest.php
+++ b/tests/Feature/FeatureFlag/FeatureFlagServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\FeatureFlag;
+
+use App\Domain\FeatureFlag\Actions\SetFeatureRolloutAction;
+use App\Domain\FeatureFlag\Exceptions\UnknownFeatureFlagException;
+use App\Domain\FeatureFlag\Services\FeatureFlagService;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+class FeatureFlagServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private FeatureFlagService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(FeatureFlagService::class);
+    }
+
+    private function makeTeam(string $slug): Team
+    {
+        $user = User::factory()->create();
+
+        return Team::create([
+            'name' => 'T '.$slug,
+            'slug' => 'ff-'.$slug.'-'.uniqid(),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+    }
+
+    public function test_meta_flag_off_returns_static_default_even_with_stored_override(): void
+    {
+        config(['feature_flags.runtime_enabled' => true]);
+        $team = $this->makeTeam('a');
+        Feature::for($team)->activate('beta_feature');
+
+        config(['feature_flags.runtime_enabled' => false]);
+        Feature::flushCache();
+
+        $this->assertFalse($this->service->active('beta_feature', $team));
+    }
+
+    public function test_meta_flag_on_no_override_zero_rollout_returns_default(): void
+    {
+        config(['feature_flags.runtime_enabled' => true]);
+        $team = $this->makeTeam('b');
+
+        $this->assertFalse($this->service->active('beta_feature', $team));
+    }
+
+    public function test_per_team_override_wins_over_rollout(): void
+    {
+        config(['feature_flags.runtime_enabled' => true]);
+        $teamA = $this->makeTeam('on');
+        $teamB = $this->makeTeam('off');
+
+        Feature::for($teamA)->activate('beta_feature');
+
+        $this->assertTrue($this->service->active('beta_feature', $teamA));
+        $this->assertFalse($this->service->active('beta_feature', $teamB));
+    }
+
+    public function test_rollout_100_enables_all_and_0_returns_default(): void
+    {
+        config(['feature_flags.runtime_enabled' => true]);
+        $team = $this->makeTeam('c');
+
+        app(SetFeatureRolloutAction::class)->execute('beta_feature', 100);
+        Feature::purge('beta_feature');
+        Feature::flushCache();
+        $this->assertTrue($this->service->active('beta_feature', $team));
+
+        app(SetFeatureRolloutAction::class)->execute('beta_feature', 0);
+        Feature::purge('beta_feature');
+        Feature::flushCache();
+        $this->assertFalse($this->service->active('beta_feature', $team));
+    }
+
+    public function test_rollout_bucket_is_monotonic(): void
+    {
+        config(['feature_flags.runtime_enabled' => true]);
+        $teams = collect(range(1, 30))->map(fn ($i) => $this->makeTeam("m{$i}"));
+
+        $enabledAt = function (int $pct) use ($teams): array {
+            app(SetFeatureRolloutAction::class)->execute('beta_feature', $pct);
+            Feature::purge('beta_feature');
+            Feature::flushCache();
+
+            return $teams->filter(fn (Team $t) => $this->service->active('beta_feature', $t))
+                ->map->id->values()->all();
+        };
+
+        $at10 = $enabledAt(10);
+        $at50 = $enabledAt(50);
+
+        $this->assertEmpty(array_diff($at10, $at50), 'Teams enabled at 10% must remain enabled at 50%.');
+    }
+
+    public function test_unknown_flag_throws(): void
+    {
+        $this->expectException(UnknownFeatureFlagException::class);
+        $this->service->definition('does_not_exist');
+    }
+
+    public function test_scope_isolation_between_teams(): void
+    {
+        config(['feature_flags.runtime_enabled' => true]);
+        $teamA = $this->makeTeam('iso-a');
+        $teamB = $this->makeTeam('iso-b');
+
+        Feature::for($teamA)->activate('beta_feature');
+
+        $this->assertTrue($this->service->active('beta_feature', $teamA));
+        $this->assertFalse($this->service->active('beta_feature', $teamB));
+    }
+}


### PR DESCRIPTION
## Summary
Second feature-flag tier alongside the existing env dark-ship flags: **team-scoped, percentage-rollout, runtime-toggleable** via Laravel Pennant. Dark-shipped behind `FEATURE_FLAGS_RUNTIME_ENABLED` (default **off**) — when off, reads return the static definition default and no override is consulted.

Borrowed from [Vercel Flags](https://vercel.com/blog/vercel-flags-platform-native-feature-flags): decouple deploy/release, progressive rollout, **agent-native flag management**. Laravel/Livewire-native; none of the Vercel/Next.js runtime bits.

## What's here
- **FeatureFlagService** — meta-flag-gated read, deterministic *monotonic* rollout bucket, per-team override precedence, sensitivity classification
- **Actions** Set / Rollout / Archive with a **sensitivity gate**: sensitive flips (security/billing/destructive) by a non-super-admin (e.g. an agent over MCP) create an `ApprovalRequest` instead of applying; non-sensitive apply immediately (agent-autonomous)
- **5 MCP tools** `feature_list / feature_status / feature_toggle / feature_rollout / feature_archive` + assistant tools via `#[AssistantTool]`
- `FeatureUpdated` → `AuditEntry`; `feature_flag_rollouts` table + published Pennant `features` table

## Tests
18 tests (service / actions / MCP) — meta-flag off no-op, per-team override wins over rollout, monotonic rollout, sensitivity approval gate, super-admin direct, audit. larastan + pint clean. 363 existing MCP tests still green (boot change).

## Activation
`FEATURE_FLAGS_RUNTIME_ENABLED=true` → `config:cache` → `kill -USR2 1`. Admin UI in the cloud parent PR.

⚠️ Draft — human merge only, never auto-merge.