### PR TITLE
[FleetQ] Fix: Fix bug: RedisException: php_network_getaddresses: getaddrinfo for redis failed: Name or service not known

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,6 +32,7 @@
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="REDIS_HOST" value="127.0.0.1"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>


### PR DESCRIPTION
Automated fix opened by FleetQ for experiment `019f2736-531b-71d1-b97e-a6784b26e3a4`.

**Issue:** Fix bug: RedisException: php_network_getaddresses: getaddrinfo for redis failed: Name or service not known

⚠️ Draft PR — requires human review before merge.