### PR TITLE
[FleetQ] Fix: Fix bug: TypeError: array_values(): Argument #1 ($array) must be of type array, false given

### DIFF
--- a/app/Infrastructure/Horizon/GuardedRedisSupervisorRepository.php
+++ b/app/Infrastructure/Horizon/GuardedRedisSupervisorRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Infrastructure\Horizon;
+
+use Laravel\Horizon\Repositories\RedisSupervisorRepository;
+
+/**
+ * Laravel\Horizon\Repositories\RedisSupervisorRepository::get() calls
+ * array_values() on every pipelined `hmget` result without checking that the
+ * result is actually an array. A transient Redis hiccup (or a pipelined
+ * command failing independently of the others) can make one of those results
+ * `false`, which throws `TypeError: array_values(): Argument #1 ($array)
+ * must be of type array, false given`. The sibling
+ * RedisMasterSupervisorRepository already guards against this with an
+ * `is_array()` check; this override applies the same guard here.
+ */
+class GuardedRedisSupervisorRepository extends RedisSupervisorRepository
+{
+    public function get(array $names)
+    {
+        $records = $this->pipeline(function ($pipe) use ($names) {
+            foreach ($names as $name) {
+                $pipe->hmget('supervisor:'.$name, ['name', 'master', 'pid', 'status', 'processes', 'options']);
+            }
+        });
+
+        return collect($records)
+            ->filter(fn ($record) => is_array($record))
+            ->map(function ($record) {
+                $record = array_values($record);
+
+                return ! $record[0] ? null : (object) [
+                    'name' => $record[0],
+                    'master' => $record[1],
+                    'pid' => $record[2],
+                    'status' => $record[3],
+                    'processes' => json_decode($record[4], true),
+                    'options' => json_decode($record[5], true),
+                ];
+            })
+            ->filter()
+            ->all();
+    }
+}

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
+use App\Infrastructure\Horizon\GuardedRedisSupervisorRepository;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Queue;
+use Laravel\Horizon\Contracts\SupervisorRepository;
 use Laravel\Horizon\Horizon;
 use Laravel\Horizon\HorizonApplicationServiceProvider;
 use Monolog\ResettableInterface;
@@ -16,6 +18,11 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
     public function boot(): void
     {
         parent::boot();
+
+        // Horizon's own RedisSupervisorRepository::get() calls array_values()
+        // on unguarded pipeline results (TypeError when Redis returns false
+        // for a hiccuping pipelined command). Override with a guarded version.
+        $this->app->singleton(SupervisorRepository::class, GuardedRedisSupervisorRepository::class);
 
         // Defensive: reset Monolog handler buffers after each job.
         // StreamHandler (current default) is a no-op. This guards against future

--- a/tests/Unit/Infrastructure/Horizon/GuardedRedisSupervisorRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Horizon/GuardedRedisSupervisorRepositoryTest.php
@@ -13,7 +13,7 @@ class GuardedRedisSupervisorRepositoryTest extends TestCase
     {
         $this->assertInstanceOf(
             GuardedRedisSupervisorRepository::class,
-            $this->app->make(SupervisorRepository::class)
+            $this->app->make(SupervisorRepository::class),
         );
     }
 

--- a/tests/Unit/Infrastructure/Horizon/GuardedRedisSupervisorRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Horizon/GuardedRedisSupervisorRepositoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\Horizon;
+
+use App\Infrastructure\Horizon\GuardedRedisSupervisorRepository;
+use Illuminate\Contracts\Redis\Factory as RedisFactory;
+use Laravel\Horizon\Contracts\SupervisorRepository;
+use Tests\TestCase;
+
+class GuardedRedisSupervisorRepositoryTest extends TestCase
+{
+    public function test_container_resolves_supervisor_repository_to_guarded_implementation(): void
+    {
+        $this->assertInstanceOf(
+            GuardedRedisSupervisorRepository::class,
+            $this->app->make(SupervisorRepository::class)
+        );
+    }
+
+    public function test_get_ignores_non_array_pipeline_results_instead_of_throwing(): void
+    {
+        $repository = new class($this->app->make(RedisFactory::class)) extends GuardedRedisSupervisorRepository
+        {
+            protected function pipeline(callable $callback)
+            {
+                // Simulates Horizon's real pipeline() returning `false` for one
+                // of the pipelined hmget commands (the condition that used to
+                // crash RedisSupervisorRepository::get() with a TypeError).
+                return [
+                    false,
+                    [
+                        'name' => 'supervisor-1',
+                        'master' => 'master-1',
+                        'pid' => 123,
+                        'status' => 'running',
+                        'processes' => '{"redis:default":1}',
+                        'options' => '{"timeout":60}',
+                    ],
+                ];
+            }
+        };
+
+        $result = array_values($repository->get(['supervisor-1', 'supervisor-2']));
+
+        $this->assertCount(1, $result);
+        $this->assertSame('supervisor-1', $result[0]->name);
+        $this->assertSame(['redis:default' => 1], $result[0]->processes);
+    }
+}


### PR DESCRIPTION
Automated fix opened by FleetQ for experiment `019f220f-e90d-735f-b30d-4e1b14ad49ed`.

**Issue:** Fix bug: TypeError: array_values(): Argument #1 ($array) must be of type array, false given

⚠️ Draft PR — requires human review before merge.