### PR TITLE
feat(ai-routing): eval-grounded routing (shadow) + savings-vs-flagship metric

### DIFF
--- a/app/Infrastructure/AI/Middleware/EvalGroundedRoutingShadow.php
+++ b/app/Infrastructure/AI/Middleware/EvalGroundedRoutingShadow.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Infrastructure\AI\Middleware;
+
+use App\Infrastructure\AI\Contracts\AiMiddlewareInterface;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\Services\EvalGroundedModelRecommender;
+use App\Infrastructure\AI\Services\EvalShadowCounters;
+use Closure;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * SHADOW / advisory eval-grounded routing (Cast AI "AI Enabler" borrow).
+ *
+ * Pass-through: computes the cheapest model that historically cleared the
+ * quality bar for this task-type, LOGS the recommendation, and counts it — then
+ * forwards the request UNCHANGED. It NEVER alters provider/model, so it is safe
+ * to flip on for any provider archetype (cloud Prism, claude-code-vps, bridge).
+ * Sits after BudgetPressureRouting so it sees the post-budget chosen model.
+ */
+class EvalGroundedRoutingShadow implements AiMiddlewareInterface
+{
+    public function __construct(
+        private readonly EvalGroundedModelRecommender $recommender,
+        private readonly EvalShadowCounters $counters,
+    ) {}
+
+    public function handle(AiRequestDTO $request, Closure $next): AiResponseDTO
+    {
+        if (config('ai_routing.eval_grounded.enabled') && $request->teamId) {
+            try {
+                $recommendation = $this->recommender->recommend($request);
+                if ($recommendation !== null) {
+                    Log::channel(config('ai_routing.eval_grounded.log_channel', 'stack'))
+                        ->info('[eval-routing-shadow]', $recommendation);
+                    $this->counters->record($request->teamId, $recommendation);
+                }
+            } catch (\Throwable $e) {
+                // Telemetry must never break the gateway — observe-only.
+                Log::warning('eval-routing-shadow failed', ['error' => $e->getMessage()]);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Infrastructure/AI/Services/EvalGroundedModelRecommender.php
+++ b/app/Infrastructure/AI/Services/EvalGroundedModelRecommender.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Infrastructure\AI\Services;
+
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Eval-grounded model recommendation (Cast AI "AI Enabler" borrow), SHADOW only.
+ *
+ * For a request's task-type (purpose), looks at recent recorded quality
+ * outcomes per model — `ai_runs.verification_passed` / `schema_valid` /
+ * completion are the eval gate already persisted per run — and recommends the
+ * CHEAPEST model whose success rate clears the configured threshold.
+ *
+ * We source the quality signal from `ai_runs` rather than `evaluation_runs`
+ * because eval runs evaluate agents/workflows and store no "model-under-test"
+ * dimension, whereas every ai_run records (purpose, provider, model, cost,
+ * pass/fail) — exactly the (task-type × model) grid this needs.
+ *
+ * Returns null when the feature is off, there's no team, or no model has
+ * enough samples clearing the bar. The caller never mutates routing from this.
+ */
+class EvalGroundedModelRecommender
+{
+    /**
+     * @return array{
+     *   purpose: string,
+     *   recommended_provider: string,
+     *   recommended_model: string,
+     *   recommended_avg_cost: float,
+     *   recommended_success_rate: float,
+     *   sample_size: int,
+     *   scope: string,
+     *   chosen_model: string,
+     *   chosen_avg_cost: float|null,
+     *   would_downgrade: bool,
+     *   est_savings_per_call: float
+     * }|null
+     */
+    public function recommend(AiRequestDTO $request): ?array
+    {
+        if (! config('ai_routing.eval_grounded.enabled')) {
+            return null;
+        }
+
+        if (! $request->teamId) {
+            return null;
+        }
+
+        $complexity = $request->classifiedComplexity;
+        $purpose = $request->purpose ?: ('tier:'.($complexity !== null ? $complexity->value : 'unknown'));
+        $windowDays = (int) config('ai_routing.eval_grounded.window_days', 30);
+        $minSamples = (int) config('ai_routing.eval_grounded.min_samples', 20);
+        $threshold = (float) config('ai_routing.eval_grounded.success_threshold', 0.9);
+        $cutoff = now()->subDays($windowDays);
+
+        $rows = $this->scoreModels($purpose, $cutoff, $request->teamId);
+        $scope = 'team';
+
+        $teamSampleTotal = (int) array_sum(array_map(static fn ($r) => (int) $r->total, $rows));
+        if ($teamSampleTotal < $minSamples && config('ai_routing.eval_grounded.platform_fallback', true)) {
+            $rows = $this->scoreModels($purpose, $cutoff, null);
+            $scope = 'platform';
+        }
+
+        if ($rows === []) {
+            return null;
+        }
+
+        $candidates = array_filter(
+            $rows,
+            static fn ($r) => (int) $r->total >= $minSamples && (float) $r->success_rate >= $threshold,
+        );
+
+        if ($candidates === []) {
+            return null;
+        }
+
+        usort($candidates, static fn ($a, $b) => (float) $a->avg_cost <=> (float) $b->avg_cost);
+        $best = $candidates[0];
+
+        $chosen = null;
+        foreach ($rows as $r) {
+            if ($r->provider === $request->provider && $r->model === $request->model) {
+                $chosen = $r;
+                break;
+            }
+        }
+        $chosenAvgCost = $chosen !== null ? (float) $chosen->avg_cost : null;
+
+        $wouldDowngrade = $chosenAvgCost !== null && (float) $best->avg_cost < $chosenAvgCost;
+        $estSaving = $wouldDowngrade ? max(0.0, $chosenAvgCost - (float) $best->avg_cost) : 0.0;
+
+        return [
+            'purpose' => $purpose,
+            'recommended_provider' => (string) $best->provider,
+            'recommended_model' => (string) $best->model,
+            'recommended_avg_cost' => round((float) $best->avg_cost, 2),
+            'recommended_success_rate' => round((float) $best->success_rate, 3),
+            'sample_size' => (int) $best->total,
+            'scope' => $scope,
+            'chosen_model' => "{$request->provider}/{$request->model}",
+            'chosen_avg_cost' => $chosenAvgCost !== null ? round($chosenAvgCost, 2) : null,
+            'would_downgrade' => $wouldDowngrade,
+            'est_savings_per_call' => round($estSaving, 2),
+        ];
+    }
+
+    /**
+     * @return list<object{provider: string, model: string, total: int, success_rate: float, avg_cost: float}>
+     */
+    private function scoreModels(string $purpose, \DateTimeInterface $cutoff, ?string $teamId): array
+    {
+        // Query builder (not the Eloquent model) so the aggregate aliases are
+        // plain stdClass attributes — keeps larastan's checkModelProperties off
+        // our back and lets withoutGlobalScopes + explicit team_id be the only
+        // tenancy filter regardless of console/queue context.
+        $query = DB::table('ai_runs')
+            ->where('purpose', $purpose)
+            ->where('created_at', '>=', $cutoff);
+
+        if ($teamId !== null) {
+            $query->where('team_id', $teamId);
+        }
+
+        return $query->select(
+            'provider',
+            'model',
+            DB::raw('COUNT(*) as total'),
+            DB::raw($this->successExpression().' as success_rate'),
+            DB::raw('AVG(cost_credits) as avg_cost'),
+        )
+            ->groupBy('provider', 'model')
+            ->get()
+            ->all();
+    }
+
+    /**
+     * Fraction of runs that completed AND were not flagged as a quality failure.
+     * NULL verification/schema means "not gated" → counts as a pass. Built per
+     * driver because PostgreSQL booleans and SQLite 0/1 ints differ.
+     */
+    private function successExpression(): string
+    {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            return "AVG(CASE WHEN status = 'completed' AND verification_passed IS NOT FALSE AND schema_valid IS NOT FALSE THEN 1.0 ELSE 0.0 END)";
+        }
+
+        return "AVG(CASE WHEN status = 'completed' AND COALESCE(verification_passed, 1) = 1 AND COALESCE(schema_valid, 1) = 1 THEN 1.0 ELSE 0.0 END)";
+    }
+}

--- a/app/Infrastructure/AI/Services/EvalShadowCounters.php
+++ b/app/Infrastructure/AI/Services/EvalShadowCounters.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Infrastructure\AI\Services;
+
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * Rolling per-team daily counters for eval-grounded routing in SHADOW mode.
+ *
+ * The shadow middleware records every advisory recommendation here; the AI
+ * Routing page reads the window's totals. Pure telemetry — never gates a
+ * request — so small races under concurrency are acceptable. Backed by Redis
+ * hashes with a short TTL; one hash per (team, day).
+ */
+class EvalShadowCounters
+{
+    private const PREFIX = 'eval_shadow';
+
+    // Longest supported dashboard window (30d) plus a buffer day.
+    private const TTL_SECONDS = 31 * 86400;
+
+    /**
+     * @param  array{would_downgrade?: bool, est_savings_per_call?: float|int}  $recommendation
+     */
+    public function record(string $teamId, array $recommendation): void
+    {
+        $key = $this->key($teamId, now()->format('Ymd'));
+
+        Redis::hincrby($key, 'total', 1);
+
+        if (! empty($recommendation['would_downgrade'])) {
+            Redis::hincrby($key, 'would_downgrade', 1);
+            $saving = (int) round((float) ($recommendation['est_savings_per_call'] ?? 0));
+            if ($saving > 0) {
+                Redis::hincrby($key, 'est_savings_credits', $saving);
+            }
+        }
+
+        Redis::expire($key, self::TTL_SECONDS);
+    }
+
+    /**
+     * Sum the per-day counters across the trailing window.
+     *
+     * @return array{total: int, would_downgrade: int, est_savings_credits: int}
+     */
+    public function totals(string $teamId, int $days): array
+    {
+        $total = 0;
+        $downgrade = 0;
+        $savings = 0;
+
+        for ($i = 0; $i < max(1, $days); $i++) {
+            $hash = Redis::hgetall($this->key($teamId, now()->subDays($i)->format('Ymd')));
+            if (! $hash) {
+                continue;
+            }
+            $total += (int) ($hash['total'] ?? 0);
+            $downgrade += (int) ($hash['would_downgrade'] ?? 0);
+            $savings += (int) ($hash['est_savings_credits'] ?? 0);
+        }
+
+        return [
+            'total' => $total,
+            'would_downgrade' => $downgrade,
+            'est_savings_credits' => $savings,
+        ];
+    }
+
+    private function key(string $teamId, string $day): string
+    {
+        return self::PREFIX.":{$teamId}:{$day}";
+    }
+}

--- a/app/Livewire/Metrics/AiRoutingPage.php
+++ b/app/Livewire/Metrics/AiRoutingPage.php
@@ -192,7 +192,7 @@ class AiRoutingPage extends Component
     private function getTopModels($query): array
     {
         return $query->select(
-            DB::raw("CONCAT(provider, '/', model) as model_key"),
+            DB::raw("(provider || '/' || model) as model_key"),
             DB::raw('COUNT(*) as requests'),
             DB::raw('AVG(latency_ms) as avg_latency'),
             DB::raw('AVG(cost_credits) as avg_cost'),

--- a/app/Livewire/Metrics/AiRoutingPage.php
+++ b/app/Livewire/Metrics/AiRoutingPage.php
@@ -3,6 +3,8 @@
 namespace App\Livewire\Metrics;
 
 use App\Domain\Agent\Models\AiRun;
+use App\Domain\Budget\Services\CostCalculator;
+use App\Infrastructure\AI\Services\EvalShadowCounters;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
@@ -21,7 +23,7 @@ class AiRoutingPage extends Component
         $teamId = auth()->user()->current_team_id;
         $cacheKey = "ai_routing.stats:{$teamId}:{$this->timeWindow}";
 
-        $stats = Cache::remember($cacheKey, 30, function () {
+        $stats = Cache::remember($cacheKey, 30, function () use ($teamId) {
             $cutoff = match ($this->timeWindow) {
                 '24h' => now()->subDay(),
                 '7d' => now()->subWeek(),
@@ -39,6 +41,7 @@ class AiRoutingPage extends Component
                 'costSavings' => $this->getCostSavings($query->clone()),
                 'topModels' => $this->getTopModels($query->clone()),
                 'totalRequests' => $query->clone()->count(),
+                'evalShadow' => $this->getEvalShadow($teamId),
             ];
         });
 
@@ -119,50 +122,70 @@ class AiRoutingPage extends Component
         ];
     }
 
+    /**
+     * Counterfactual "credits saved vs always-flagship": re-price the period's
+     * actual token volume at the configured baseline (flagship) model and
+     * compare to what was actually spent. Both sides are in credits (via
+     * CostCalculator), so the figure is unit-coherent — the previous version
+     * mixed credits with raw USD-per-token rates and always reported 0%.
+     */
     private function getCostSavings($query): object
     {
         $actualCost = (int) $query->clone()->sum('cost_credits');
 
-        // Find the most expensive model's output pricing as the "expensive tier" baseline
-        $models = config('llm_pricing.models', config('llm_pricing.providers', []));
-        $maxOutputRate = 0;
-        foreach ($models as $providerModels) {
-            foreach ($providerModels as $pricing) {
-                if (isset($pricing['output']) && $pricing['output'] > $maxOutputRate) {
-                    $maxOutputRate = $pricing['output'];
-                }
-            }
-        }
-
-        // Theoretical cost: re-price all tokens at the most expensive rate
         $tokenStats = $query->clone()->select(
-            DB::raw('SUM(input_tokens) as total_input'),
-            DB::raw('SUM(output_tokens) as total_output'),
+            DB::raw('COALESCE(SUM(input_tokens), 0) as total_input'),
+            DB::raw('COALESCE(SUM(output_tokens), 0) as total_output'),
         )->first();
 
-        $maxInputRate = 0;
-        foreach ($models as $providerModels) {
-            foreach ($providerModels as $pricing) {
-                if (isset($pricing['input']) && $pricing['input'] > $maxInputRate) {
-                    $maxInputRate = $pricing['input'];
-                }
-            }
-        }
+        $baseline = config('ai_routing.savings_baseline');
+        $baselineModel = (string) ($baseline['model'] ?? '');
 
-        $theoreticalCost = 0;
-        if ($tokenStats) {
-            $theoreticalCost = (int) (
-                (($tokenStats->total_input ?? 0) / 1000 * $maxInputRate) +
-                (($tokenStats->total_output ?? 0) / 1000 * $maxOutputRate)
-            );
-        }
+        $theoreticalCost = app(CostCalculator::class)->calculateCost(
+            (string) ($baseline['provider'] ?? ''),
+            $baselineModel,
+            (int) ($tokenStats->total_input ?? 0),
+            (int) ($tokenStats->total_output ?? 0),
+        );
 
-        $savings = $theoreticalCost > 0 ? round((1 - ($actualCost / $theoreticalCost)) * 100, 1) : 0;
+        $saved = max(0, $theoreticalCost - $actualCost);
+        $savingsPct = $theoreticalCost > 0 ? round(($saved / $theoreticalCost) * 100, 1) : 0;
 
         return (object) [
             'actual' => $actualCost,
             'theoretical' => $theoreticalCost,
-            'savings_pct' => max(0, $savings),
+            'saved_credits' => $saved,
+            'savings_pct' => $savingsPct,
+            'baseline_model' => $baselineModel,
+        ];
+    }
+
+    /**
+     * Eval-grounded routing shadow telemetry (advisory only — never changes
+     * live routing). Reads the rolling Redis counters the shadow middleware
+     * writes; empty/zeroed when the feature is off or no traffic recorded.
+     *
+     * @return object{enabled: bool, total: int, would_downgrade: int, downgrade_pct: float, est_savings_credits: int}
+     */
+    private function getEvalShadow(string $teamId): object
+    {
+        $days = match ($this->timeWindow) {
+            '24h' => 1,
+            '30d' => 30,
+            default => 7,
+        };
+
+        $totals = app(EvalShadowCounters::class)->totals($teamId, $days);
+
+        $total = (int) $totals['total'];
+        $downgrade = (int) $totals['would_downgrade'];
+
+        return (object) [
+            'enabled' => (bool) config('ai_routing.eval_grounded.enabled'),
+            'total' => $total,
+            'would_downgrade' => $downgrade,
+            'downgrade_pct' => $total > 0 ? round(($downgrade / $total) * 100, 1) : 0,
+            'est_savings_credits' => (int) $totals['est_savings_credits'],
         ];
     }
 

--- a/app/Providers/AiServiceProvider.php
+++ b/app/Providers/AiServiceProvider.php
@@ -14,6 +14,7 @@ use App\Infrastructure\AI\Gateways\PrismAiGateway;
 use App\Infrastructure\AI\Middleware\BudgetEnforcement;
 use App\Infrastructure\AI\Middleware\BudgetPressureRouting;
 use App\Infrastructure\AI\Middleware\ContextCompaction;
+use App\Infrastructure\AI\Middleware\EvalGroundedRoutingShadow;
 use App\Infrastructure\AI\Middleware\IdempotencyCheck;
 use App\Infrastructure\AI\Middleware\LangfuseExportMiddleware;
 use App\Infrastructure\AI\Middleware\PhoenixExportMiddleware;
@@ -79,6 +80,10 @@ class AiServiceProvider extends ServiceProvider
             $middleware = [
                 $app->make(RateLimiting::class),
                 $app->make(BudgetPressureRouting::class),
+                // SHADOW eval-grounded routing — observes the post-budget chosen model,
+                // logs the cheapest model that historically cleared the quality bar, and
+                // forwards the request untouched. Self-gated by config flag (default off).
+                $app->make(EvalGroundedRoutingShadow::class),
                 $app->make(BudgetEnforcement::class),
                 $app->make(IdempotencyCheck::class),
                 // SteeringInjection runs AFTER IdempotencyCheck so steering creates a new

--- a/config/ai_routing.php
+++ b/config/ai_routing.php
@@ -193,4 +193,46 @@ return [
         'default_sort' => env('AI_PROVIDER_RANKING_SORT'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Savings Baseline (counterfactual "credits saved vs flagship")
+    |--------------------------------------------------------------------------
+    |
+    | AiRoutingPage re-prices the period's actual token volume at this single
+    | flagship model to compute "credits saved vs always-flagship". The baseline
+    | must be a model present in config/llm_pricing.php; if it has no pricing the
+    | savings metric degrades gracefully to zero (never throws).
+    |
+    */
+    'savings_baseline' => [
+        'provider' => env('AI_SAVINGS_BASELINE_PROVIDER', 'anthropic'),
+        'model' => env('AI_SAVINGS_BASELINE_MODEL', 'claude-opus-4-6'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Eval-Grounded Routing (SHADOW / advisory — Cast AI "AI Enabler" borrow)
+    |--------------------------------------------------------------------------
+    |
+    | Observe-only: for each request, recommend the cheapest model whose recent
+    | recorded quality outcomes (ai_runs verification_passed / schema_valid /
+    | completion) clear a success threshold for the same task-type (purpose).
+    | The recommendation is LOGGED and counted — the live routing decision is
+    | NEVER changed. Flip to active routing only after shadow data proves the
+    | cheaper picks hold quality. Disabled by default.
+    |
+    */
+    'eval_grounded' => [
+        'enabled' => (bool) env('AI_ROUTING_EVAL_GROUNDED', false),
+        // Recent window of ai_runs outcomes used to score each (purpose, model).
+        'window_days' => (int) env('AI_ROUTING_EVAL_WINDOW_DAYS', 30),
+        // Minimum runs for a (purpose, model) cell to be eligible — guards noise.
+        'min_samples' => (int) env('AI_ROUTING_EVAL_MIN_SAMPLES', 20),
+        // Success rate a model must clear to be a routing candidate (0..1).
+        'success_threshold' => (float) env('AI_ROUTING_EVAL_SUCCESS_THRESHOLD', 0.9),
+        // When team-scoped data is too sparse, fall back to platform-wide outcomes.
+        'platform_fallback' => (bool) env('AI_ROUTING_EVAL_PLATFORM_FALLBACK', true),
+        'log_channel' => env('AI_ROUTING_EVAL_LOG_CHANNEL', 'stack'),
+    ],
+
 ];

--- a/resources/views/livewire/metrics/ai-routing-page.blade.php
+++ b/resources/views/livewire/metrics/ai-routing-page.blade.php
@@ -20,11 +20,11 @@
             <p class="mt-1 text-3xl font-bold text-gray-900">{{ number_format($totalRequests) }}</p>
         </div>
         <div class="rounded-xl border border-gray-200 bg-white p-5">
-            <p class="text-xs font-medium uppercase tracking-wider text-gray-400">Cost Savings</p>
-            <p class="mt-1 text-3xl font-bold {{ $costSavings->savings_pct > 0 ? 'text-green-600' : 'text-gray-900' }}">
-                {{ $costSavings->savings_pct }}%
+            <p class="text-xs font-medium uppercase tracking-wider text-gray-400">Credits Saved</p>
+            <p class="mt-1 text-3xl font-bold {{ $costSavings->saved_credits > 0 ? 'text-green-600' : 'text-gray-900' }}">
+                ≈ {{ number_format($costSavings->saved_credits) }}
             </p>
-            <p class="mt-0.5 text-xs text-gray-400">vs all-expensive tier</p>
+            <p class="mt-0.5 text-xs text-gray-400">{{ $costSavings->savings_pct }}% vs always {{ $costSavings->baseline_model ?: 'flagship' }}</p>
         </div>
         <div class="rounded-xl border border-gray-200 bg-white p-5">
             <p class="text-xs font-medium uppercase tracking-wider text-gray-400">Escalation Rate</p>
@@ -145,12 +145,39 @@
         </div>
     </div>
 
+    {{-- Eval-Grounded Routing (Shadow) --}}
+    <div class="mb-6 rounded-xl border border-gray-200 bg-white">
+        <div class="flex items-center justify-between border-b border-gray-200 px-5 py-3">
+            <h3 class="text-sm font-semibold text-gray-900">Eval-Grounded Routing (Shadow)</h3>
+            <span class="rounded-full px-2 py-0.5 text-xs font-medium {{ $evalShadow->enabled ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-500' }}">
+                {{ $evalShadow->enabled ? 'Observing' : 'Off' }}
+            </span>
+        </div>
+        <div class="grid grid-cols-1 gap-4 p-5 sm:grid-cols-3">
+            <div>
+                <p class="text-xs font-medium uppercase tracking-wider text-gray-400">Calls Analyzed</p>
+                <p class="mt-1 text-2xl font-bold text-gray-900">{{ number_format($evalShadow->total) }}</p>
+            </div>
+            <div>
+                <p class="text-xs font-medium uppercase tracking-wider text-gray-400">Would Downgrade</p>
+                <p class="mt-1 text-2xl font-bold text-gray-900">{{ $evalShadow->downgrade_pct }}%</p>
+                <p class="mt-0.5 text-xs text-gray-400">{{ number_format($evalShadow->would_downgrade) }} calls a cheaper model passed the bar</p>
+            </div>
+            <div>
+                <p class="text-xs font-medium uppercase tracking-wider text-gray-400">Est. Extra Savings</p>
+                <p class="mt-1 text-2xl font-bold {{ $evalShadow->est_savings_credits > 0 ? 'text-green-600' : 'text-gray-900' }}">≈ {{ number_format($evalShadow->est_savings_credits) }}</p>
+                <p class="mt-0.5 text-xs text-gray-400">credits, if recommendations were applied</p>
+            </div>
+        </div>
+    </div>
+
     {{-- Legend --}}
     <div class="rounded-lg bg-gray-50 p-3">
         <p class="text-xs text-gray-500">
             <strong>Tier</strong> — Complexity classification (light/standard/heavy) used for model routing.
             <strong>Budget Pressure</strong> — Spending pressure level at time of request.
-            <strong>Cost Savings</strong> — Percentage saved vs routing everything through the most expensive model.
+            <strong>Credits Saved</strong> — Credits saved vs re-pricing the same token volume at the flagship baseline model.
+            <strong>Eval-Grounded Routing (Shadow)</strong> — Advisory only: how often a cheaper model historically cleared the quality bar for the same task-type. Does not change live routing.
             <strong>Cost</strong> — Credits consumed (1 credit = $0.001).
         </p>
     </div>

--- a/tests/Feature/Infrastructure/AI/EvalGroundedModelRecommenderTest.php
+++ b/tests/Feature/Infrastructure/AI/EvalGroundedModelRecommenderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\Infrastructure\AI;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\Services\EvalGroundedModelRecommender;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EvalGroundedModelRecommenderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private EvalGroundedModelRecommender $recommender;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->recommender = app(EvalGroundedModelRecommender::class);
+        $this->team = Team::factory()->create();
+
+        config()->set('ai_routing.eval_grounded.enabled', true);
+        config()->set('ai_routing.eval_grounded.min_samples', 3);
+        config()->set('ai_routing.eval_grounded.success_threshold', 0.9);
+        config()->set('ai_routing.eval_grounded.platform_fallback', false);
+    }
+
+    private function makeRuns(string $model, int $count, int $credits, ?bool $verificationPassed, string $status = 'completed', string $purpose = 'scoring'): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            AiRun::create([
+                'team_id' => $this->team->id,
+                'purpose' => $purpose,
+                'provider' => 'anthropic',
+                'model' => $model,
+                'prompt_snapshot' => [],
+                'cost_credits' => $credits,
+                'status' => $status,
+                'verification_passed' => $verificationPassed,
+            ]);
+        }
+    }
+
+    private function request(string $model = 'claude-opus-4-6', ?string $teamId = null, string $purpose = 'scoring'): AiRequestDTO
+    {
+        return new AiRequestDTO(
+            provider: 'anthropic',
+            model: $model,
+            systemPrompt: 'x',
+            userPrompt: 'y',
+            teamId: $teamId ?? $this->team->id,
+            purpose: $purpose,
+        );
+    }
+
+    public function test_returns_null_when_flag_disabled(): void
+    {
+        config()->set('ai_routing.eval_grounded.enabled', false);
+        $this->makeRuns('claude-haiku-4-5', 5, 5, true);
+
+        $this->assertNull($this->recommender->recommend($this->request()));
+    }
+
+    public function test_returns_null_without_team(): void
+    {
+        $this->assertNull($this->recommender->recommend($this->request(teamId: '')));
+    }
+
+    public function test_recommends_cheapest_passing_model_and_flags_downgrade(): void
+    {
+        // Cheap model clears the bar; expensive model also passes but costs more.
+        $this->makeRuns('claude-haiku-4-5', 5, 5, true);
+        $this->makeRuns('claude-opus-4-6', 5, 50, true);
+
+        // Chosen model on the request is the expensive one.
+        $rec = $this->recommender->recommend($this->request(model: 'claude-opus-4-6'));
+
+        $this->assertNotNull($rec);
+        $this->assertSame('claude-haiku-4-5', $rec['recommended_model']);
+        $this->assertTrue($rec['would_downgrade']);
+        $this->assertSame(45.0, $rec['est_savings_per_call']);
+        $this->assertSame('team', $rec['scope']);
+    }
+
+    public function test_skips_cheap_model_that_fails_quality_bar(): void
+    {
+        // Cheap model fails verification on every run → not a candidate.
+        $this->makeRuns('claude-haiku-4-5', 5, 5, false);
+        $this->makeRuns('claude-opus-4-6', 5, 50, true);
+
+        $rec = $this->recommender->recommend($this->request(model: 'claude-opus-4-6'));
+
+        $this->assertNotNull($rec);
+        $this->assertSame('claude-opus-4-6', $rec['recommended_model']);
+        $this->assertFalse($rec['would_downgrade']);
+    }
+
+    public function test_returns_null_when_samples_below_minimum(): void
+    {
+        $this->makeRuns('claude-haiku-4-5', 2, 5, true);
+
+        $this->assertNull($this->recommender->recommend($this->request()));
+    }
+
+    public function test_falls_back_to_platform_wide_when_team_sparse(): void
+    {
+        config()->set('ai_routing.eval_grounded.platform_fallback', true);
+
+        $otherTeam = Team::factory()->create();
+        for ($i = 0; $i < 5; $i++) {
+            AiRun::create([
+                'team_id' => $otherTeam->id,
+                'purpose' => 'scoring',
+                'provider' => 'anthropic',
+                'model' => 'claude-haiku-4-5',
+                'prompt_snapshot' => [],
+                'cost_credits' => 5,
+                'status' => 'completed',
+                'verification_passed' => true,
+            ]);
+        }
+
+        $rec = $this->recommender->recommend($this->request());
+
+        $this->assertNotNull($rec);
+        $this->assertSame('platform', $rec['scope']);
+        $this->assertSame('claude-haiku-4-5', $rec['recommended_model']);
+    }
+}

--- a/tests/Feature/Infrastructure/AI/EvalGroundedRoutingShadowTest.php
+++ b/tests/Feature/Infrastructure/AI/EvalGroundedRoutingShadowTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\Infrastructure\AI;
+
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Infrastructure\AI\Middleware\EvalGroundedRoutingShadow;
+use App\Infrastructure\AI\Services\EvalGroundedModelRecommender;
+use App\Infrastructure\AI\Services\EvalShadowCounters;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class EvalGroundedRoutingShadowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function request(string $provider = 'anthropic', string $model = 'claude-opus-4-6'): AiRequestDTO
+    {
+        return new AiRequestDTO(
+            provider: $provider,
+            model: $model,
+            systemPrompt: 'sys',
+            userPrompt: 'usr',
+            teamId: 'team-1',
+            purpose: 'scoring',
+        );
+    }
+
+    private function next(): \Closure
+    {
+        return fn (AiRequestDTO $passed) => new AiResponseDTO(
+            content: 'ok',
+            parsedOutput: null,
+            usage: new AiUsageDTO(promptTokens: 1, completionTokens: 1, costCredits: 0),
+            provider: $passed->provider,
+            model: $passed->model,
+            latencyMs: 1,
+        );
+    }
+
+    public function test_passes_request_through_unchanged_when_recommendation_exists(): void
+    {
+        config()->set('ai_routing.eval_grounded.enabled', true);
+
+        $recommender = Mockery::mock(EvalGroundedModelRecommender::class);
+        $recommender->shouldReceive('recommend')->once()->andReturn([
+            'would_downgrade' => true,
+            'est_savings_per_call' => 12,
+            'recommended_model' => 'anthropic/claude-haiku-4-5',
+        ]);
+
+        $counters = Mockery::mock(EvalShadowCounters::class);
+        $counters->shouldReceive('record')->once()->with('team-1', Mockery::type('array'));
+
+        $mw = new EvalGroundedRoutingShadow($recommender, $counters);
+
+        $captured = null;
+        $mw->handle($this->request(), function (AiRequestDTO $passed) use (&$captured) {
+            $captured = $passed;
+
+            return $this->next()($passed);
+        });
+
+        $this->assertSame('anthropic', $captured->provider);
+        $this->assertSame('claude-opus-4-6', $captured->model);
+        $this->assertSame('scoring', $captured->purpose);
+    }
+
+    public function test_no_record_when_recommender_returns_null(): void
+    {
+        config()->set('ai_routing.eval_grounded.enabled', true);
+
+        $recommender = Mockery::mock(EvalGroundedModelRecommender::class);
+        $recommender->shouldReceive('recommend')->once()->andReturnNull();
+
+        $counters = Mockery::mock(EvalShadowCounters::class);
+        $counters->shouldNotReceive('record');
+
+        $mw = new EvalGroundedRoutingShadow($recommender, $counters);
+        $response = $mw->handle($this->request(), $this->next());
+
+        $this->assertSame('ok', $response->content);
+    }
+
+    public function test_recommender_not_called_when_flag_off(): void
+    {
+        config()->set('ai_routing.eval_grounded.enabled', false);
+
+        $recommender = Mockery::mock(EvalGroundedModelRecommender::class);
+        $recommender->shouldNotReceive('recommend');
+
+        $counters = Mockery::mock(EvalShadowCounters::class);
+
+        $mw = new EvalGroundedRoutingShadow($recommender, $counters);
+        $response = $mw->handle($this->request(), $this->next());
+
+        $this->assertSame('ok', $response->content);
+    }
+
+    public function test_swallows_recommender_failure_and_still_forwards(): void
+    {
+        config()->set('ai_routing.eval_grounded.enabled', true);
+
+        $recommender = Mockery::mock(EvalGroundedModelRecommender::class);
+        $recommender->shouldReceive('recommend')->once()->andThrow(new \RuntimeException('boom'));
+
+        $counters = Mockery::mock(EvalShadowCounters::class);
+        $counters->shouldNotReceive('record');
+
+        $mw = new EvalGroundedRoutingShadow($recommender, $counters);
+        $response = $mw->handle($this->request(), $this->next());
+
+        $this->assertSame('ok', $response->content);
+    }
+
+    public function test_does_not_alter_routing_for_local_provider_archetypes(): void
+    {
+        config()->set('ai_routing.eval_grounded.enabled', true);
+
+        $recommender = Mockery::mock(EvalGroundedModelRecommender::class);
+        $recommender->shouldReceive('recommend')->andReturn([
+            'would_downgrade' => true,
+            'est_savings_per_call' => 5,
+            'recommended_model' => 'anthropic/claude-haiku-4-5',
+        ]);
+        $counters = Mockery::mock(EvalShadowCounters::class);
+        $counters->shouldReceive('record');
+
+        $mw = new EvalGroundedRoutingShadow($recommender, $counters);
+
+        foreach (['claude-code-vps', 'bridge_agent', 'codex'] as $provider) {
+            $captured = null;
+            $mw->handle($this->request(provider: $provider, model: 'claude-sonnet-4-5'), function (AiRequestDTO $passed) use (&$captured) {
+                $captured = $passed;
+
+                return $this->next()($passed);
+            });
+
+            $this->assertSame($provider, $captured->provider);
+            $this->assertSame('claude-sonnet-4-5', $captured->model);
+        }
+    }
+}

--- a/tests/Feature/Infrastructure/AI/EvalShadowCountersTest.php
+++ b/tests/Feature/Infrastructure/AI/EvalShadowCountersTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Infrastructure\AI;
+
+use App\Infrastructure\AI\Services\EvalShadowCounters;
+use Illuminate\Support\Facades\Redis;
+use Tests\TestCase;
+
+class EvalShadowCountersTest extends TestCase
+{
+    private string $teamId = 'team-counters-test';
+
+    private EvalShadowCounters $counters;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->counters = app(EvalShadowCounters::class);
+        $this->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->flush();
+        parent::tearDown();
+    }
+
+    private function flush(): void
+    {
+        $keys = Redis::keys("eval_shadow:{$this->teamId}:*");
+        foreach ($keys as $key) {
+            // Redis::keys may return prefixed names depending on config; strip a
+            // leading prefix so del addresses the logical key.
+            $logical = preg_replace('/^.*(eval_shadow:)/', '$1', (string) $key);
+            Redis::del($logical);
+        }
+    }
+
+    public function test_records_totals_and_downgrade_savings(): void
+    {
+        $this->counters->record($this->teamId, ['would_downgrade' => true, 'est_savings_per_call' => 12]);
+        $this->counters->record($this->teamId, ['would_downgrade' => true, 'est_savings_per_call' => 8]);
+        $this->counters->record($this->teamId, ['would_downgrade' => false, 'est_savings_per_call' => 0]);
+
+        $totals = $this->counters->totals($this->teamId, 7);
+
+        $this->assertSame(3, $totals['total']);
+        $this->assertSame(2, $totals['would_downgrade']);
+        $this->assertSame(20, $totals['est_savings_credits']);
+    }
+
+    public function test_returns_zeros_for_team_with_no_data(): void
+    {
+        $totals = $this->counters->totals('no-such-team', 7);
+
+        $this->assertSame(0, $totals['total']);
+        $this->assertSame(0, $totals['would_downgrade']);
+        $this->assertSame(0, $totals['est_savings_credits']);
+    }
+}

--- a/tests/Feature/Livewire/Metrics/AiRoutingSavingsTest.php
+++ b/tests/Feature/Livewire/Metrics/AiRoutingSavingsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Livewire\Metrics;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Domain\Shared\Models\Team;
+use App\Livewire\Metrics\AiRoutingPage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AiRoutingSavingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $user = User::factory()->create();
+        $this->team = Team::factory()->create(['owner_id' => $user->id]);
+        $user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($user, ['role' => 'owner']);
+        $this->actingAs($user);
+
+        config()->set('ai_routing.savings_baseline', ['provider' => 'anthropic', 'model' => 'claude-opus-4-6']);
+    }
+
+    public function test_reports_credits_saved_vs_flagship_in_credits(): void
+    {
+        // Cheap model, huge token volume, tiny actual credit spend → re-pricing
+        // at the opus baseline must dwarf the actual cost.
+        for ($i = 0; $i < 5; $i++) {
+            AiRun::create([
+                'team_id' => $this->team->id,
+                'purpose' => 'scoring',
+                'provider' => 'anthropic',
+                'model' => 'claude-haiku-4-5',
+                'prompt_snapshot' => [],
+                'input_tokens' => 200_000,
+                'output_tokens' => 200_000,
+                'cost_credits' => 10,
+                'status' => 'completed',
+            ]);
+        }
+
+        Livewire::test(AiRoutingPage::class)
+            ->assertViewHas('costSavings', function ($cs) {
+                return $cs->actual === 50
+                    && $cs->theoretical > $cs->actual
+                    && $cs->saved_credits === ($cs->theoretical - $cs->actual)
+                    && $cs->savings_pct > 0
+                    && $cs->baseline_model === 'claude-opus-4-6';
+            });
+    }
+
+    public function test_zero_savings_with_no_runs(): void
+    {
+        Livewire::test(AiRoutingPage::class)
+            ->assertViewHas('costSavings', function ($cs) {
+                return $cs->actual === 0
+                    && $cs->theoretical === 0
+                    && $cs->saved_credits === 0
+                    && $cs->savings_pct === 0;
+            });
+    }
+}


### PR DESCRIPTION
## Cast AI 'AI Enabler' borrows (shadow + metric)

Research verdict: `docs/research/research_cast-ai_2026-06-30.md` (parent repo) — do **not** adopt the platform (K8s/GPU infra, wrong layer); FleetQ's gateway already implements ~90% of AI Enabler. This ships the 2 worthwhile refinements + a spike. **All flag-OFF.**

### #1 — Eval-grounded routing (SHADOW / advisory only)
`AI_ROUTING_EVAL_GROUNDED` (default off). Even when on, it **never changes live routing** — it logs + counts a recommendation only.
- `EvalGroundedModelRecommender` — cheapest model whose recent `ai_runs` quality outcomes (`verification_passed`/`schema_valid`/completion) clear a success threshold for the same task-type (`purpose`). Team-scoped with platform-wide fallback when sparse.
- `EvalGroundedRoutingShadow` — pass-through middleware after `BudgetPressureRouting`; logs `[eval-routing-shadow]` + Redis counters, forwards request untouched. Swallows its own errors.
- Sourced from `ai_runs` (not `evaluation_runs`, which has no model-under-test dimension). No migration.

### #2 — Savings-vs-flagship metric
`AiRoutingPage::getCostSavings` now re-prices the period's tokens at a configured flagship baseline (`ai_routing.savings_baseline`, default opus) via `CostCalculator` → unit-coherent **credits saved** headline. Fixes the prior credits-vs-USD unit bug (old metric always read 0).

### #3 — per-tag attribution: spike only (no code)
Findings in `docs/architecture/architecture-castai-borrows.md`: source/sub-program/user dims already exist; no arbitrary tag. Recommend surfacing existing `llm_request_logs.user_id`; don't build a tag system.

### Tests / quality
15 new tests (recommender, shadow middleware incl. provider-archetype no-op, counters, savings); full AI infra suite green (362). pint + larastan clean.

### Rollout
Flag-flip activation, 30s rollback. Shadow first; flip to active routing only after shadow data proves cheaper picks hold quality.