### PR TITLE
feat(experiment): signal-aware scoring rubrics (per source_type / track)

### DIFF
--- a/app/Domain/Experiment/Pipeline/RunScoringStage.php
+++ b/app/Domain/Experiment/Pipeline/RunScoringStage.php
@@ -4,17 +4,24 @@ namespace App\Domain\Experiment\Pipeline;
 
 use App\Domain\Experiment\Actions\TransitionExperimentAction;
 use App\Domain\Experiment\Enums\ExperimentStatus;
-use App\Domain\Experiment\Enums\ExperimentTrack;
 use App\Domain\Experiment\Enums\StageType;
 use App\Domain\Experiment\Models\Experiment;
 use App\Domain\Experiment\Models\ExperimentStage;
 use App\Domain\Memory\Services\MemoryContextInjector;
 use App\Domain\Project\Models\ProjectRun;
+use App\Domain\Signal\Models\Signal;
 use App\Infrastructure\AI\Contracts\AiGatewayInterface;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
 
 class RunScoringStage extends BaseStageJob
 {
+    /**
+     * Ultimate fallback scoring question, used when config('experiments.scoring_rubrics')
+     * is missing/empty — so a config-cache miss can never break scoring; it
+     * degrades to the historical business-potential behaviour.
+     */
+    private const FALLBACK_PROMPT = 'You are an experiment scoring agent. Evaluate the business potential of the given signal or thesis. If context from predecessor projects is provided, factor it into your evaluation. Return ONLY a valid JSON object (no markdown, no code fences) with: score (0.0-1.0), reasoning (string, max 2 sentences), recommended_track (growth|retention|revenue|engagement), and key_metrics (array of max 5 short strings). Keep the response compact.';
+
     public function __construct(string $experimentId, ?string $teamId = null)
     {
         parent::__construct($experimentId, $teamId);
@@ -37,8 +44,10 @@ class RunScoringStage extends BaseStageJob
         $transition = app(TransitionExperimentAction::class);
         $llm = $this->resolvePipelineLlm($experiment);
 
+        /** @var Signal|null $signal */
         $signal = $experiment->signals()->latest()->first();
         $signalPayload = $signal->payload ?? ['thesis' => $experiment->thesis];
+        $rubric = $this->resolveScoringRubric($experiment, $signal);
 
         // Inject relevant memories from past experiments
         $memoryContext = '';
@@ -78,7 +87,7 @@ class RunScoringStage extends BaseStageJob
         $request = new AiRequestDTO(
             provider: $llm['provider'],
             model: $llm['model'],
-            systemPrompt: 'You are an experiment scoring agent. Evaluate the business potential of the given signal or thesis. If context from predecessor projects is provided, factor it into your evaluation. Return ONLY a valid JSON object (no markdown, no code fences) with: score (0.0-1.0), reasoning (string, max 2 sentences), recommended_track (growth|retention|revenue|engagement), and key_metrics (array of max 5 short strings). Keep the response compact.',
+            systemPrompt: $rubric['system_prompt'],
             userPrompt: $userPrompt,
             maxTokens: 1024,
             userId: $experiment->user_id,
@@ -107,12 +116,10 @@ class RunScoringStage extends BaseStageJob
             'output_snapshot' => $parsedOutput,
         ]);
 
-        // Decide next transition. Debug-track (bug-fix) runs are triaged work,
-        // not business bets, so they must not be gated by the business-potential
-        // score — default their threshold to 0.0 (always advance) unless an
-        // explicit per-experiment score_threshold overrides it.
-        $defaultThreshold = $experiment->track === ExperimentTrack::Debug ? 0.0 : 0.3;
-        $threshold = $experiment->constraints['score_threshold'] ?? $defaultThreshold;
+        // Decide next transition. The rubric (resolved by signal type / track)
+        // sets the default threshold; an explicit per-experiment score_threshold
+        // still overrides it.
+        $threshold = $experiment->constraints['score_threshold'] ?? $rubric['threshold'];
 
         if ($score >= $threshold) {
             $transition->execute(
@@ -127,5 +134,40 @@ class RunScoringStage extends BaseStageJob
                 reason: "Score {$score} below threshold {$threshold}",
             );
         }
+    }
+
+    /**
+     * Resolve the scoring rubric via a priority chain:
+     * signal source_type → experiment track → default. Each rubric supplies the
+     * scoring question (system_prompt) and a default threshold, so different
+     * signal types are judged by the right criteria (e.g. business potential vs
+     * bug severity). The per-experiment constraints.score_threshold (applied by
+     * the caller) still overrides the threshold.
+     *
+     * recommended_track / scoring_details are display-only, so a rubric may use
+     * its own vocabulary without downstream coupling. Falls back to the built-in
+     * business prompt + 0.3 when config is absent.
+     *
+     * @return array{system_prompt: string, threshold: float}
+     */
+    private function resolveScoringRubric(Experiment $experiment, ?Signal $signal): array
+    {
+        $rubrics = config('experiments.scoring_rubrics', []);
+        $key = 'default';
+
+        $source = $signal?->source_type;
+        $bySource = config('experiments.scoring_rubric_by_source', []);
+        if (is_string($source) && isset($bySource[$source], $rubrics[$bySource[$source]])) {
+            $key = $bySource[$source];
+        } elseif (($track = $experiment->track?->value) !== null && isset($rubrics[$track])) {
+            $key = $track;
+        }
+
+        $rubric = is_array($rubrics[$key] ?? null) ? $rubrics[$key] : [];
+
+        return [
+            'system_prompt' => is_string($rubric['system_prompt'] ?? null) ? $rubric['system_prompt'] : self::FALLBACK_PROMPT,
+            'threshold' => (float) ($rubric['threshold'] ?? 0.3),
+        ];
     }
 }

--- a/config/experiments.php
+++ b/config/experiments.php
@@ -101,6 +101,43 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Scoring Rubrics (signal-aware experiment scoring)
+    |--------------------------------------------------------------------------
+    | RunScoringStage picks a rubric — its scoring question (system_prompt) +
+    | default threshold — per experiment via this chain:
+    |   constraints.score_threshold (per-run override, threshold only)
+    |     → scoring_rubric_by_source[signal.source_type]
+    |     → scoring_rubrics[experiment.track]
+    |     → 'default'
+    | Different signal types are judged by the right criteria (business potential
+    | vs bug severity). recommended_track / scoring_details are display-only, so a
+    | rubric may use its own vocabulary. Add a signal type → add a rubric or a
+    | source route here, no code change. A missing 'default' falls back to a
+    | built-in business prompt + 0.3 in RunScoringStage.
+    */
+    'scoring_rubrics' => [
+        'default' => [
+            'threshold' => 0.3,
+            'system_prompt' => 'You are an experiment scoring agent. Evaluate the business potential of the given signal or thesis. If context from predecessor projects is provided, factor it into your evaluation. Return ONLY a valid JSON object (no markdown, no code fences) with: score (0.0-1.0), reasoning (string, max 2 sentences), recommended_track (growth|retention|revenue|engagement), and key_metrics (array of max 5 short strings). Keep the response compact.',
+        ],
+        'debug' => [
+            'threshold' => 0.2,
+            'system_prompt' => 'You are a bug-triage scoring agent. Assess the SEVERITY and IMPACT of the reported bug, NOT its business novelty. Weigh reproducibility, blast radius (users/flows affected), user- and revenue-impact, and frequency. A real, reproducible production error scores HIGH (0.7-1.0); a minor or cosmetic issue scores MEDIUM; noise — non-reproducible, third-party, duplicate, or non-actionable — scores LOW (near 0). Return ONLY a valid JSON object (no markdown, no code fences) with: score (0.0-1.0), reasoning (string, max 2 sentences), recommended_track (critical|high|medium|low), and key_metrics (array of max 5 short strings, e.g. affected flow, error frequency). Keep the response compact.',
+        ],
+    ],
+
+    /*
+    | Map a signal's AI-classified source_type to a rubric key. Strongest signal
+    | of intent (known at ingestion). Unlisted types fall through to track/default.
+    */
+    'scoring_rubric_by_source' => [
+        'bug_report' => 'debug',
+        'incident' => 'debug',
+        'alert' => 'debug',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Model Tiers
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/Domain/Experiment/ScoringTrackThresholdTest.php
+++ b/tests/Feature/Domain/Experiment/ScoringTrackThresholdTest.php
@@ -18,9 +18,10 @@ use Illuminate\Support\Str;
 use Tests\TestCase;
 
 /**
- * A low business-potential score (0.2, below the standard 0.3 threshold)
- * discards a normal experiment but must ADVANCE a Debug-track (bug-fix) run:
- * triaged bugs are work to do, not business bets to gate.
+ * RunScoringStage resolves its rubric (scoring question + threshold) per
+ * experiment via: constraints.score_threshold → signal source_type → track →
+ * default. Different signal types are judged by the right criteria, and a
+ * triaged bug is no longer discarded under a business-potential lens.
  */
 class ScoringTrackThresholdTest extends TestCase
 {
@@ -44,7 +45,6 @@ class ScoringTrackThresholdTest extends TestCase
         $this->user->update(['current_team_id' => $this->team->id]);
         $this->team->users()->attach($this->user, ['role' => 'owner']);
 
-        // Skip the verification gate so the test exercises only the threshold logic.
         config(['ai_routing.verification.enabled' => false]);
     }
 
@@ -52,7 +52,7 @@ class ScoringTrackThresholdTest extends TestCase
     {
         $gateway = $this->createMock(AiGatewayInterface::class);
         $gateway->method('complete')->willReturn(new AiResponseDTO(
-            content: json_encode(['score' => $score, 'reasoning' => 'low', 'recommended_track' => 'revenue']),
+            content: json_encode(['score' => $score, 'reasoning' => 'x', 'recommended_track' => 'high']),
             parsedOutput: null,
             usage: new AiUsageDTO(promptTokens: 10, completionTokens: 10, costCredits: 1),
             provider: 'anthropic',
@@ -62,7 +62,7 @@ class ScoringTrackThresholdTest extends TestCase
         $this->app->instance(AiGatewayInterface::class, $gateway);
     }
 
-    private function makeScoringExperiment(ExperimentTrack $track): Experiment
+    private function makeScoringExperiment(ExperimentTrack $track, string $sourceType = 'manual'): Experiment
     {
         $exp = Experiment::factory()->create([
             'team_id' => $this->team->id,
@@ -76,43 +76,71 @@ class ScoringTrackThresholdTest extends TestCase
         Signal::factory()->create([
             'team_id' => $this->team->id,
             'experiment_id' => $exp->id,
+            'source_type' => $sourceType,
             'payload' => ['thesis' => $exp->thesis],
         ]);
 
         return $exp;
     }
 
-    public function test_debug_track_advances_to_planning_on_low_score(): void
+    private function runScoring(Experiment $exp): ExperimentStatus
     {
         Queue::fake();
-        $this->fakeScore(0.2);
+        (new RunScoringStage($exp->id, $this->team->id))->handle();
+
+        return $exp->fresh()->status;
+    }
+
+    public function test_bug_report_source_routes_to_severity_rubric_and_beats_track(): void
+    {
+        // source=bug_report → debug/severity (threshold 0.2); track=Growth would
+        // be default (0.3). Score 0.25 advances only if the source rubric wins.
+        $this->fakeScore(0.25);
+        $exp = $this->makeScoringExperiment(ExperimentTrack::Growth, 'bug_report');
+
+        $this->assertSame(ExperimentStatus::Planning, $this->runScoring($exp));
+    }
+
+    public function test_debug_track_advances_on_real_bug_score(): void
+    {
+        $this->fakeScore(0.5);
         $exp = $this->makeScoringExperiment(ExperimentTrack::Debug);
 
-        (new RunScoringStage($exp->id, $this->team->id))->handle();
-
-        $this->assertSame(ExperimentStatus::Planning, $exp->fresh()->status);
+        $this->assertSame(ExperimentStatus::Planning, $this->runScoring($exp));
     }
 
-    public function test_non_debug_track_is_discarded_on_low_score(): void
+    public function test_debug_filters_noise_below_severity_threshold(): void
     {
-        Queue::fake();
-        $this->fakeScore(0.2);
-        $exp = $this->makeScoringExperiment(ExperimentTrack::Growth);
+        $this->fakeScore(0.1);
+        $exp = $this->makeScoringExperiment(ExperimentTrack::Debug);
 
-        (new RunScoringStage($exp->id, $this->team->id))->handle();
-
-        $this->assertSame(ExperimentStatus::Discarded, $exp->fresh()->status);
+        $this->assertSame(ExperimentStatus::Discarded, $this->runScoring($exp));
     }
 
-    public function test_explicit_constraint_threshold_still_wins_for_debug(): void
+    public function test_default_business_rubric_discards_low_score(): void
     {
-        Queue::fake();
-        $this->fakeScore(0.2);
+        $this->fakeScore(0.25);
+        $exp = $this->makeScoringExperiment(ExperimentTrack::Growth, 'manual');
+
+        $this->assertSame(ExperimentStatus::Discarded, $this->runScoring($exp));
+    }
+
+    public function test_explicit_constraint_threshold_overrides_rubric(): void
+    {
+        $this->fakeScore(0.5);
         $exp = $this->makeScoringExperiment(ExperimentTrack::Debug);
         $exp->update(['constraints' => ['score_threshold' => 0.9]]);
 
-        (new RunScoringStage($exp->id, $this->team->id))->handle();
+        $this->assertSame(ExperimentStatus::Discarded, $this->runScoring($exp));
+    }
 
-        $this->assertSame(ExperimentStatus::Discarded, $exp->fresh()->status);
+    public function test_falls_back_to_default_when_rubrics_config_empty(): void
+    {
+        config(['experiments.scoring_rubrics' => [], 'experiments.scoring_rubric_by_source' => []]);
+        $this->fakeScore(0.5);
+        $exp = $this->makeScoringExperiment(ExperimentTrack::Growth, 'manual');
+
+        // Fallback business prompt + 0.3: 0.5 >= 0.3 → advances, no crash.
+        $this->assertSame(ExperimentStatus::Planning, $this->runScoring($exp));
     }
 }


### PR DESCRIPTION
## What
Replaces the single business-potential scoring prompt (and the debug-track threshold-0.0 stopgap) with a **rubric registry** resolved per experiment via a priority chain:

```
constraints.score_threshold (per-run override, threshold only)
  → scoring_rubric_by_source[signal.source_type]   (bug_report|incident|alert → severity)
  → scoring_rubrics[experiment.track]              (debug → severity)
  → 'default'                                      (business potential — unchanged)
```

## Why
Bugs/incidents/support were judged on "business potential" → scored 0.2–0.25 → discarded before reaching a PR. Now a real bug is judged on **severity** (reproducibility, blast radius, impact, frequency) and scores high; genuine noise scores low and is filtered by a modest threshold. Scoring stays meaningful triage instead of a bypassed gate.

## Design
- `source_type` is the AI-classified semantic type (`bug_report`, `feature_request`, `support_ticket`, `feedback`, `alert`, `incident`, `task`, `manual`) — the strongest intent signal; `track` is the normalized fallback. Resolution chain uses whichever is most reliable.
- `recommended_track`/`scoring_details` are display-only (verified — no consumers), so rubrics may use their own vocab (severity: `critical|high|medium|low`).
- `FALLBACK_PROMPT` + 0.3 in code → a config-cache miss can't break scoring (degrades to current behaviour).
- No new domain/model/migration/flag. Non-debug/non-bug behaviour byte-identical to `default`.

## Files
- `config/experiments.php` — `scoring_rubrics` + `scoring_rubric_by_source`.
- `app/Domain/Experiment/Pipeline/RunScoringStage.php` — `resolveScoringRubric()`; removed the `track===Debug?0.0` stopgap.
- `tests/Feature/Domain/Experiment/ScoringTrackThresholdTest.php` — 6 cases.

## Tests
6 rubric cases green; 247 Experiment-domain + bug-delegation tests green; pint + larastan clean (Docker).

Docs: `docs/{design,architecture,test-plans}/*-scoring-rubrics.md` (parent).

⚠️ Draft — human merge. Supersedes the deployed debug→0.0 behaviour once merged+deployed.