### PR TITLE
feat(agent): update_plan built-in planning tool (deepagents write_todos borrow)

### DIFF
--- a/app/Domain/Tool/Enums/BuiltInToolKind.php
+++ b/app/Domain/Tool/Enums/BuiltInToolKind.php
@@ -14,6 +14,7 @@ enum BuiltInToolKind: string
     case ExecuteCode = 'execute_code';
     case BrowserHarness = 'browser_harness';
     case ProgressAppend = 'progress_append';
+    case Plan = 'plan';
 
     public function label(): string
     {
@@ -28,6 +29,7 @@ enum BuiltInToolKind: string
             self::ExecuteCode => 'Execute Code',
             self::BrowserHarness => 'Browser Harness (self-healing CDP)',
             self::ProgressAppend => 'Progress Log (workspace contract)',
+            self::Plan => 'Plan / To-Do (self-managed task list)',
         };
     }
 }

--- a/app/Domain/Tool/Services/ToolTranslator.php
+++ b/app/Domain/Tool/Services/ToolTranslator.php
@@ -190,6 +190,7 @@ class ToolTranslator
             BuiltInToolKind::ComputerUse => $this->buildComputerUseTools($tool),
             BuiltInToolKind::BrowserUseCloud => $this->buildBrowserUseCloudTools($tool),
             BuiltInToolKind::ExecuteCode => $this->buildExecuteCodeTools($tool, $workspace),
+            BuiltInToolKind::Plan => $this->buildPlanTools($workspace),
             default => [],
         };
     }
@@ -468,6 +469,147 @@ class ToolTranslator
         }
 
         return $tools;
+    }
+
+    /**
+     * Build the `update_plan` planning tool (deepagents write_todos borrow).
+     *
+     * Gives a solo agent a live, self-authored to-do list it rewrites in full
+     * on every call (replace semantics). The rendered plan is returned as the
+     * tool result so the model always sees its current plan as fresh context —
+     * that echo-back is the coherence mechanism — and persisted to plan.md in
+     * the sandbox workspace when one is present. Flag-gated: returns no tool
+     * unless agent.planning_tool.enabled is true.
+     *
+     * Distinct from the system-authored feature-list.json (done-criteria) and
+     * the append-only progress.md (iteration log) in the workspace contract.
+     *
+     * @return array<PrismToolObject>
+     */
+    private function buildPlanTools(?SandboxedWorkspace $workspace = null): array
+    {
+        if (! config('agent.planning_tool.enabled', false)) {
+            return [];
+        }
+
+        return [
+            PrismTool::as('update_plan')
+                ->for(
+                    'Maintain your live working plan / to-do list for this task (alias: write_todos). '
+                    .'Call this at the start of a multi-step task and again whenever the plan changes. '
+                    .'Always pass the COMPLETE current list — it replaces the previous plan, it does not append. '
+                    .'Keep exactly one item in_progress at a time and mark items completed as you finish them.',
+                )
+                ->withStringParameter(
+                    'todos',
+                    'JSON array of plan items. Each item: {"content": "<step>", "status": "pending|in_progress|completed"}.',
+                )
+                ->withStringParameter(
+                    'note',
+                    'Optional one-line rationale for this plan update.',
+                    required: false,
+                )
+                ->using(function (string $todos, ?string $note = null) use ($workspace): string {
+                    try {
+                        $items = $this->parsePlanTodos($todos);
+                    } catch (\InvalidArgumentException $e) {
+                        return 'Error: '.$e->getMessage();
+                    }
+
+                    $rendered = $this->renderPlan($items, $note);
+
+                    if ($workspace !== null) {
+                        // resolve() guards traversal; 'plan.md' is a literal name.
+                        file_put_contents($workspace->resolve('plan.md'), $rendered);
+                    }
+
+                    return $rendered;
+                }),
+        ];
+    }
+
+    /**
+     * Parse and validate the agent-supplied todo list, tolerant of the
+     * markdown-fenced / dirty JSON that local agents emit.
+     *
+     * @return list<array{content: string, status: string}>
+     *
+     * @throws \InvalidArgumentException with an actionable message the model can self-correct from
+     */
+    private function parsePlanTodos(string $raw): array
+    {
+        $valid = ['pending', 'in_progress', 'completed'];
+        $shape = 'Expected a non-empty JSON array of {"content": string, "status": "pending|in_progress|completed"}.';
+
+        $trimmed = trim($raw);
+        // Strip a leading/trailing markdown code fence if present.
+        $trimmed = trim(preg_replace('/^```[a-zA-Z0-9]*\s*|\s*```$/m', '', $trimmed) ?? $trimmed);
+
+        $decoded = json_decode($trimmed, true);
+        if (! is_array($decoded)) {
+            // Fallback: extract the outermost array literal.
+            $start = strpos($trimmed, '[');
+            $end = strrpos($trimmed, ']');
+            if ($start !== false && $end !== false && $end > $start) {
+                $decoded = json_decode(substr($trimmed, $start, $end - $start + 1), true);
+            }
+        }
+
+        if (! is_array($decoded) || $decoded === []) {
+            throw new \InvalidArgumentException("Could not parse `todos`. {$shape}");
+        }
+
+        $items = [];
+        foreach ($decoded as $entry) {
+            if (! is_array($entry)) {
+                throw new \InvalidArgumentException("Each plan item must be an object. {$shape}");
+            }
+            $content = trim((string) ($entry['content'] ?? ''));
+            $status = (string) ($entry['status'] ?? '');
+            if ($content === '') {
+                throw new \InvalidArgumentException("A plan item is missing `content`. {$shape}");
+            }
+            if (! in_array($status, $valid, true)) {
+                throw new \InvalidArgumentException(
+                    "Invalid status '{$status}' for item '{$content}'. Use one of: ".implode(', ', $valid).'.',
+                );
+            }
+            $items[] = ['content' => $content, 'status' => $status];
+        }
+
+        return $items;
+    }
+
+    /**
+     * Render the plan as an ASCII checklist with a counts summary.
+     *
+     * @param  list<array{content: string, status: string}>  $items
+     */
+    private function renderPlan(array $items, ?string $note = null): string
+    {
+        $glyph = [
+            'pending' => '[ ]',
+            'in_progress' => '[~]',
+            'completed' => '[x]',
+        ];
+
+        $lines = ['# Plan'];
+        if ($note !== null && trim($note) !== '') {
+            $lines[] = '';
+            $lines[] = '_'.trim($note).'_';
+        }
+        $lines[] = '';
+
+        $counts = ['pending' => 0, 'in_progress' => 0, 'completed' => 0];
+        foreach ($items as $item) {
+            $counts[$item['status']]++;
+            $lines[] = $glyph[$item['status']].' '.$item['content'];
+        }
+
+        $lines[] = '';
+        $lines[] = "{$counts['completed']} done, {$counts['in_progress']} in progress, {$counts['pending']} todo";
+
+        return implode("\n", $lines)."\n";
     }
 
     private function buildBrowserTools(Tool $tool): array

--- a/config/agent.php
+++ b/config/agent.php
@@ -265,4 +265,20 @@ return [
         */
         'argument_predicates' => (bool) env('AGENT_TOOL_ARG_PREDICATES', false),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Planning tool (deepagents write_todos borrow)
+    |--------------------------------------------------------------------------
+    | When enabled, the built-in `plan` tool kind exposes an `update_plan`
+    | tool that lets a solo agent maintain a live, self-authored to-do list
+    | (replace-semantics) during a long-horizon run — distinct from the
+    | system-authored feature-list.json and the append-only progress.md.
+    | Off by default: the `plan` kind translates to no tool while disabled,
+    | so no agent gains the capability until both the flag is on AND the
+    | tool is explicitly attached.
+    */
+    'planning_tool' => [
+        'enabled' => (bool) env('AGENT_PLANNING_TOOL_ENABLED', false),
+    ],
 ];

--- a/tests/Unit/Domain/Tool/ToolTranslatorPlanToolTest.php
+++ b/tests/Unit/Domain/Tool/ToolTranslatorPlanToolTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Unit\Domain\Tool;
+
+use App\Domain\Agent\Services\SandboxedWorkspace;
+use App\Domain\Tool\Enums\ToolType;
+use App\Domain\Tool\Models\Tool;
+use App\Domain\Tool\Services\ToolTranslator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Covers the `update_plan` planning tool (deepagents write_todos borrow):
+ * flag gating, the rendered checklist, plan.md persistence, tolerant JSON
+ * parsing, and the actionable error paths the model self-corrects from.
+ */
+class ToolTranslatorPlanToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function planTool(): Tool
+    {
+        return Tool::factory()->create([
+            'type' => ToolType::BuiltIn,
+            'transport_config' => ['kind' => 'plan'],
+        ]);
+    }
+
+    public function test_disabled_flag_returns_no_tool(): void
+    {
+        config(['agent.planning_tool.enabled' => false]);
+
+        $tools = app(ToolTranslator::class)->toPrismTools($this->planTool());
+
+        $this->assertSame([], $tools);
+    }
+
+    public function test_enabled_flag_exposes_update_plan_tool(): void
+    {
+        config(['agent.planning_tool.enabled' => true]);
+
+        $tools = app(ToolTranslator::class)->toPrismTools($this->planTool());
+
+        $this->assertCount(1, $tools);
+        $this->assertSame('update_plan', $tools[0]->name());
+    }
+
+    public function test_renders_checklist_with_statuses_and_counts(): void
+    {
+        config(['agent.planning_tool.enabled' => true]);
+        $tools = app(ToolTranslator::class)->toPrismTools($this->planTool());
+
+        $json = json_encode([
+            ['content' => 'Scope the task', 'status' => 'completed'],
+            ['content' => 'Write the code', 'status' => 'in_progress'],
+            ['content' => 'Add tests', 'status' => 'pending'],
+        ]);
+
+        $out = $tools[0]->handle($json);
+
+        $this->assertStringContainsString('Scope the task', $out);
+        $this->assertStringContainsString('Write the code', $out);
+        $this->assertStringContainsString('[x]', $out);
+        $this->assertStringContainsString('[~]', $out);
+        $this->assertStringContainsString('[ ]', $out);
+        $this->assertStringContainsString('1 done, 1 in progress, 1 todo', $out);
+    }
+
+    public function test_persists_plan_md_to_sandbox_workspace(): void
+    {
+        config(['agent.planning_tool.enabled' => true]);
+
+        $workspace = new SandboxedWorkspace(
+            'exec-plan-test',
+            'agent-x',
+            'team-y',
+            sys_get_temp_dir().'/fleetq-plan-test',
+        );
+        $tools = app(ToolTranslator::class)->toPrismTools($this->planTool(), [], null, $workspace);
+
+        $json = json_encode([['content' => 'Do the thing', 'status' => 'pending']]);
+        $tools[0]->handle($json);
+
+        $planPath = $workspace->resolve('plan.md');
+        $this->assertFileExists($planPath);
+        $this->assertStringContainsString('Do the thing', (string) file_get_contents($planPath));
+
+        $workspace->teardown();
+    }
+
+    public function test_accepts_markdown_fenced_json(): void
+    {
+        config(['agent.planning_tool.enabled' => true]);
+        $tools = app(ToolTranslator::class)->toPrismTools($this->planTool());
+
+        $fenced = "```json\n".json_encode([['content' => 'Fenced step', 'status' => 'pending']])."\n```";
+        $out = $tools[0]->handle($fenced);
+
+        $this->assertStringContainsString('Fenced step', $out);
+        $this->assertStringNotContainsString('Error', $out);
+    }
+
+    public function test_malformed_json_returns_actionable_error(): void
+    {
+        config(['agent.planning_tool.enabled' => true]);
+        $tools = app(ToolTranslator::class)->toPrismTools($this->planTool());
+
+        $out = $tools[0]->handle('not json at all');
+
+        $this->assertStringContainsString('Error', $out);
+        $this->assertStringContainsString('JSON array', $out);
+    }
+
+    public function test_invalid_status_returns_error(): void
+    {
+        config(['agent.planning_tool.enabled' => true]);
+        $tools = app(ToolTranslator::class)->toPrismTools($this->planTool());
+
+        $json = json_encode([['content' => 'Bad status item', 'status' => 'done']]);
+        $out = $tools[0]->handle($json);
+
+        $this->assertStringContainsString('Error', $out);
+        $this->assertStringContainsString('Invalid status', $out);
+    }
+}


### PR DESCRIPTION
## What

Adds a new `plan` `BuiltInToolKind` that exposes an **`update_plan`** tool (alias `write_todos`) — the deepagents per-execution planning primitive. It lets a *solo* agent maintain a live, self-authored to-do list during a long-horizon run.

This is the one genuine harness-primitive gap found in the deepagents review (`docs/research/research_langchain-deepagents_2026-06-30.md`, §B): FleetQ already has macro planning (`feature-list.json` done-criteria) and an append-only `progress.md` log, but no agent-authored *live working plan*.

## How

- `update_plan(todos, note?)` — `todos` is a JSON array of `{content, status∈pending|in_progress|completed}`. The agent passes the **complete** list each call (replace semantics, like Claude Code's TodoWrite).
- Renders an ASCII checklist + counts back as the tool result → the model always sees its current plan as fresh context (the coherence mechanism).
- Persists `plan.md` to the sandbox workspace when present (sibling to the existing contract files; the `WorkspaceContractSnapshot` DTO is intentionally untouched).
- Tolerant of markdown-fenced / dirty JSON (local-agent gotcha); malformed input → actionable error the model self-corrects from (never throws into the loop).

## Flag (OFF by default)

`AGENT_PLANNING_TOOL_ENABLED` (default `false`). While off, the `plan` kind translates to **no tool** — zero blast radius. No agent gains the capability until the flag is on AND the tool is explicitly attached. Auto-surfaces in `CreateToolForm` via `BuiltInToolKind::cases()`.

## Scope discipline

No new domain/model/migration/MCP CRUD tool, no DTO change, no governance gate (writes only to its own scratchpad + echoes), no AGENTS.md edit (won't advertise a disabled tool).

## Tests

`tests/Unit/Domain/Tool/ToolTranslatorPlanToolTest.php` (7, all green): flag gating (off→[], on→`update_plan`), checklist render + counts, `plan.md` persistence, fenced-JSON tolerance, malformed-JSON error, invalid-status error. Full Tool domain suite: 229 passed. pint + larastan clean.

Docs: `docs/{design,architecture,test-plans}/*-agent-planning-tool.md` (in parent repo).

⚠️ Draft — human merge only.