### PR TITLE
[FleetQ] Fix: Fix bug: UnexpectedValueException: The stream or file "/var/www/storage/logs/laravel-2026-07-01.log" could not be opened in append mode: chmod(): Operation not permitted

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -71,11 +71,15 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
-            // 0664 (group-writable) lets every container's php-fpm worker
-            // append to the daily file regardless of which one created it.
-            // Pairs with deploy.sh's chown www-data:www-data on storage/.
-            // (FLEETQ-67 #683 / FLEETQ-89 #778)
-            'permission' => 0664,
+            // No explicit 'permission' here: Monolog chmod()s the file on every
+            // stream open when this is set, which throws UnexpectedValueException
+            // ("could not be opened in append mode: chmod(): Operation not permitted")
+            // whenever the log file is owned by a different user/container than the
+            // one currently writing — chmod requires file ownership, unlike append
+            // writes. Group-writable access across containers should be handled via
+            // umask/setgid on storage/logs, not a forced per-write chmod.
+            // (Previously 'permission' => 0664 per FLEETQ-67 #683 / FLEETQ-89 #778;
+            // reverted after it caused FLEETQ-121.)
             'replace_placeholders' => true,
         ],
 

--- a/docker/php/entrypoint.sh
+++ b/docker/php/entrypoint.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e
 
+# Logs are written by several processes that may run as different users
+# (php-fpm as www-data, artisan/scheduler as root). Make storage/logs setgid so
+# new daily files inherit the www-data group, and set umask 0002 so they are
+# group-writable — every writer can then append without Monolog force-chmod'ing
+# the file (which throws "Operation not permitted" when it doesn't own it; see
+# the 'daily' channel in config/logging.php). Best-effort; needs root at entry.
+umask 0002
+chmod g+s /var/www/storage/logs 2>/dev/null || true
+
 # Sync vendor directory (named volume may be empty or stale)
 if [ ! -f /var/www/vendor/autoload.php ]; then
     echo "[entrypoint] Installing Composer dependencies..."

--- a/tests/Unit/Config/DailyLogPermissionTest.php
+++ b/tests/Unit/Config/DailyLogPermissionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit\Config;
+
+use Tests\TestCase;
+
+/**
+ * The daily log channel must NOT set an explicit 'permission'. When set, Monolog
+ * chmod()s the file on every stream open, which throws UnexpectedValueException
+ * ("Operation not permitted") whenever the log file is owned by a different user
+ * than the writer (php-fpm=www-data vs artisan/scheduler=root). Group-writable
+ * access is instead guaranteed by setgid + umask 0002 on storage/logs (see the
+ * php entrypoint). This test locks that decision so it isn't silently reverted.
+ */
+class DailyLogPermissionTest extends TestCase
+{
+    public function test_daily_channel_does_not_force_a_file_permission(): void
+    {
+        $daily = config('logging.channels.daily');
+
+        $this->assertIsArray($daily);
+        $this->assertArrayNotHasKey('permission', $daily);
+    }
+}


### PR DESCRIPTION
Automated fix opened by FleetQ for experiment `019f1ce9-9147-70e7-a021-43730ec17fa9`.

**Issue:** Fix bug: UnexpectedValueException: The stream or file "/var/www/storage/logs/laravel-2026-07-01.log" could not be opened in append mode: chmod(): Operation not permitted

⚠️ Draft PR — requires human review before merge.