### PR TITLE
feat(git): WarmRepoManager — warm build sandbox (no re-clone per run)

### DIFF
--- a/app/Domain/GitRepository/Services/WarmRepoManager.php
+++ b/app/Domain/GitRepository/Services/WarmRepoManager.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Domain\GitRepository\Services;
+
+use App\Domain\GitRepository\Models\GitRepository;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+/**
+ * Warm build sandbox: keeps a persistent per-(team, repo) base clone and hands
+ * out isolated, hard-reset worktrees per run — so a build checks out in seconds
+ * (git fetch + worktree) instead of re-cloning the whole repository every time.
+ *
+ * Flag-gated via experiments.warm_build.enabled; when off, nothing calls this.
+ * All git invocations use array-form Process (no shell injection).
+ *
+ * NOTE: pass `$ref` as a fetched ref (e.g. "origin/main") or a commit SHA — a
+ * bare local branch name would point at the clone-time state, not the freshly
+ * fetched tip.
+ */
+class WarmRepoManager
+{
+    public static function enabled(): bool
+    {
+        return (bool) config('experiments.warm_build.enabled', false);
+    }
+
+    /**
+     * Provision an isolated worktree for a run, reusing a warm base clone.
+     *
+     * @param  string|null  $cloneUrl  Authenticated clone URL for private repos;
+     *                                 defaults to the repository's stored url.
+     * @return string Absolute path to the worktree, hard-reset + cleaned to $ref.
+     */
+    public function checkout(GitRepository $repo, string $ref, string $runId, ?string $cloneUrl = null): string
+    {
+        $base = $this->ensureBase($repo, $cloneUrl);
+
+        return $this->makeWorktree($repo, $base, $ref, $runId);
+    }
+
+    /**
+     * Ensure a persistent base clone exists: clone ONCE, otherwise fetch.
+     */
+    private function ensureBase(GitRepository $repo, ?string $cloneUrl): string
+    {
+        $base = $this->basePath($repo);
+        if (! is_dir(dirname($base))) {
+            mkdir(dirname($base), 0700, true);
+        }
+
+        $this->withLock($base, function () use ($base, $repo, $cloneUrl): void {
+            if (is_dir($base.'/.git')) {
+                $this->git(['-C', $base, 'fetch', '--prune', 'origin']);
+
+                return;
+            }
+
+            $url = $cloneUrl ?: (string) $repo->url;
+            if ($url === '') {
+                throw new RuntimeException("GitRepository {$repo->id} has no clone url.");
+            }
+            $this->git(['clone', $url, $base]);
+        });
+
+        return $base;
+    }
+
+    private function makeWorktree(GitRepository $repo, string $base, string $ref, string $runId): string
+    {
+        $branch = 'fleetq/run-'.substr($runId, 0, 8);
+        $path = $this->worktreeDir($repo).'/'.substr($runId, 0, 8).'-'.Str::slug($branch);
+
+        if (! is_dir(dirname($path))) {
+            mkdir(dirname($path), 0700, true);
+        }
+
+        // Reuse-safe: drop any worktree already registered at this slot (e.g. a
+        // re-run of the same id) so it starts pristine. Best-effort.
+        Process::run(['git', '-C', $base, 'worktree', 'remove', '--force', $path]);
+        Process::run(['git', '-C', $base, 'worktree', 'prune']);
+
+        // --force + -B so the slot is deterministic even if it pre-exists.
+        $this->git(['-C', $base, 'worktree', 'add', '--force', '-B', $branch, $path, $ref]);
+        // Belt-and-suspenders: a pristine tree regardless of any prior state.
+        $this->git(['-C', $path, 'reset', '--hard', $ref]);
+        $this->git(['-C', $path, 'clean', '-fdx']);
+
+        return $path;
+    }
+
+    public function release(GitRepository $repo, string $worktreePath): void
+    {
+        $base = $this->basePath($repo);
+        if (is_dir($base.'/.git')) {
+            // Best-effort: a failed remove must not break the caller's teardown.
+            Process::run(['git', '-C', $base, 'worktree', 'remove', '--force', $worktreePath]);
+        }
+    }
+
+    /**
+     * GC: keep the $keep most-recently-modified worktrees, remove the rest.
+     */
+    public function prune(GitRepository $repo, int $keep = 5): int
+    {
+        $dir = $this->worktreeDir($repo);
+        if (! is_dir($dir)) {
+            return 0;
+        }
+        $base = $this->basePath($repo);
+
+        $entries = array_values(array_filter(glob($dir.'/*') ?: [], 'is_dir'));
+        usort($entries, fn ($a, $b) => filemtime($b) <=> filemtime($a));
+
+        $removed = 0;
+        foreach (array_slice($entries, max(0, $keep)) as $stale) {
+            Process::run(['git', '-C', $base, 'worktree', 'remove', '--force', $stale]);
+            $removed++;
+        }
+
+        return $removed;
+    }
+
+    private function basePath(GitRepository $repo): string
+    {
+        return $this->baseDir().'/'.$repo->team_id.'/'.$repo->id;
+    }
+
+    private function worktreeDir(GitRepository $repo): string
+    {
+        return $this->baseDir().'/'.$repo->team_id.'/'.$repo->id.'.worktrees';
+    }
+
+    private function baseDir(): string
+    {
+        return rtrim((string) config('experiments.warm_build.base_dir', storage_path('app/warm-repos')), '/');
+    }
+
+    /**
+     * @param  list<string>  $args
+     */
+    private function git(array $args): void
+    {
+        $result = Process::run(array_merge(['git'], $args));
+        if (! $result->successful()) {
+            throw new RuntimeException('git '.implode(' ', $args).' failed: '.trim($result->errorOutput()));
+        }
+    }
+
+    /**
+     * Serialize base-repo mutation (clone/fetch) across concurrent runs so two
+     * runs on the same repo don't race the base. Falls back to unlocked rather
+     * than failing the run if the lock can't be acquired.
+     */
+    private function withLock(string $base, callable $fn): void
+    {
+        $fh = @fopen($base.'.lock', 'c');
+        if ($fh === false) {
+            $fn();
+
+            return;
+        }
+        try {
+            flock($fh, LOCK_EX);
+            $fn();
+        } finally {
+            flock($fh, LOCK_UN);
+            fclose($fh);
+        }
+    }
+}

--- a/config/experiments.php
+++ b/config/experiments.php
@@ -178,4 +178,19 @@ return [
     */
     'require_team_ai_access' => (bool) env('EXPERIMENTS_REQUIRE_TEAM_AI_ACCESS', false),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Warm build sandbox
+    |--------------------------------------------------------------------------
+    | When enabled, builds reuse a persistent per-(team, repo) base clone and an
+    | isolated worktree per run (WarmRepoManager) instead of re-cloning the repo
+    | every time — clone once, then `git fetch` + worktree (seconds vs minutes).
+    | base_dir should be a persistent volume in production so the warm clones
+    | survive container restarts. Off by default.
+    */
+    'warm_build' => [
+        'enabled' => (bool) env('EXPERIMENTS_WARM_BUILD', false),
+        'base_dir' => env('EXPERIMENTS_WARM_BUILD_DIR', storage_path('app/warm-repos')),
+    ],
+
 ];

--- a/tests/Feature/Domain/GitRepository/WarmRepoManagerTest.php
+++ b/tests/Feature/Domain/GitRepository/WarmRepoManagerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature\Domain\GitRepository;
+
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\WarmRepoManager;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * Real-git integration tests for the warm build sandbox: clone once, then
+ * fetch; isolated, pristine worktree per run.
+ */
+class WarmRepoManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $tmp = '';
+
+    private string $bare = '';
+
+    private string $seed = '';
+
+    private ?Team $team = null;
+
+    private ?WarmRepoManager $mgr = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! Process::run(['git', '--version'])->successful()) {
+            $this->markTestSkipped('git binary not available in this environment');
+        }
+
+        $this->tmp = sys_get_temp_dir().'/wrm-'.Str::random(10);
+        File::makeDirectory($this->tmp, 0777, true);
+        config(['experiments.warm_build.base_dir' => $this->tmp.'/warm']);
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'T', 'slug' => 't-'.Str::random(6),
+            'owner_id' => $user->id, 'settings' => [],
+        ]);
+
+        $this->bare = $this->tmp.'/remote.git';
+        $this->seed = $this->tmp.'/seed';
+        $this->initRemote();
+
+        $this->mgr = app(WarmRepoManager::class);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->tmp) && is_dir($this->tmp)) {
+            File::deleteDirectory($this->tmp);
+        }
+        parent::tearDown();
+    }
+
+    private function git(array $args): void
+    {
+        Process::run(array_merge(['git'], $args))->throw();
+    }
+
+    private function initRemote(): void
+    {
+        File::makeDirectory($this->seed, 0777, true);
+        $this->git(['init', '--bare', '-b', 'main', $this->bare]);
+        $this->git(['-C', $this->seed, 'init', '-b', 'main']);
+        $this->git(['-C', $this->seed, 'config', 'user.email', 't@example.com']);
+        $this->git(['-C', $this->seed, 'config', 'user.name', 'Test']);
+        File::put($this->seed.'/README.md', 'v1');
+        $this->git(['-C', $this->seed, 'add', '-A']);
+        $this->git(['-C', $this->seed, 'commit', '-m', 'seed']);
+        $this->git(['-C', $this->seed, 'remote', 'add', 'origin', $this->bare]);
+        $this->git(['-C', $this->seed, 'push', 'origin', 'main']);
+    }
+
+    private function pushSeedCommit(string $file, string $content): void
+    {
+        File::put($this->seed.'/'.$file, $content);
+        $this->git(['-C', $this->seed, 'add', '-A']);
+        $this->git(['-C', $this->seed, 'commit', '-m', 'add '.$file]);
+        $this->git(['-C', $this->seed, 'push', 'origin', 'main']);
+    }
+
+    private function repo(): GitRepository
+    {
+        return GitRepository::create([
+            'team_id' => $this->team->id,
+            'name' => 'r',
+            'url' => $this->bare,
+        ]);
+    }
+
+    private function basePath(GitRepository $repo): string
+    {
+        return $this->tmp.'/warm/'.$repo->team_id.'/'.$repo->id;
+    }
+
+    public function test_first_checkout_clones_base_and_returns_worktree_at_ref(): void
+    {
+        $repo = $this->repo();
+        $wt = $this->mgr->checkout($repo, 'origin/main', 'run-aaaaaaaa');
+
+        $this->assertDirectoryExists($wt);
+        $this->assertFileExists($wt.'/README.md');
+        $this->assertSame('v1', File::get($wt.'/README.md'));
+        $this->assertDirectoryExists($this->basePath($repo).'/.git');
+    }
+
+    public function test_second_checkout_fetches_not_reclones(): void
+    {
+        $repo = $this->repo();
+        $this->mgr->checkout($repo, 'origin/main', 'run-1');
+
+        // Sentinel inside the base .git — survives a fetch, gone if re-cloned.
+        $sentinel = $this->basePath($repo).'/.git/FLEETQ_SENTINEL';
+        File::put($sentinel, 'x');
+
+        $this->pushSeedCommit('v2.txt', 'v2');
+        $wt2 = $this->mgr->checkout($repo, 'origin/main', 'run-2');
+
+        $this->assertFileExists($sentinel, 'base was re-cloned (clone-once violated)');
+        $this->assertFileExists($wt2.'/v2.txt', 'fetch did not pick up the new commit');
+    }
+
+    public function test_worktree_is_pristine_on_reuse_discarding_dirty_state(): void
+    {
+        $repo = $this->repo();
+        $wt = $this->mgr->checkout($repo, 'origin/main', 'run-reuse');
+        File::put($wt.'/stray.txt', 'dirt');
+        File::put($wt.'/README.md', 'tampered');
+
+        $wt2 = $this->mgr->checkout($repo, 'origin/main', 'run-reuse');
+
+        $this->assertFileDoesNotExist($wt2.'/stray.txt');
+        $this->assertSame('v1', File::get($wt2.'/README.md'));
+    }
+
+    public function test_two_runs_get_isolated_worktrees(): void
+    {
+        $repo = $this->repo();
+        $a = $this->mgr->checkout($repo, 'origin/main', 'run-aaa');
+        $b = $this->mgr->checkout($repo, 'origin/main', 'run-bbb');
+
+        $this->assertNotSame($a, $b);
+        File::put($a.'/only-a.txt', '1');
+        $this->assertFileDoesNotExist($b.'/only-a.txt');
+    }
+
+    public function test_checkout_at_specific_commit_sha(): void
+    {
+        $repo = $this->repo();
+        $firstSha = trim(Process::run(['git', '-C', $this->seed, 'rev-parse', 'HEAD'])->output());
+        $this->pushSeedCommit('later.txt', 'later');
+
+        $wt = $this->mgr->checkout($repo, $firstSha, 'run-sha');
+
+        $this->assertFileDoesNotExist($wt.'/later.txt');
+        $this->assertSame($firstSha, trim(Process::run(['git', '-C', $wt, 'rev-parse', 'HEAD'])->output()));
+    }
+
+    public function test_release_removes_worktree_but_keeps_base(): void
+    {
+        $repo = $this->repo();
+        $wt = $this->mgr->checkout($repo, 'origin/main', 'run-rel');
+
+        $this->mgr->release($repo, $wt);
+
+        $this->assertDirectoryDoesNotExist($wt);
+        $this->assertDirectoryExists($this->basePath($repo).'/.git');
+    }
+
+    public function test_prune_keeps_only_recent_worktrees(): void
+    {
+        $repo = $this->repo();
+        foreach (['r1', 'r2', 'r3', 'r4'] as $id) {
+            $this->mgr->checkout($repo, 'origin/main', 'run-'.$id);
+        }
+
+        $removed = $this->mgr->prune($repo, keep: 2);
+
+        $this->assertSame(2, $removed);
+        $remaining = array_filter(glob($this->tmp.'/warm/'.$repo->team_id.'/'.$repo->id.'.worktrees/*') ?: [], 'is_dir');
+        $this->assertCount(2, $remaining);
+    }
+
+    public function test_enabled_reflects_config(): void
+    {
+        config(['experiments.warm_build.enabled' => true]);
+        $this->assertTrue(WarmRepoManager::enabled());
+        config(['experiments.warm_build.enabled' => false]);
+        $this->assertFalse(WarmRepoManager::enabled());
+    }
+}


### PR DESCRIPTION
## What
`WarmRepoManager` — keeps a **persistent per-(team,repo) base clone** and hands out an **isolated worktree per run**, so builds check out in **seconds** (`git fetch` + `git worktree add`) instead of re-cloning the whole repo every time.

- `checkout(repo, ref, runId)` → worktree path, `reset --hard` + `clean -fdx` to `ref` (no cross-run contamination); `release()`, `prune(keep)`.
- First call clones once; later calls fetch. Base mutation is `flock`-serialized.
- Flag `experiments.warm_build.enabled` (default **off**) + `base_dir` (persistent volume on prod). Off = nothing calls it → zero behaviour change.

## Decisions (delegated "best choice")
Persistent platform builder · per-(team,repo) base · always `git fetch` (correctness) · building-only · deps-cache deferred.

## ⚠️ Infra prerequisite (found during build)
`app`/`horizon` are **alpine without `git`**. The platform-builder path needs a builder image with `git` (+ later `composer`/`npm` for the dep-cache). Until provisioned, keep the flag off. Tests **skip when git is absent** (CI/alpine never red) and run fully where git exists.

## Deferred (documented follow-ups)
Dependency cache (lockfile-hash) · wiring `WarmRepoManager` into the debug-build executor (the prod-risky integration). This sprint ships the reusable mechanism + tests.

## Tests
`WarmRepoManagerTest` (8, real git): clone-once-then-fetch, worktree at ref/SHA, pristine-on-reuse (discards dirty), isolation, release, prune, enabled flag. pint + larastan clean (Docker, git added locally to verify).

Docs: `docs/specs/spec-warm-build-sandbox.md` (requirements), `docs/{design,architecture,test-plans}/*-warm-build-sandbox.md`.

⚠️ Draft — human merge.