### PR TITLE
fix(observability): stuck_experiments counted orphaned stage rows

### DIFF
--- a/app/Console/Commands/RecoverStuckTasks.php
+++ b/app/Console/Commands/RecoverStuckTasks.php
@@ -8,6 +8,7 @@ use App\Domain\Experiment\Enums\ExperimentStatus;
 use App\Domain\Experiment\Enums\ExperimentTaskStatus;
 use App\Domain\Experiment\Enums\ExperimentTrack;
 use App\Domain\Experiment\Enums\StageStatus;
+use App\Domain\Experiment\Enums\StageType;
 use App\Domain\Experiment\Events\StuckPatternDetected;
 use App\Domain\Experiment\Models\Experiment;
 use App\Domain\Experiment\Models\ExperimentStage;
@@ -370,6 +371,20 @@ class RecoverStuckTasks extends Command
                 ExperimentStatus::BuildingFailed,
                 'Debug-track agent timed out after 90 minutes without signaling completion',
             );
+
+            // Close the building stage too — otherwise it lingers as a
+            // status=running row forever and inflates the stuck_experiments
+            // alert metric (orphaned stage on a now-terminal experiment).
+            ExperimentStage::withoutGlobalScopes()
+                ->where('experiment_id', $experiment->id)
+                ->where('stage', StageType::Building)
+                ->whereIn('status', [StageStatus::Running, StageStatus::Pending])
+                ->update([
+                    'status' => StageStatus::Failed,
+                    'completed_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
             $recovered++;
         }
 

--- a/app/Infrastructure/Observability/Alerts/AlertEvaluator.php
+++ b/app/Infrastructure/Observability/Alerts/AlertEvaluator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Observability\Alerts;
 
+use App\Domain\Experiment\Enums\ExperimentStatus;
 use App\Domain\Experiment\Models\ExperimentStage;
 use App\Infrastructure\AI\Models\CircuitBreakerState;
 use Carbon\CarbonImmutable;
@@ -11,6 +12,7 @@ use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
 use Throwable;
@@ -132,9 +134,29 @@ final class AlertEvaluator
 
     private function stuckExperiments(): int
     {
+        // A running/pending stage is only "stuck pipeline" if its experiment is
+        // still meant to be progressing. Exclude stages whose parent already
+        // reached a terminal/failed/rejected/paused state — those are orphaned
+        // rows (the stage was never closed when the experiment ended), not a
+        // locked pipeline, and would otherwise inflate the metric forever.
+        $inactive = array_map(
+            static fn (ExperimentStatus $s) => $s->value,
+            array_filter(
+                ExperimentStatus::cases(),
+                static fn (ExperimentStatus $s) => $s->isTerminal() || $s->isFailed()
+                    || $s === ExperimentStatus::Rejected || $s === ExperimentStatus::Paused,
+            ),
+        );
+
         return ExperimentStage::withoutGlobalScopes()
             ->whereIn('status', ['running', 'pending'])
             ->where('updated_at', '<', now()->subMinutes(15))
+            ->whereExists(function ($q) use ($inactive) {
+                $q->select(DB::raw(1))
+                    ->from('experiments')
+                    ->whereColumn('experiments.id', 'experiment_stages.experiment_id')
+                    ->whereNotIn('experiments.status', $inactive);
+            })
             ->count();
     }
 

--- a/tests/Unit/Infrastructure/Observability/StuckExperimentsMetricTest.php
+++ b/tests/Unit/Infrastructure/Observability/StuckExperimentsMetricTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\Observability;
+
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Enums\StageStatus;
+use App\Domain\Experiment\Enums\StageType;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Experiment\Models\ExperimentStage;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\Observability\Alerts\AlertEvaluator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * The stuck_experiments alert metric must count only running/pending stages
+ * whose parent experiment is still active — orphaned rows left running on
+ * terminal/failed/killed experiments must NOT inflate it (that class of row is
+ * exactly what fired the false-positive PlatformAlert emails).
+ */
+class StuckExperimentsMetricTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function stuckStageOn(ExperimentStatus $expStatus): void
+    {
+        $team = Team::factory()->create();
+        $exp = Experiment::factory()->create(['team_id' => $team->id, 'status' => $expStatus]);
+        $stage = ExperimentStage::factory()->create([
+            'team_id' => $team->id,
+            'experiment_id' => $exp->id,
+            'stage' => StageType::Building,
+            'status' => StageStatus::Running,
+        ]);
+
+        // Force updated_at older than the 15-min stuck window (bypass model timestamps).
+        DB::table('experiment_stages')->where('id', $stage->id)
+            ->update(['updated_at' => now()->subMinutes(20)]);
+    }
+
+    private function stuckCount(): int
+    {
+        $m = new ReflectionMethod(AlertEvaluator::class, 'stuckExperiments');
+        $m->setAccessible(true);
+
+        return (int) $m->invoke(app(AlertEvaluator::class));
+    }
+
+    public function test_orphaned_stages_on_terminal_or_failed_experiments_are_excluded(): void
+    {
+        $this->stuckStageOn(ExperimentStatus::BuildingFailed);
+        $this->stuckStageOn(ExperimentStatus::Killed);
+        $this->stuckStageOn(ExperimentStatus::Discarded);
+
+        $this->assertSame(0, $this->stuckCount(), 'orphaned stages on non-active experiments must not count');
+    }
+
+    public function test_running_stage_on_active_experiment_still_counts(): void
+    {
+        $this->stuckStageOn(ExperimentStatus::Building);   // genuinely in-progress
+        $this->stuckStageOn(ExperimentStatus::BuildingFailed); // orphan, must be ignored
+
+        $this->assertSame(1, $this->stuckCount(), 'only the active-parent stage should count');
+    }
+}


### PR DESCRIPTION
**Why the PlatformAlert emails fired:** the `stuck_experiments` metric counted every `experiment_stages` row `running`/`pending` >15min old — including rows orphaned on already-terminal experiments. Debug-track builds that time out (PriceX, no builder) went `building_failed` but left the building stage `running`; these accumulated since 2026-05-24 until crossing threshold 10 (value 12) → email every cooldown.

**Fix:**
1. `AlertEvaluator::stuckExperiments` excludes stages whose parent experiment is terminal/failed/rejected/paused.
2. `RecoverStuckTasks` debug-track 90-min timeout now closes the building stage, so no new orphans form.

Prod cleanup already ran (12→3). Tests + pint + larastan green. No migration.