### PR TITLE
fix(warm-build): cloud-edition blockers (gateway bind + GitHub client param)

### DIFF
--- a/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
+++ b/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
@@ -34,7 +34,6 @@ class ExecuteWarmDebugBuildAction
         private readonly WarmRepoManager $warmRepo,
         private readonly GitCloneUrlResolver $cloneUrls,
         private readonly GitOperationRouter $gitRouter,
-        private readonly LocalAgentGateway $localAgent,
         private readonly CompleteBuildingAction $completeBuilding,
         private readonly TransitionExperimentAction $transition,
     ) {}
@@ -66,7 +65,12 @@ class ExecuteWarmDebugBuildAction
 
             $baseSha = $this->git($worktree, ['rev-parse', 'HEAD']);
 
-            $this->localAgent->complete($this->buildRequest($experiment, $worktree));
+            // Resolve by class (not constructor DI): the cloud edition binds
+            // LocalAgentGateway::class to DisabledLocalAgentGateway (implements
+            // AiGatewayInterface, not a subclass — DI-hinting the concrete class
+            // would TypeError). Disabled delegates vps_only providers to a real
+            // gateway, so calling complete() directly preserves workingDirectory.
+            app(LocalAgentGateway::class)->complete($this->buildRequest($experiment, $worktree));
 
             // The agent edits files with the CLI's own tools; capture whatever it
             // changed as a single commit (a no-op when it already committed).

--- a/app/Infrastructure/Git/Clients/GitHubApiClient.php
+++ b/app/Infrastructure/Git/Clients/GitHubApiClient.php
@@ -20,10 +20,12 @@ class GitHubApiClient implements GitClientInterface
 
     private string $token;
 
-    public function __construct(GitRepository $gitRepository)
+    public function __construct(GitRepository $repo)
     {
-        [$this->owner, $this->repo] = $this->parseOwnerRepo($gitRepository->url);
-        $this->token = $gitRepository->credential?->secret_data['token'] ?? '';
+        // Param is named $repo to match GitOperationRouter's container binding
+        // (app(GitHubApiClient::class, ['repo' => $repo])) and the other clients.
+        [$this->owner, $this->repo] = $this->parseOwnerRepo($repo->url);
+        $this->token = (string) (data_get($repo->credential, 'secret_data.token') ?? '');
     }
 
     public function ping(): bool


### PR DESCRIPTION
Follow-up to #117. Live prod E2E proved the warm-build core works but exposed 2 cloud-only breakers on the autowired path:
1. Concrete `LocalAgentGateway` type-hint TypeErrors in cloud (bound to `DisabledLocalAgentGateway`) → resolve via `app(LocalAgentGateway::class)` (delegates vps_only, preserves workingDirectory).
2. `GitHubApiClient($gitRepository)` vs router's `['repo'=>...]` → null url TypeError at PR step → renamed to `$repo`, token via data_get.

git-in-image (3rd blocker) fixed in parent Dockerfile. Tests + pint + larastan green.