### PR TITLE
feat(experiments): warm-build debug executor — VPS-side agentic fix + draft PR

### DIFF
--- a/app/Domain/Experiment/Actions/CompleteBuildingAction.php
+++ b/app/Domain/Experiment/Actions/CompleteBuildingAction.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Domain\Experiment\Actions;
+
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Enums\StageStatus;
+use App\Domain\Experiment\Enums\StageType;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\ExperimentStage;
+
+/**
+ * Marks a debug-track building stage complete and moves the experiment to
+ * AwaitingApproval, recording the opened PR URLs + a summary on the stage.
+ *
+ * Shared by both completion paths: the external bridge builder (via the
+ * experiment_complete_building MCP tool) and the platform-side warm-build
+ * executor (ExecuteWarmDebugBuildAction). Both must produce identical state.
+ */
+class CompleteBuildingAction
+{
+    /**
+     * @param  list<string>  $prUrls
+     */
+    public function execute(Experiment $experiment, array $prUrls = [], ?string $summary = null, string $completedBy = 'agent_mcp'): void
+    {
+        $stage = ExperimentStage::withoutGlobalScopes()
+            ->where('experiment_id', $experiment->id)
+            ->where('stage', StageType::Building)
+            ->where('status', StageStatus::Running)
+            ->latest()
+            ->first();
+
+        if ($stage) {
+            $stage->update([
+                'status' => StageStatus::Completed,
+                'completed_at' => now(),
+                'duration_ms' => $stage->started_at ? (int) $stage->started_at->diffInMilliseconds(now()) : null,
+                'output_snapshot' => array_merge($stage->output_snapshot ?? [], array_filter([
+                    'pr_urls' => $prUrls,
+                    'summary' => $summary,
+                    'completed_by' => $completedBy,
+                ])),
+            ]);
+        }
+
+        app(TransitionExperimentAction::class)->execute(
+            experiment: $experiment,
+            toState: ExperimentStatus::AwaitingApproval,
+            reason: 'Building completed — '.count($prUrls).' PR(s) opened',
+        );
+    }
+}

--- a/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
+++ b/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace App\Domain\Experiment\Actions;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Enums\ExperimentTrack;
+use App\Domain\Experiment\Enums\StageStatus;
+use App\Domain\Experiment\Enums\StageType;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\ExperimentStage;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\GitCloneUrlResolver;
+use App\Domain\GitRepository\Services\GitOperationRouter;
+use App\Domain\GitRepository\Services\WarmRepoManager;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\Gateways\LocalAgentGateway;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+
+/**
+ * Platform-side debug-track builder: instead of waiting for an external bridge
+ * agent, this checks the target repo out into a warm worktree on the VPS, runs
+ * claude-code-vps agentically inside it to apply the fix, then commits, pushes a
+ * branch, opens a DRAFT pull request, and completes the building stage.
+ *
+ * Dispatched from RunBuildingStage only when experiments.warm_build.enabled is on
+ * AND a repository can be resolved; otherwise the legacy bridge-wait path stands.
+ * Any failure transitions the experiment to BuildingFailed with a safe reason.
+ */
+class ExecuteWarmDebugBuildAction
+{
+    public function __construct(
+        private readonly WarmRepoManager $warmRepo,
+        private readonly GitCloneUrlResolver $cloneUrls,
+        private readonly GitOperationRouter $gitRouter,
+        private readonly LocalAgentGateway $localAgent,
+        private readonly CompleteBuildingAction $completeBuilding,
+        private readonly TransitionExperimentAction $transition,
+    ) {}
+
+    public function execute(Experiment $experiment): void
+    {
+        if ($experiment->track !== ExperimentTrack::Debug || $experiment->status !== ExperimentStatus::Building) {
+            return;
+        }
+
+        $repo = $this->resolveRepository($experiment);
+        if (! $repo) {
+            $this->fail($experiment, 'No git repository is configured for this experiment\'s agent.');
+
+            return;
+        }
+
+        $ref = 'origin/'.($repo->default_branch ?: 'main');
+        $cloneUrl = $this->cloneUrls->authenticatedUrl($repo);
+        $worktree = null;
+        $prUrls = [];
+
+        // Build phase: any failure here flips the experiment to BuildingFailed.
+        // Completion (the AwaitingApproval transition) is deliberately AFTER this
+        // block so a throwing downstream transition listener can't be mistaken
+        // for a build failure and re-transition an already-completed experiment.
+        try {
+            $worktree = $this->warmRepo->checkout($repo, $ref, $experiment->id, $cloneUrl);
+
+            $baseSha = $this->git($worktree, ['rev-parse', 'HEAD']);
+
+            $this->localAgent->complete($this->buildRequest($experiment, $worktree));
+
+            // The agent edits files with the CLI's own tools; capture whatever it
+            // changed as a single commit (a no-op when it already committed).
+            if (trim($this->git($worktree, ['status', '--porcelain'])) !== '') {
+                $this->git($worktree, ['add', '-A']);
+                $this->git($worktree, [
+                    '-c', 'user.email=agent@fleetq.ai',
+                    '-c', 'user.name=FleetQ Agent',
+                    'commit', '-m', 'Fix: '.$experiment->title,
+                ]);
+            }
+
+            if ($this->git($worktree, ['rev-parse', 'HEAD']) === $baseSha) {
+                $this->fail($experiment, 'Agent produced no changes — nothing to open a PR for.');
+
+                return;
+            }
+
+            $branch = 'fleetq/fix-'.substr($experiment->id, 0, 8);
+            $this->git($worktree, ['push', 'origin', 'HEAD:refs/heads/'.$branch, '--force']);
+
+            $pr = $this->gitRouter->resolve($repo)->createPullRequest(
+                title: '[FleetQ] Fix: '.$experiment->title,
+                body: $this->prBody($experiment),
+                head: $branch,
+                base: (string) ($repo->default_branch ?: 'main'),
+                draft: true,
+            );
+            $prUrls = array_filter([$pr['pr_url']]);
+        } catch (\Throwable $e) {
+            // Never leak an authenticated clone URL into the failure reason/logs.
+            $this->fail($experiment, 'Warm build failed: '.$this->scrub($e->getMessage(), $cloneUrl));
+
+            return;
+        } finally {
+            if ($worktree !== null) {
+                $this->warmRepo->release($repo, $worktree);
+                $this->warmRepo->prune($repo);
+            }
+        }
+
+        $this->completeBuilding->execute(
+            experiment: $experiment,
+            prUrls: $prUrls,
+            summary: 'Warm-build agent opened a draft PR on '.$repo->name.'.',
+            completedBy: 'agent_warm_build',
+        );
+
+        Log::info('ExecuteWarmDebugBuildAction: draft PR opened', [
+            'experiment_id' => $experiment->id,
+            'repo_id' => $repo->id,
+            'pr_urls' => $prUrls,
+        ]);
+    }
+
+    private function resolveRepository(Experiment $experiment): ?GitRepository
+    {
+        $repoId = $experiment->constraints['git_repository_id'] ?? null;
+
+        if (! $repoId && $experiment->agent_id) {
+            $agent = Agent::withoutGlobalScopes()->find($experiment->agent_id);
+            $repoId = $agent?->config['git_repository_ids'][0] ?? null;
+        }
+
+        if (! $repoId) {
+            return null;
+        }
+
+        return GitRepository::withoutGlobalScopes()
+            ->where('team_id', $experiment->team_id)
+            ->find($repoId);
+    }
+
+    private function buildRequest(Experiment $experiment, string $worktree): AiRequestDTO
+    {
+        $system = 'You are a senior software engineer fixing a reported bug in the checked-out '
+            .'repository (your current working directory). Make the smallest correct change that '
+            .'resolves the issue. If the project has tests, run them and ensure they pass. Do NOT '
+            .'push or open a pull request — that is handled for you. When done, stop.';
+
+        $user = trim($experiment->title."\n\n".($experiment->thesis ?? ''));
+
+        return new AiRequestDTO(
+            provider: 'claude-code-vps',
+            model: (string) config('local_agents.vps.build_model', ''),
+            systemPrompt: $system,
+            userPrompt: $user,
+            teamId: $experiment->team_id,
+            experimentId: $experiment->id,
+            purpose: 'experiment.debug_build',
+            workingDirectory: $worktree,
+        );
+    }
+
+    private function prBody(Experiment $experiment): string
+    {
+        return "Automated fix opened by FleetQ for experiment `{$experiment->id}`.\n\n"
+            ."**Issue:** {$experiment->title}\n\n"
+            ."⚠️ Draft PR — requires human review before merge.";
+    }
+
+    private function fail(Experiment $experiment, string $reason): void
+    {
+        $stage = ExperimentStage::withoutGlobalScopes()
+            ->where('experiment_id', $experiment->id)
+            ->where('stage', StageType::Building)
+            ->where('status', StageStatus::Running)
+            ->latest()
+            ->first();
+
+        $stage?->update([
+            'status' => StageStatus::Failed,
+            'completed_at' => now(),
+            'output_snapshot' => array_merge($stage->output_snapshot ?? [], ['error' => $reason]),
+        ]);
+
+        if ($experiment->status === ExperimentStatus::Building) {
+            $this->transition->execute(
+                experiment: $experiment,
+                toState: ExperimentStatus::BuildingFailed,
+                reason: $reason,
+            );
+        }
+    }
+
+    /**
+     * @param  list<string>  $args
+     */
+    private function git(string $worktree, array $args): string
+    {
+        $result = Process::timeout(120)->run(array_merge(['git', '-C', $worktree], $args));
+        if (! $result->successful()) {
+            throw new \RuntimeException('git '.($args[0] ?? '').' failed: '.trim($result->errorOutput()));
+        }
+
+        return trim($result->output());
+    }
+
+    private function scrub(string $message, ?string $cloneUrl): string
+    {
+        if ($cloneUrl) {
+            $message = str_replace($cloneUrl, '[repo-url]', $message);
+        }
+
+        // Strip any embedded userinfo token from stray git error output.
+        return (string) preg_replace('#https://[^@/\s]+:[^@/\s]+@#', 'https://[redacted]@', $message);
+    }
+}

--- a/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
+++ b/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
@@ -165,7 +165,7 @@ class ExecuteWarmDebugBuildAction
     {
         return "Automated fix opened by FleetQ for experiment `{$experiment->id}`.\n\n"
             ."**Issue:** {$experiment->title}\n\n"
-            ."⚠️ Draft PR — requires human review before merge.";
+            .'⚠️ Draft PR — requires human review before merge.';
     }
 
     private function fail(Experiment $experiment, string $reason): void

--- a/app/Domain/Experiment/Pipeline/RunBuildingStage.php
+++ b/app/Domain/Experiment/Pipeline/RunBuildingStage.php
@@ -11,6 +11,7 @@ use App\Domain\Experiment\Enums\StageType;
 use App\Domain\Experiment\Models\Experiment;
 use App\Domain\Experiment\Models\ExperimentStage;
 use App\Domain\Experiment\Models\ExperimentTask;
+use App\Domain\GitRepository\Services\WarmRepoManager;
 use App\Domain\Website\Actions\CreateWebsiteAction;
 use App\Domain\Website\Actions\GenerateWebsiteStructureAction;
 use App\Domain\Website\Actions\PublishWebsitePageAction;
@@ -92,14 +93,26 @@ class RunBuildingStage extends BaseStageJob
 
         $plan = $planningStage->output_snapshot ?? [];
 
-        // Debug track: the bridge agent signals completion via experiment_complete_building MCP tool.
-        // No tasks, no batch — just mark the stage Running and return.
+        // Debug track: the fix is applied by an agent, not by in-process artifact
+        // jobs. Two builders can do it:
+        //  - warm-build (flag on + a repo resolvable): a claude-code-vps agent runs
+        //    on the VPS in a checked-out worktree and opens a draft PR itself;
+        //  - otherwise, an EXTERNAL bridge agent signals completion via the
+        //    experiment_complete_building MCP tool (legacy default).
+        // Either way the stage just stays Running here.
         if ($experiment->track === ExperimentTrack::Debug) {
+            $useWarmBuild = WarmRepoManager::enabled();
+
             $stage->update([
                 'output_snapshot' => array_merge($stage->output_snapshot ?? [], [
                     'debug_track' => true,
+                    'builder' => $useWarmBuild ? 'warm_build' : 'bridge',
                 ]),
             ]);
+
+            if ($useWarmBuild) {
+                RunWarmDebugBuildJob::dispatch($experiment->id, $experiment->team_id);
+            }
 
             return;
         }

--- a/app/Domain/Experiment/Pipeline/RunWarmDebugBuildJob.php
+++ b/app/Domain/Experiment/Pipeline/RunWarmDebugBuildJob.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Domain\Experiment\Pipeline;
+
+use App\Domain\Experiment\Actions\ExecuteWarmDebugBuildAction;
+use App\Domain\Experiment\Models\Experiment;
+use App\Jobs\Middleware\CheckKillSwitch;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Runs the platform-side warm-build debug builder in its own long-lived job so
+ * the RunBuildingStage job can return immediately (stage stays Running). A build
+ * is a single agentic coding session — never retried (a retry would re-run the
+ * agent and re-spend), so failures go straight to BuildingFailed via the action.
+ */
+class RunWarmDebugBuildJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public int $timeout = 2000;
+
+    public function __construct(
+        public readonly string $experimentId,
+        public readonly ?string $teamId = null,
+    ) {
+        $this->onQueue('ai-calls');
+    }
+
+    /**
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new CheckKillSwitch];
+    }
+
+    public function handle(ExecuteWarmDebugBuildAction $action): void
+    {
+        $experiment = Experiment::withoutGlobalScopes()->find($this->experimentId);
+        if (! $experiment) {
+            Log::warning('RunWarmDebugBuildJob: experiment not found', ['experiment_id' => $this->experimentId]);
+
+            return;
+        }
+
+        $action->execute($experiment);
+    }
+}

--- a/app/Domain/GitRepository/Contracts/GitClientInterface.php
+++ b/app/Domain/GitRepository/Contracts/GitClientInterface.php
@@ -54,11 +54,12 @@ interface GitClientInterface
     public function push(string $branch): void;
 
     /**
-     * Open a pull request.
+     * Open a pull request. When $draft is true the PR is opened in draft state
+     * (agent-authored fixes ship as draft for mandatory human review before merge).
      *
      * @return array{pr_number: string, pr_url: string, title: string, status: string}
      */
-    public function createPullRequest(string $title, string $body, string $head, string $base): array;
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array;
 
     /**
      * List pull requests.

--- a/app/Domain/GitRepository/Services/GitCloneUrlResolver.php
+++ b/app/Domain/GitRepository/Services/GitCloneUrlResolver.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Domain\GitRepository\Services;
+
+use App\Domain\GitRepository\Models\GitRepository;
+
+/**
+ * Builds an authenticated HTTPS clone URL for a private repository by injecting
+ * the repo's stored credential token into the URL userinfo.
+ *
+ * The returned URL contains a secret — callers MUST keep it in memory only and
+ * never log it or persist it. Returns null when the repo has no usable
+ * credential (public repos clone fine from the bare url).
+ */
+class GitCloneUrlResolver
+{
+    public function authenticatedUrl(GitRepository $repo): ?string
+    {
+        $url = (string) $repo->url;
+        if ($url === '' || ! str_starts_with($url, 'https://')) {
+            // SSH or empty url: leave auth to the environment (deploy key/agent).
+            return null;
+        }
+
+        $token = $this->token($repo);
+        if ($token === null || $token === '') {
+            return null;
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false || empty($parts['host'])) {
+            return null;
+        }
+
+        $host = $parts['host'];
+        $path = $parts['path'] ?? '';
+        $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+
+        // GitLab wants the oauth2 username; GitHub (and most others) accept any
+        // username with the token as the password.
+        $user = str_contains($host, 'gitlab') ? 'oauth2' : 'x-access-token';
+
+        return 'https://'.$user.':'.rawurlencode($token).'@'.$host.$port.$path;
+    }
+
+    private function token(GitRepository $repo): ?string
+    {
+        // data_get (not ->credential->secret_data) so larastan doesn't trip on
+        // the generic Model relation type; the TeamEncryptedArray cast still runs.
+        $secrets = data_get($repo->credential, 'secret_data');
+        if (! is_array($secrets)) {
+            return null;
+        }
+
+        return $secrets['token']
+            ?? $secrets['access_token']
+            ?? $secrets['api_key']
+            ?? $secrets['password']
+            ?? null;
+    }
+}

--- a/app/Infrastructure/AI/Gateways/LocalAgentGateway.php
+++ b/app/Infrastructure/AI/Gateways/LocalAgentGateway.php
@@ -285,7 +285,21 @@ class LocalAgentGateway implements AiGatewayInterface
         }
 
         $workdir = $this->makeEphemeralWorkdir();
-        $timeout = (int) config('local_agents.vps.timeout_seconds', 300);
+
+        // For in-repo builds the caller passes a checked-out worktree as the
+        // working directory: run the CLI THERE so its file edits land in the repo,
+        // while HOME stays on the ephemeral dir so the agent's config/caches never
+        // pollute the checkout. Such runs also get a longer timeout than a normal
+        // one-shot completion (a real fix takes minutes, not seconds).
+        $cwd = $workdir;
+        $isRepoBuild = $request->workingDirectory !== null && is_dir($request->workingDirectory);
+        if ($isRepoBuild) {
+            $cwd = $request->workingDirectory;
+        }
+
+        $timeout = $isRepoBuild
+            ? (int) config('local_agents.vps.build_timeout_seconds', 1800)
+            : (int) config('local_agents.vps.timeout_seconds', 300);
         $oauthToken = (string) config('local_agents.vps.oauth_token');
 
         // Assistant mode uses the same --system-prompt / --tools "" separation as
@@ -368,7 +382,7 @@ class LocalAgentGateway implements AiGatewayInterface
         $stderr = '';
 
         try {
-            $process = new Process($args, $workdir, $env, $prompt, $timeout);
+            $process = new Process($args, $cwd, $env, $prompt, $timeout);
 
             if ($useStreaming) {
                 $this->runVpsProcessStreaming($process, $onChunk);

--- a/app/Infrastructure/Git/Clients/AtomicCommittingGitClient.php
+++ b/app/Infrastructure/Git/Clients/AtomicCommittingGitClient.php
@@ -77,9 +77,9 @@ class AtomicCommittingGitClient implements GitClientInterface
         $this->inner->push($branch);
     }
 
-    public function createPullRequest(string $title, string $body, string $head, string $base): array
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
     {
-        return $this->inner->createPullRequest($title, $body, $head, $base);
+        return $this->inner->createPullRequest($title, $body, $head, $base, $draft);
     }
 
     public function mergePullRequest(int $prNumber, string $method = 'squash', ?string $commitTitle = null, ?string $commitMessage = null): array

--- a/app/Infrastructure/Git/Clients/BridgeGitClient.php
+++ b/app/Infrastructure/Git/Clients/BridgeGitClient.php
@@ -90,7 +90,7 @@ class BridgeGitClient implements GitClientInterface
         $this->dispatch('push', ['branch' => $branch]);
     }
 
-    public function createPullRequest(string $title, string $body, string $head, string $base): array
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
     {
         // Bridge mode delegates PR creation to the local agent (e.g. via gh CLI)
         $result = $this->dispatch('create_pr', [
@@ -98,6 +98,7 @@ class BridgeGitClient implements GitClientInterface
             'body' => $body,
             'head' => $head,
             'base' => $base,
+            'draft' => $draft,
         ]);
 
         return [

--- a/app/Infrastructure/Git/Clients/GatedGitClient.php
+++ b/app/Infrastructure/Git/Clients/GatedGitClient.php
@@ -136,16 +136,17 @@ class GatedGitClient implements GitClientInterface
         $this->inner->push($branch);
     }
 
-    public function createPullRequest(string $title, string $body, string $head, string $base): array
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
     {
         $this->gate->check($this->repo, 'createPullRequest', [
             'title' => $title,
             'body' => $body,
             'head' => $head,
             'base' => $base,
+            'draft' => $draft,
         ]);
 
-        return $this->inner->createPullRequest($title, $body, $head, $base);
+        return $this->inner->createPullRequest($title, $body, $head, $base, $draft);
     }
 
     public function mergePullRequest(int $prNumber, string $method = 'squash', ?string $commitTitle = null, ?string $commitMessage = null): array

--- a/app/Infrastructure/Git/Clients/GitHubApiClient.php
+++ b/app/Infrastructure/Git/Clients/GitHubApiClient.php
@@ -229,13 +229,14 @@ class GitHubApiClient implements GitClientInterface
         // No-op for API-only mode — commits are pushed atomically via the API
     }
 
-    public function createPullRequest(string $title, string $body, string $head, string $base): array
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
     {
         $response = $this->http()->post("/repos/{$this->owner}/{$this->repo}/pulls", [
             'title' => $title,
             'body' => $body,
             'head' => $head,
             'base' => $base,
+            'draft' => $draft,
         ]);
 
         $this->checkAuth($response);

--- a/app/Infrastructure/Git/Clients/GitLabApiClient.php
+++ b/app/Infrastructure/Git/Clients/GitLabApiClient.php
@@ -191,9 +191,14 @@ class GitLabApiClient implements GitClientInterface
         // No-op for API-only mode
     }
 
-    public function createPullRequest(string $title, string $body, string $head, string $base): array
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
     {
         $id = urlencode($this->projectPath);
+
+        // GitLab marks a merge request as draft via a "Draft:" title prefix.
+        if ($draft && ! str_starts_with($title, 'Draft:')) {
+            $title = 'Draft: '.$title;
+        }
 
         $response = $this->http()->post("/projects/{$id}/merge_requests", [
             'title' => $title,

--- a/app/Infrastructure/Git/Clients/SandboxGitClient.php
+++ b/app/Infrastructure/Git/Clients/SandboxGitClient.php
@@ -124,13 +124,14 @@ class SandboxGitClient implements GitClientInterface
         $this->dispatch('push', ['branch' => $branch]);
     }
 
-    public function createPullRequest(string $title, string $body, string $head, string $base): array
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
     {
         $result = $this->dispatch('create_pr', [
             'title' => $title,
             'body' => $body,
             'head' => $head,
             'base' => $base,
+            'draft' => $draft,
         ]);
 
         return [

--- a/app/Mcp/Tools/Experiment/ExperimentCompleteBuildingTool.php
+++ b/app/Mcp/Tools/Experiment/ExperimentCompleteBuildingTool.php
@@ -2,12 +2,9 @@
 
 namespace App\Mcp\Tools\Experiment;
 
-use App\Domain\Experiment\Actions\TransitionExperimentAction;
+use App\Domain\Experiment\Actions\CompleteBuildingAction;
 use App\Domain\Experiment\Enums\ExperimentStatus;
-use App\Domain\Experiment\Enums\StageStatus;
-use App\Domain\Experiment\Enums\StageType;
 use App\Domain\Experiment\Models\Experiment;
-use App\Domain\Experiment\Models\ExperimentStage;
 use App\Mcp\Concerns\HasStructuredErrors;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
@@ -65,30 +62,11 @@ class ExperimentCompleteBuildingTool extends Tool
             return $this->validationError("Experiment is in '{$experiment->status->value}' state, not 'building'. Cannot complete.");
         }
 
-        $stage = ExperimentStage::withoutGlobalScopes()
-            ->where('experiment_id', $experiment->id)
-            ->where('stage', StageType::Building)
-            ->where('status', StageStatus::Running)
-            ->latest()
-            ->first();
-
-        if ($stage) {
-            $stage->update([
-                'status' => StageStatus::Completed,
-                'completed_at' => now(),
-                'duration_ms' => $stage->started_at ? (int) $stage->started_at->diffInMilliseconds(now()) : null,
-                'output_snapshot' => array_merge($stage->output_snapshot ?? [], array_filter([
-                    'pr_urls' => $validated['pr_urls'] ?? [],
-                    'summary' => $validated['summary'] ?? null,
-                    'completed_by' => 'agent_mcp',
-                ])),
-            ]);
-        }
-
-        app(TransitionExperimentAction::class)->execute(
+        app(CompleteBuildingAction::class)->execute(
             experiment: $experiment,
-            toState: ExperimentStatus::AwaitingApproval,
-            reason: 'Agent completed building via MCP tool',
+            prUrls: $validated['pr_urls'] ?? [],
+            summary: $validated['summary'] ?? null,
+            completedBy: 'agent_mcp',
         );
 
         return Response::text(json_encode([

--- a/config/local_agents.php
+++ b/config/local_agents.php
@@ -212,6 +212,10 @@ return [
         'binary_path' => env('CLAUDE_CODE_VPS_BINARY', '/usr/local/bin/claude'),
         'max_concurrency_per_team' => (int) env('CLAUDE_CODE_VPS_MAX_CONCURRENCY', 2),
         'timeout_seconds' => (int) env('CLAUDE_CODE_VPS_TIMEOUT', 300),
+        // In-repo debug builds run an agentic coding session (edit → test → commit)
+        // in a checked-out worktree — they need minutes, not the one-shot timeout.
+        // Kept under the debug-track stage's 90-minute stuck-recovery net.
+        'build_timeout_seconds' => (int) env('CLAUDE_CODE_VPS_BUILD_TIMEOUT', 1800),
     ],
 
     // Host bridge — allows Docker containers to reach host-installed agents

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,11 +1,15 @@
 FROM php:8.4-fpm-alpine AS base
 
 # Install system dependencies
+# git + openssh-client: required by the warm-build debug builder (WarmRepoManager
+# clones/worktrees the target repo on the VPS so claude-code-vps can build in it).
 RUN apk add --no-cache \
     postgresql-dev \
     libzip-dev \
     icu-dev \
     linux-headers \
+    git \
+    openssh-client \
     $PHPIZE_DEPS
 
 # Install system dependencies for exif

--- a/tests/Feature/Domain/Experiment/ExecuteWarmDebugBuildActionTest.php
+++ b/tests/Feature/Domain/Experiment/ExecuteWarmDebugBuildActionTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Tests\Feature\Domain\Experiment;
+
+use App\Domain\Experiment\Actions\ExecuteWarmDebugBuildAction;
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Enums\ExperimentTrack;
+use App\Domain\Experiment\Enums\StageStatus;
+use App\Domain\Experiment\Enums\StageType;
+use App\Domain\Experiment\Events\ExperimentTransitioned;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\ExperimentStage;
+use App\Domain\GitRepository\Contracts\GitClientInterface;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\GitOperationRouter;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Infrastructure\AI\Gateways\LocalAgentGateway;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Real-git integration for the platform-side warm-build debug builder: the agent
+ * (faked) edits the worktree, the action commits + pushes to a bare origin and
+ * opens a (faked) draft PR, then completes the building stage.
+ */
+class ExecuteWarmDebugBuildActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $tmp = '';
+
+    private string $bare = '';
+
+    private string $seed = '';
+
+    private ?Team $team = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (! Process::run(['git', '--version'])->successful()) {
+            $this->markTestSkipped('git binary not available in this environment');
+        }
+
+        $this->tmp = sys_get_temp_dir().'/wbld-'.Str::random(10);
+        File::makeDirectory($this->tmp, 0777, true);
+        config(['experiments.warm_build.base_dir' => $this->tmp.'/warm']);
+        config(['experiments.warm_build.enabled' => true]);
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'T', 'slug' => 't-'.Str::random(6),
+            'owner_id' => $user->id, 'settings' => [],
+        ]);
+
+        // Isolate the action's orchestration from transition side-effects
+        // (DispatchNextStageJob et al. have their own tests).
+        Event::fake([ExperimentTransitioned::class]);
+
+        $this->bare = $this->tmp.'/remote.git';
+        $this->seed = $this->tmp.'/seed';
+        $this->initRemote();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->tmp) && is_dir($this->tmp)) {
+            File::deleteDirectory($this->tmp);
+        }
+        parent::tearDown();
+    }
+
+    private function git(array $args): void
+    {
+        Process::run(array_merge(['git'], $args))->throw();
+    }
+
+    private function initRemote(): void
+    {
+        File::makeDirectory($this->seed, 0777, true);
+        $this->git(['init', '--bare', '-b', 'main', $this->bare]);
+        $this->git(['-C', $this->seed, 'init', '-b', 'main']);
+        $this->git(['-C', $this->seed, 'config', 'user.email', 't@example.com']);
+        $this->git(['-C', $this->seed, 'config', 'user.name', 'Test']);
+        File::put($this->seed.'/README.md', 'v1');
+        $this->git(['-C', $this->seed, 'add', '-A']);
+        $this->git(['-C', $this->seed, 'commit', '-m', 'seed']);
+        $this->git(['-C', $this->seed, 'remote', 'add', 'origin', $this->bare]);
+        $this->git(['-C', $this->seed, 'push', 'origin', 'main']);
+    }
+
+    private function repo(): GitRepository
+    {
+        return GitRepository::create([
+            'team_id' => $this->team->id,
+            'name' => 'r',
+            'url' => $this->bare,
+            'default_branch' => 'main',
+        ]);
+    }
+
+    private function experiment(array $constraints): Experiment
+    {
+        $exp = Experiment::factory()->create([
+            'team_id' => $this->team->id,
+            'track' => ExperimentTrack::Debug,
+            'status' => ExperimentStatus::Building,
+            'constraints' => $constraints,
+            'title' => 'Null deref in checkout',
+        ]);
+
+        ExperimentStage::factory()->create([
+            'team_id' => $this->team->id,
+            'experiment_id' => $exp->id,
+            'stage' => StageType::Building,
+            'status' => StageStatus::Running,
+            'started_at' => now(),
+        ]);
+
+        return $exp;
+    }
+
+    /** Fake the VPS agent: on complete() it edits a file in the worktree. */
+    private function fakeAgentWriting(?string $file, string $content = 'patched'): void
+    {
+        $gw = Mockery::mock(LocalAgentGateway::class);
+        $gw->shouldReceive('complete')->andReturnUsing(function ($request) use ($file, $content) {
+            if ($file !== null) {
+                File::put($request->workingDirectory.'/'.$file, $content);
+            }
+
+            return new AiResponseDTO(
+                content: 'done', parsedOutput: null, usage: new AiUsageDTO(0, 0, 0),
+                provider: 'claude-code-vps', model: '', latencyMs: 1,
+            );
+        });
+        $this->app->instance(LocalAgentGateway::class, $gw);
+    }
+
+    /** Fake the git client so createPullRequest returns a PR and records the draft flag. */
+    private function fakePrClient(array &$captured): void
+    {
+        $client = Mockery::mock(GitClientInterface::class);
+        $client->shouldReceive('createPullRequest')
+            ->andReturnUsing(function ($title, $body, $head, $base, $draft = false) use (&$captured) {
+                $captured = compact('title', 'head', 'base', 'draft');
+
+                return ['pr_number' => '7', 'pr_url' => 'https://example.test/pr/7', 'title' => $title, 'status' => 'open'];
+            });
+
+        $router = Mockery::mock(GitOperationRouter::class);
+        $router->shouldReceive('resolve')->andReturn($client);
+        $this->app->instance(GitOperationRouter::class, $router);
+    }
+
+    public function test_happy_path_opens_draft_pr_and_awaits_approval(): void
+    {
+        $repo = $this->repo();
+        $exp = $this->experiment(['git_repository_id' => $repo->id]);
+        $this->fakeAgentWriting('fix.txt');
+        $captured = [];
+        $this->fakePrClient($captured);
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $exp->refresh();
+        $this->assertSame(ExperimentStatus::AwaitingApproval, $exp->status);
+        $this->assertTrue($captured['draft'], 'PR must be opened as a draft');
+        $this->assertSame('main', $captured['base']);
+
+        $stage = ExperimentStage::where('experiment_id', $exp->id)->where('stage', StageType::Building)->first();
+        $this->assertSame(StageStatus::Completed, $stage->status);
+        $this->assertContains('https://example.test/pr/7', $stage->output_snapshot['pr_urls']);
+
+        // The fix branch was actually pushed to the bare origin.
+        $branches = Process::run(['git', '-C', $this->bare, 'branch', '--list', 'fleetq/fix-*'])->output();
+        $this->assertStringContainsString('fleetq/fix-', $branches);
+    }
+
+    public function test_no_changes_fails_the_build(): void
+    {
+        $repo = $this->repo();
+        $exp = $this->experiment(['git_repository_id' => $repo->id]);
+        $this->fakeAgentWriting(null); // agent touches nothing
+        $captured = [];
+        $this->fakePrClient($captured);
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $exp->refresh();
+        $this->assertSame(ExperimentStatus::BuildingFailed, $exp->status);
+        $this->assertSame([], $captured, 'no PR should be opened when there are no changes');
+    }
+
+    public function test_missing_repository_fails_the_build(): void
+    {
+        $exp = $this->experiment([]); // no git_repository_id, no agent
+        $this->fakeAgentWriting('fix.txt');
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $exp->refresh();
+        $this->assertSame(ExperimentStatus::BuildingFailed, $exp->status);
+    }
+}

--- a/tests/Feature/Domain/Experiment/RunBuildingStageDebugDispatchTest.php
+++ b/tests/Feature/Domain/Experiment/RunBuildingStageDebugDispatchTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Domain\Experiment;
+
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Enums\ExperimentTrack;
+use App\Domain\Experiment\Enums\StageStatus;
+use App\Domain\Experiment\Enums\StageType;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\ExperimentStage;
+use App\Domain\Experiment\Pipeline\RunBuildingStage;
+use App\Domain\Experiment\Pipeline\RunWarmDebugBuildJob;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class RunBuildingStageDebugDispatchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function debugExperimentInBuilding(): Experiment
+    {
+        $user = User::factory()->create();
+        $team = Team::create(['name' => 'T', 'slug' => 't-'.Str::random(6), 'owner_id' => $user->id, 'settings' => []]);
+
+        $exp = Experiment::factory()->create([
+            'team_id' => $team->id,
+            'track' => ExperimentTrack::Debug,
+            'status' => ExperimentStatus::Building,
+        ]);
+
+        ExperimentStage::factory()->create([
+            'team_id' => $team->id,
+            'experiment_id' => $exp->id,
+            'stage' => StageType::Building,
+            'status' => StageStatus::Pending,
+            'iteration' => $exp->current_iteration,
+        ]);
+
+        return $exp;
+    }
+
+    public function test_dispatches_warm_build_job_when_flag_enabled(): void
+    {
+        config(['experiments.warm_build.enabled' => true]);
+        Bus::fake();
+        $exp = $this->debugExperimentInBuilding();
+
+        (new RunBuildingStage($exp->id, $exp->team_id))->handle();
+
+        Bus::assertDispatched(RunWarmDebugBuildJob::class);
+
+        $stage = ExperimentStage::where('experiment_id', $exp->id)->where('stage', StageType::Building)->first();
+        $this->assertSame('warm_build', $stage->output_snapshot['builder']);
+    }
+
+    public function test_does_not_dispatch_when_flag_disabled_bridge_path(): void
+    {
+        config(['experiments.warm_build.enabled' => false]);
+        Bus::fake();
+        $exp = $this->debugExperimentInBuilding();
+
+        (new RunBuildingStage($exp->id, $exp->team_id))->handle();
+
+        Bus::assertNotDispatched(RunWarmDebugBuildJob::class);
+
+        $stage = ExperimentStage::where('experiment_id', $exp->id)->where('stage', StageType::Building)->first();
+        $this->assertSame('bridge', $stage->output_snapshot['builder']);
+    }
+}

--- a/tests/Feature/Domain/GitRepository/AtomicCommitTest.php
+++ b/tests/Feature/Domain/GitRepository/AtomicCommitTest.php
@@ -253,7 +253,7 @@ class FakeGitClient implements GitClientInterface
 
     public function push(string $branch): void {}
 
-    public function createPullRequest(string $title, string $body, string $head, string $base): array
+    public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
     {
         return ['pr_number' => '1', 'pr_url' => 'http://x', 'title' => $title, 'status' => 'open'];
     }

--- a/tests/Feature/Infrastructure/Git/GitHubApiClientDraftPrTest.php
+++ b/tests/Feature/Infrastructure/Git/GitHubApiClientDraftPrTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Infrastructure\Git;
+
+use App\Domain\Credential\Models\Credential;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\Git\Clients\GitHubApiClient;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class GitHubApiClientDraftPrTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_pull_request_forwards_draft_flag(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::create(['name' => 'T', 'slug' => 't-'.Str::random(6), 'owner_id' => $user->id, 'settings' => []]);
+
+        $credential = Credential::factory()->create([
+            'team_id' => $team->id,
+            'secret_data' => ['token' => 'ghp_test'],
+        ]);
+
+        $repo = GitRepository::create([
+            'team_id' => $team->id,
+            'name' => 'r',
+            'url' => 'https://github.com/acme/widgets',
+            'credential_id' => $credential->id,
+        ]);
+
+        Http::fake([
+            'api.github.com/repos/acme/widgets/pulls' => Http::response([
+                'number' => 42,
+                'html_url' => 'https://github.com/acme/widgets/pull/42',
+                'title' => 'Fix',
+                'state' => 'open',
+            ], 201),
+        ]);
+
+        $client = new GitHubApiClient($repo->load('credential'));
+        $result = $client->createPullRequest('Fix', 'body', 'fleetq/fix-1', 'main', draft: true);
+
+        $this->assertSame('42', $result['pr_number']);
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://api.github.com/repos/acme/widgets/pulls'
+                && $request['draft'] === true
+                && $request['head'] === 'fleetq/fix-1';
+        });
+    }
+}

--- a/tests/Feature/Workflow/WorkflowYamlGitSyncTest.php
+++ b/tests/Feature/Workflow/WorkflowYamlGitSyncTest.php
@@ -181,7 +181,7 @@ class WorkflowYamlGitSyncTest extends TestCase
 
             public function push(string $branch): void {}
 
-            public function createPullRequest(string $title, string $body, string $head, string $base): array
+            public function createPullRequest(string $title, string $body, string $head, string $base, bool $draft = false): array
             {
                 return [];
             }


### PR DESCRIPTION
Completes warm-build-sandbox: wires `WarmRepoManager` into the debug-track building stage so a fix is built on the VPS by claude-code-vps (no external bridge), then opens a **draft** PR.

## What's new
- `ExecuteWarmDebugBuildAction` — checkout warm worktree → run claude-code-vps agentically in it → commit → push branch → open draft PR → complete stage. Failures → BuildingFailed.
- `RunWarmDebugBuildJob` — long-lived job dispatched from `RunBuildingStage` when `EXPERIMENTS_WARM_BUILD` on AND a repo resolves; else the legacy bridge-wait path stands.
- `executeVps` honours `AiRequestDTO.workingDirectory` as cwd (worktree) with HOME kept ephemeral + longer `build_timeout_seconds`.
- Draft-PR support across `GitClientInterface` + all 6 implementors.
- `GitCloneUrlResolver` (in-memory authed URL, never logged) + shared `CompleteBuildingAction`.
- `docker/php/Dockerfile`: add git + openssh-client.
- Flag **EXPERIMENTS_WARM_BUILD stays OFF** by default.

## Tests
14 new/regression tests (warm-build action happy/no-change/no-repo real-git, dispatch wiring, draft-PR forwarding). pint + larastan clean.

⚠️ Deploy note: needs an **image rebuild** on prod (git baked into app/horizon image), not just recreate.