### PR TITLE
feat(ai): proactive agent loop-detection engine (dark-shipped)

### DIFF
--- a/app/Domain/Agent/Models/AiRun.php
+++ b/app/Domain/Agent/Models/AiRun.php
@@ -13,6 +13,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * @property string $id
+ * @property string|null $team_id
+ * @property string|null $agent_id
+ * @property string|null $experiment_id
+ * @property array<string, mixed>|null $prompt_snapshot
+ * @property array<string, mixed>|null $raw_output
  * @property array<string, mixed>|null $error_metadata
  */
 class AiRun extends Model

--- a/app/Domain/Agent/Models/AiRun.php
+++ b/app/Domain/Agent/Models/AiRun.php
@@ -5,7 +5,9 @@ namespace App\Domain\Agent\Models;
 use App\Domain\Experiment\Models\Experiment;
 use App\Domain\Experiment\Models\ExperimentStage;
 use App\Domain\Shared\Traits\BelongsToTeam;
+use Database\Factories\Domain\Agent\AiRunFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -63,6 +65,11 @@ class AiRun extends Model
             'has_reasoning' => 'boolean',
             'error_metadata' => 'array',
         ];
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return AiRunFactory::new();
     }
 
     public function agent(): BelongsTo

--- a/app/Domain/Agent/Observers/AiRunObserver.php
+++ b/app/Domain/Agent/Observers/AiRunObserver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Domain\Agent\Observers;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Infrastructure\AI\LoopDetection\Events\AgentLoopDetected;
+use App\Infrastructure\AI\LoopDetection\LoopDetector;
+use Illuminate\Support\Facades\Log;
+
+class AiRunObserver
+{
+    public function __construct(private readonly LoopDetector $detector) {}
+
+    public function created(AiRun $run): void
+    {
+        if (! (bool) config('loop_detection.enabled', false)) {
+            return;
+        }
+
+        // Loop detection must never break the inference/recording path.
+        try {
+            $signal = $this->detector->inspect($run);
+
+            if ($signal->tripped()) {
+                AgentLoopDetected::dispatch($run, $signal);
+            }
+        } catch (\Throwable $e) {
+            Log::warning('AiRunObserver: loop detection failed', [
+                'ai_run_id' => $run->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Infrastructure/AI/LoopDetection/Contracts/TurnHistoryStore.php
+++ b/app/Infrastructure/AI/LoopDetection/Contracts/TurnHistoryStore.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection\Contracts;
+
+interface TurnHistoryStore
+{
+    /**
+     * Append a turn to a context's history, capped to $window most-recent entries.
+     *
+     * @param  array{bg: list<string>, oh: string, t: float}  $turn
+     */
+    public function push(string $contextKey, array $turn, int $window, int $ttlSeconds): void;
+
+    /**
+     * Recent turns for a context, newest-first.
+     *
+     * @return list<array{bg: list<string>, oh: string, t: float}>
+     */
+    public function recent(string $contextKey): array;
+}

--- a/app/Infrastructure/AI/LoopDetection/Enums/LoopSignalType.php
+++ b/app/Infrastructure/AI/LoopDetection/Enums/LoopSignalType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection\Enums;
+
+enum LoopSignalType: string
+{
+    case None = 'none';
+    case SemanticLoop = 'semantic_loop';
+    case Runaway = 'runaway';
+    case Stall = 'stall';
+}

--- a/app/Infrastructure/AI/LoopDetection/Events/AgentLoopDetected.php
+++ b/app/Infrastructure/AI/LoopDetection/Events/AgentLoopDetected.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection\Events;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Infrastructure\AI\LoopDetection\LoopSignal;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class AgentLoopDetected
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly AiRun $run,
+        public readonly LoopSignal $signal,
+    ) {}
+}

--- a/app/Infrastructure/AI/LoopDetection/Listeners/HandleAgentLoop.php
+++ b/app/Infrastructure/AI/LoopDetection/Listeners/HandleAgentLoop.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection\Listeners;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Domain\Experiment\Actions\KillExperimentAction;
+use App\Domain\Experiment\Actions\PauseExperimentAction;
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Shared\Services\NotificationService;
+use App\Infrastructure\AI\LoopDetection\Events\AgentLoopDetected;
+use App\Infrastructure\AI\LoopDetection\LoopSignal;
+use Illuminate\Support\Facades\Log;
+use Sentry\Severity;
+
+/**
+ * Trips the runaway-agent circuit breaker. Mirrors PauseOnBudgetExceeded:
+ * pause (default) or kill the parent experiment, alert the team, and record a
+ * Sentry security event. 'alert' mode observes without stopping execution.
+ */
+class HandleAgentLoop
+{
+    public function __construct(
+        private readonly PauseExperimentAction $pause,
+        private readonly KillExperimentAction $kill,
+        private readonly NotificationService $notifications,
+    ) {}
+
+    public function handle(AgentLoopDetected $event): void
+    {
+        $run = $event->run;
+        $signal = $event->signal;
+        $action = (string) config('loop_detection.on_trip', 'pause');
+
+        Log::warning('LoopDetection: agent loop detected', [
+            'ai_run_id' => $run->id,
+            'experiment_id' => $run->experiment_id,
+            'team_id' => $run->team_id,
+            'type' => $signal->type->value,
+            'reason' => $signal->reason,
+            'on_trip' => $action,
+        ]);
+
+        $this->captureSecurityEvent($signal);
+
+        // No experiment to stop, or observe-only mode: alert and return.
+        if ($action === 'alert' || ! $run->experiment_id) {
+            $this->notify($run, $signal, paused: false);
+
+            return;
+        }
+
+        $experiment = Experiment::find($run->experiment_id);
+
+        if (! $experiment || $experiment->status->isTerminal() || $experiment->status === ExperimentStatus::Paused) {
+            return;
+        }
+
+        try {
+            $reason = sprintf('Auto-%s: agent loop (%s) — %s', $action === 'kill' ? 'killed' : 'paused', $signal->type->value, $signal->reason);
+
+            if ($action === 'kill') {
+                $this->kill->execute(experiment: $experiment, reason: $reason);
+            } else {
+                $this->pause->execute(experiment: $experiment, reason: $reason);
+            }
+
+            $this->notify($run, $signal, paused: true);
+        } catch (\Throwable $e) {
+            Log::error('LoopDetection: failed to '.$action.' experiment', [
+                'experiment_id' => $experiment->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function notify(AiRun $run, LoopSignal $signal, bool $paused): void
+    {
+        if (! $run->team_id) {
+            return;
+        }
+
+        $verb = $paused ? 'stopped' : 'flagged';
+
+        $this->notifications->notifyTeam(
+            teamId: $run->team_id,
+            type: 'loop.detected',
+            title: 'Agent Loop Detected',
+            body: sprintf('A runaway agent loop (%s) was %s: %s', $signal->type->value, $verb, $signal->reason),
+            actionUrl: $run->experiment_id ? '/experiments/'.$run->experiment_id : null,
+            data: [
+                'ai_run_id' => $run->id,
+                'experiment_id' => $run->experiment_id,
+                'signal_type' => $signal->type->value,
+                'reason' => $signal->reason,
+            ],
+        );
+    }
+
+    private function captureSecurityEvent(LoopSignal $signal): void
+    {
+        if (! app()->bound('sentry')) {
+            return;
+        }
+
+        try {
+            \Sentry\captureMessage(
+                'agent_loop_detected: '.$signal->type->value.' — '.$signal->reason,
+                Severity::warning(),
+            );
+        } catch (\Throwable) {
+            // Best-effort telemetry; never let it break the trip handler.
+        }
+    }
+}

--- a/app/Infrastructure/AI/LoopDetection/LoopDetector.php
+++ b/app/Infrastructure/AI/LoopDetection/LoopDetector.php
@@ -116,8 +116,7 @@ class LoopDetector
             $allSimilar = true;
 
             for ($i = 0; $i < $needPrior; $i++) {
-                $priorBigrams = $recent[$i]['bg'] ?? [];
-                $score = SimilarityScorer::jaccard($bigrams, is_array($priorBigrams) ? $priorBigrams : []);
+                $score = SimilarityScorer::jaccard($bigrams, $recent[$i]['bg'] ?? []);
                 $minScore = min($minScore, $score);
 
                 if ($score < $simThreshold) {
@@ -160,10 +159,6 @@ class LoopDetector
     {
         $snapshot = $run->prompt_snapshot ?? [];
 
-        if (! is_array($snapshot)) {
-            return '';
-        }
-
         $system = (string) ($snapshot['system'] ?? '');
         $user = (string) ($snapshot['user'] ?? '');
 
@@ -174,10 +169,6 @@ class LoopDetector
     {
         $raw = $run->raw_output ?? [];
 
-        if (is_array($raw)) {
-            return isset($raw['text']) ? (string) $raw['text'] : (string) json_encode($raw);
-        }
-
-        return (string) $raw;
+        return isset($raw['text']) ? (string) $raw['text'] : (string) json_encode($raw);
     }
 }

--- a/app/Infrastructure/AI/LoopDetection/LoopDetector.php
+++ b/app/Infrastructure/AI/LoopDetection/LoopDetector.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Infrastructure\AI\LoopDetection\Contracts\TurnHistoryStore;
+use App\Infrastructure\AI\LoopDetection\Enums\LoopSignalType;
+
+/**
+ * Proactive runaway-agent detector. Records each LLM turn into a per-context
+ * ring buffer and evaluates three deterministic circuit breakers against the
+ * recent window: runaway velocity, stalled (repeating) output, and semantic
+ * prompt loop. Cheap and side-effect-free apart from the history write.
+ */
+class LoopDetector
+{
+    public function __construct(private readonly TurnHistoryStore $store) {}
+
+    public function inspect(AiRun $run): LoopSignal
+    {
+        $contextKey = $this->contextKey($run);
+
+        if ($contextKey === null) {
+            return LoopSignal::none();
+        }
+
+        return $this->inspectTurn(
+            $contextKey,
+            $this->promptText($run),
+            $this->outputText($run),
+            microtime(true),
+        );
+    }
+
+    public function inspectTurn(string $contextKey, string $promptText, string $outputText, float $now): LoopSignal
+    {
+        if (! (bool) config('loop_detection.enabled', false)) {
+            return LoopSignal::none();
+        }
+
+        $window = max(2, (int) config('loop_detection.window', 8));
+        $ttl = max(60, (int) config('loop_detection.ttl_seconds', 1800));
+
+        $bigrams = SimilarityScorer::bigrams($promptText);
+        $outputHash = sha1(trim(mb_strtolower($outputText)));
+
+        $recent = $this->store->recent($contextKey);
+
+        $signal = $this->evaluate($recent, $bigrams, $outputHash, $now);
+
+        $this->store->push($contextKey, [
+            'bg' => $bigrams,
+            'oh' => $outputHash,
+            't' => $now,
+        ], $window, $ttl);
+
+        return $signal;
+    }
+
+    /**
+     * @param  list<array{bg?: list<string>, oh?: string, t?: float}>  $recent
+     * @param  list<string>  $bigrams
+     */
+    private function evaluate(array $recent, array $bigrams, string $outputHash, float $now): LoopSignal
+    {
+        // 1. Runaway velocity — too many turns in a short window.
+        $velWindow = max(1, (int) config('loop_detection.velocity.window_seconds', 60));
+        $velMax = max(1, (int) config('loop_detection.velocity.max_turns', 30));
+
+        $inWindow = 1; // include the current turn
+
+        foreach ($recent as $turn) {
+            if (($now - (float) ($turn['t'] ?? 0.0)) <= $velWindow) {
+                $inWindow++;
+            }
+        }
+
+        if ($inWindow > $velMax) {
+            return new LoopSignal(
+                LoopSignalType::Runaway,
+                "velocity {$inWindow} turns within {$velWindow}s exceeds max {$velMax}",
+                (float) $inWindow,
+                ['turns' => $inWindow, 'window_seconds' => $velWindow, 'max_turns' => $velMax],
+            );
+        }
+
+        // 2. Stall — the same output repeated consecutively.
+        $stallThreshold = max(2, (int) config('loop_detection.stall.repeat_threshold', 3));
+
+        $identical = 1; // include the current turn
+
+        foreach ($recent as $turn) {
+            if (($turn['oh'] ?? null) === $outputHash) {
+                $identical++;
+            } else {
+                break;
+            }
+        }
+
+        if ($identical >= $stallThreshold) {
+            return new LoopSignal(
+                LoopSignalType::Stall,
+                "identical output repeated {$identical} times",
+                1.0,
+                ['repeats' => $identical, 'threshold' => $stallThreshold],
+            );
+        }
+
+        // 3. Semantic loop — N consecutive near-identical prompts.
+        $simThreshold = (float) config('loop_detection.similarity.threshold', 0.9);
+        $minTurns = max(2, (int) config('loop_detection.similarity.min_turns', 3));
+        $needPrior = $minTurns - 1;
+
+        if ($bigrams !== [] && count($recent) >= $needPrior) {
+            $minScore = 1.0;
+            $allSimilar = true;
+
+            for ($i = 0; $i < $needPrior; $i++) {
+                $priorBigrams = $recent[$i]['bg'] ?? [];
+                $score = SimilarityScorer::jaccard($bigrams, is_array($priorBigrams) ? $priorBigrams : []);
+                $minScore = min($minScore, $score);
+
+                if ($score < $simThreshold) {
+                    $allSimilar = false;
+                    break;
+                }
+            }
+
+            if ($allSimilar) {
+                return new LoopSignal(
+                    LoopSignalType::SemanticLoop,
+                    "prompt similarity >= {$simThreshold} across {$minTurns} consecutive turns",
+                    $minScore,
+                    ['min_score' => round($minScore, 4), 'turns' => $minTurns, 'threshold' => $simThreshold],
+                );
+            }
+        }
+
+        return LoopSignal::none();
+    }
+
+    private function contextKey(AiRun $run): ?string
+    {
+        if ($run->experiment_id) {
+            return 'exp:'.$run->experiment_id;
+        }
+
+        if ($run->agent_id) {
+            return 'agent:'.$run->agent_id.':team:'.($run->team_id ?? 'none');
+        }
+
+        if ($run->team_id) {
+            return 'team:'.$run->team_id;
+        }
+
+        return null;
+    }
+
+    private function promptText(AiRun $run): string
+    {
+        $snapshot = $run->prompt_snapshot ?? [];
+
+        if (! is_array($snapshot)) {
+            return '';
+        }
+
+        $system = (string) ($snapshot['system'] ?? '');
+        $user = (string) ($snapshot['user'] ?? '');
+
+        return trim($system."\n".$user);
+    }
+
+    private function outputText(AiRun $run): string
+    {
+        $raw = $run->raw_output ?? [];
+
+        if (is_array($raw)) {
+            return isset($raw['text']) ? (string) $raw['text'] : (string) json_encode($raw);
+        }
+
+        return (string) $raw;
+    }
+}

--- a/app/Infrastructure/AI/LoopDetection/LoopSignal.php
+++ b/app/Infrastructure/AI/LoopDetection/LoopSignal.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection;
+
+use App\Infrastructure\AI\LoopDetection\Enums\LoopSignalType;
+
+final class LoopSignal
+{
+    /**
+     * @param  array<string, mixed>  $detail
+     */
+    public function __construct(
+        public readonly LoopSignalType $type,
+        public readonly string $reason = '',
+        public readonly float $score = 0.0,
+        public readonly array $detail = [],
+    ) {}
+
+    public static function none(): self
+    {
+        return new self(LoopSignalType::None);
+    }
+
+    public function tripped(): bool
+    {
+        return $this->type !== LoopSignalType::None;
+    }
+}

--- a/app/Infrastructure/AI/LoopDetection/RedisTurnHistoryStore.php
+++ b/app/Infrastructure/AI/LoopDetection/RedisTurnHistoryStore.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection;
+
+use App\Infrastructure\AI\LoopDetection\Contracts\TurnHistoryStore;
+use Illuminate\Support\Facades\Redis;
+
+/**
+ * Redis-backed ring buffer of recent turn fingerprints, one list per execution
+ * context. Uses the 'locks' connection (DB 2) — ephemeral, self-expiring.
+ */
+class RedisTurnHistoryStore implements TurnHistoryStore
+{
+    private const PREFIX = 'loopdet:turns:';
+
+    public function push(string $contextKey, array $turn, int $window, int $ttlSeconds): void
+    {
+        $redis = Redis::connection('locks');
+        $key = self::PREFIX.$contextKey;
+
+        $redis->lpush($key, (string) json_encode($turn));
+        $redis->ltrim($key, 0, max(0, $window - 1));
+        $redis->expire($key, $ttlSeconds);
+    }
+
+    public function recent(string $contextKey): array
+    {
+        $raw = Redis::connection('locks')->lrange(self::PREFIX.$contextKey, 0, -1);
+
+        $turns = [];
+
+        foreach ($raw as $item) {
+            $decoded = json_decode((string) $item, true);
+
+            if (is_array($decoded) && isset($decoded['oh'], $decoded['t'])) {
+                $turns[] = $decoded;
+            }
+        }
+
+        return $turns;
+    }
+}

--- a/app/Infrastructure/AI/LoopDetection/SimilarityScorer.php
+++ b/app/Infrastructure/AI/LoopDetection/SimilarityScorer.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Infrastructure\AI\LoopDetection;
+
+/**
+ * Pure, deterministic text-similarity primitives for loop detection.
+ *
+ * Word-level Bi-Gram Jaccard: catches polymorphic/mutating prompts that reorder
+ * or lightly edit wording while keeping substantially the same content.
+ */
+class SimilarityScorer
+{
+    /**
+     * Tokenize normalized text into the set of adjacent word bigrams (bounded).
+     *
+     * @return list<string>
+     */
+    public static function bigrams(string $text, int $maxTokens = 400): array
+    {
+        // Preserve Unicode letters/digits (Cyrillic included); drop control chars.
+        $normalized = mb_strtolower($text);
+        $normalized = preg_replace('/[\x00-\x1F\x7F]/u', ' ', $normalized) ?? '';
+
+        $tokens = preg_split('/[^\p{L}\p{N}]+/u', $normalized, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        if (count($tokens) > $maxTokens) {
+            $tokens = array_slice($tokens, 0, $maxTokens);
+        }
+
+        $count = count($tokens);
+
+        if ($count === 0) {
+            return [];
+        }
+
+        if ($count === 1) {
+            return [$tokens[0]];
+        }
+
+        $bigrams = [];
+
+        for ($i = 0; $i < $count - 1; $i++) {
+            $bigrams[$tokens[$i].' '.$tokens[$i + 1]] = true;
+        }
+
+        return array_keys($bigrams);
+    }
+
+    /**
+     * Jaccard similarity between two bigram sets (0.0 .. 1.0).
+     *
+     * @param  list<string>  $a
+     * @param  list<string>  $b
+     */
+    public static function jaccard(array $a, array $b): float
+    {
+        if ($a === [] && $b === []) {
+            return 1.0;
+        }
+
+        if ($a === [] || $b === []) {
+            return 0.0;
+        }
+
+        $setA = array_fill_keys($a, true);
+        $setB = array_fill_keys($b, true);
+
+        $intersection = 0;
+
+        foreach ($setA as $key => $_) {
+            if (isset($setB[$key])) {
+                $intersection++;
+            }
+        }
+
+        $union = count($setA) + count($setB) - $intersection;
+
+        return $union === 0 ? 0.0 : $intersection / $union;
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -556,6 +556,7 @@ use App\Mcp\Tools\System\DashboardKpisTool;
 use App\Mcp\Tools\System\GlobalSettingsUpdateTool;
 use App\Mcp\Tools\System\InspectDiffCommentsTool;
 use App\Mcp\Tools\System\LangfuseConfigTool;
+use App\Mcp\Tools\System\LoopDetectionStatusTool;
 use App\Mcp\Tools\System\MetricsAggregationsTool;
 use App\Mcp\Tools\System\MetricsModelComparisonTool;
 use App\Mcp\Tools\System\SecretProxyStatusTool;
@@ -1415,10 +1416,11 @@ class AgentFleetServer extends Server
         EmailTemplateDeleteTool::class,
         EmailTemplateGenerateTool::class,
 
-        // System (13)
+        // System (14)
         DashboardKpisTool::class,
         SecretProxyStatusTool::class,
         SystemHealthTool::class,
+        LoopDetectionStatusTool::class,
         SystemRecentErrorsTool::class,
         SystemVersionCheckTool::class,
         SystemDiscoveryGetTool::class,

--- a/app/Mcp/Tools/System/LoopDetectionStatusTool.php
+++ b/app/Mcp/Tools/System/LoopDetectionStatusTool.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mcp\Tools\System;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Infrastructure\AI\LoopDetection\Contracts\TurnHistoryStore;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+class LoopDetectionStatusTool extends Tool
+{
+    protected string $name = 'loop_detection_status';
+
+    protected string $description = 'Report the agent loop-detection configuration (enabled, on-trip action, thresholds) and, for an optional experiment context, how many recent turns are currently buffered in its detection window.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'experiment_id' => $schema->string()
+                ->description('Optional experiment UUID to inspect its current loop-detection turn window.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $config = [
+            'enabled' => (bool) config('loop_detection.enabled', false),
+            'on_trip' => (string) config('loop_detection.on_trip', 'pause'),
+            'window' => (int) config('loop_detection.window', 8),
+            'similarity' => [
+                'threshold' => (float) config('loop_detection.similarity.threshold', 0.9),
+                'min_turns' => (int) config('loop_detection.similarity.min_turns', 3),
+            ],
+            'velocity' => [
+                'max_turns' => (int) config('loop_detection.velocity.max_turns', 30),
+                'window_seconds' => (int) config('loop_detection.velocity.window_seconds', 60),
+            ],
+            'stall' => [
+                'repeat_threshold' => (int) config('loop_detection.stall.repeat_threshold', 3),
+            ],
+        ];
+
+        $experimentId = $request->get('experiment_id');
+        $bufferedTurns = null;
+
+        // Scope the lookup through TeamScope so a caller can only inspect an
+        // experiment in their own team (find() returns null otherwise).
+        if (is_string($experimentId) && $experimentId !== '' && Experiment::find($experimentId) !== null) {
+            $bufferedTurns = count(app(TurnHistoryStore::class)->recent('exp:'.$experimentId));
+        }
+
+        return Response::text((string) json_encode([
+            'config' => $config,
+            'experiment_id' => $experimentId,
+            'buffered_turns' => $bufferedTurns,
+        ]));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,8 @@ use App\Domain\Agent\Events\AgentExecuted;
 use App\Domain\Agent\Listeners\ProvisionPersonalAgentListener;
 use App\Domain\Agent\Models\Agent;
 use App\Domain\Agent\Models\AgentExecution;
+use App\Domain\Agent\Models\AiRun;
+use App\Domain\Agent\Observers\AiRunObserver;
 use App\Domain\AgentChatProtocol\Events\ChatMessageDispatched;
 use App\Domain\AgentChatProtocol\Events\ChatMessageReceived;
 use App\Domain\AgentChatProtocol\Listeners\ExecuteAgentOnChatMessage;
@@ -139,6 +141,10 @@ use App\Domain\Workflow\Models\WorkflowNode;
 use App\Domain\Workflow\Services\WorkflowNodeRegistry;
 use App\Infrastructure\AI\Contracts\EmbeddingProviderInterface;
 use App\Infrastructure\AI\Exceptions\LocalEmbeddingNotConfiguredException;
+use App\Infrastructure\AI\LoopDetection\Contracts\TurnHistoryStore;
+use App\Infrastructure\AI\LoopDetection\Events\AgentLoopDetected;
+use App\Infrastructure\AI\LoopDetection\Listeners\HandleAgentLoop;
+use App\Infrastructure\AI\LoopDetection\RedisTurnHistoryStore;
 use App\Infrastructure\AI\Middleware\BudgetEnforcement;
 use App\Infrastructure\AI\Middleware\IdempotencyCheck;
 use App\Infrastructure\AI\Middleware\RateLimiting;
@@ -380,6 +386,9 @@ class AppServiceProvider extends ServiceProvider
         // ChatbotMessage::feedback; downstream layers rebind it to record the
         // vote into their own pipeline.
         $this->app->bind(ChatbotFeedbackRecorderInterface::class, DefaultChatbotFeedbackRecorder::class);
+
+        // Loop detection: back the turn-history ring buffer with Redis (locks DB).
+        $this->app->singleton(TurnHistoryStore::class, RedisTurnHistoryStore::class);
     }
 
     /**
@@ -455,6 +464,9 @@ class AppServiceProvider extends ServiceProvider
         // whenever a page is saved or deleted so cached widget output becomes
         // unreachable (old cache keys are abandoned, TTL sweeps them up).
         WebsitePage::observe(WebsitePageObserver::class);
+
+        // Loop detection: inspect every recorded LLM turn for runaway agent loops.
+        AiRun::observe(AiRunObserver::class);
 
         // Community edition: all authenticated users have full access
         Gate::define('manage-team', fn ($user) => true);
@@ -616,6 +628,9 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(ExperimentTransitioned::class, RecordTransitionMetrics::class);
         Event::listen(ExperimentTransitioned::class, NotifyOnCriticalTransition::class);
         Event::listen(ExperimentTransitioned::class, PauseOnBudgetExceeded::class);
+
+        // Runaway agent loop → pause/kill/alert the experiment.
+        Event::listen(AgentLoopDetected::class, HandleAgentLoop::class);
         Event::listen(ExperimentTransitioned::class, LogExperimentTransition::class);
 
         // Workflow artifact collection (must fire BEFORE SyncProjectStatusOnRunComplete

--- a/config/loop_detection.php
+++ b/config/loop_detection.php
@@ -1,0 +1,44 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Agent Loop Detection
+    |--------------------------------------------------------------------------
+    |
+    | Proactive runaway-agent guardrail. Inspects every recorded AiRun turn and
+    | trips a circuit breaker BEFORE budget is exhausted when it detects a
+    | semantic prompt loop, runaway velocity, or a stalled (repeating) output.
+    | Dark-shipped: OFF by default. Cloud/autonomous hosts tighten via env.
+    |
+    */
+
+    'enabled' => env('LOOP_DETECTION_ENABLED', false),
+
+    // What to do when a loop is detected: 'pause' | 'kill' | 'alert' (observe only).
+    'on_trip' => env('LOOP_DETECTION_ON_TRIP', 'pause'),
+
+    // How many recent turns to retain per execution context.
+    'window' => (int) env('LOOP_DETECTION_WINDOW', 8),
+
+    // TTL (seconds) for a context's turn history in Redis.
+    'ttl_seconds' => (int) env('LOOP_DETECTION_TTL', 1800),
+
+    // Semantic loop: N consecutive prompts whose Bi-Gram Jaccard similarity
+    // is at or above the threshold trips a SemanticLoop signal.
+    'similarity' => [
+        'threshold' => (float) env('LOOP_DETECTION_SIMILARITY', 0.9),
+        'min_turns' => (int) env('LOOP_DETECTION_SIMILARITY_MIN_TURNS', 3),
+    ],
+
+    // Runaway: more than max_turns within window_seconds trips a Runaway signal.
+    'velocity' => [
+        'max_turns' => (int) env('LOOP_DETECTION_VELOCITY_MAX', 30),
+        'window_seconds' => (int) env('LOOP_DETECTION_VELOCITY_WINDOW', 60),
+    ],
+
+    // Stall: identical output repeated repeat_threshold times trips a Stall signal.
+    'stall' => [
+        'repeat_threshold' => (int) env('LOOP_DETECTION_STALL_REPEATS', 3),
+    ],
+];

--- a/database/factories/Domain/Agent/AiRunFactory.php
+++ b/database/factories/Domain/Agent/AiRunFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories\Domain\Agent;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Domain\Shared\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AiRun>
+ */
+class AiRunFactory extends Factory
+{
+    protected $model = AiRun::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'agent_id' => null,
+            'experiment_id' => null,
+            'experiment_stage_id' => null,
+            'purpose' => 'test',
+            'provider' => 'anthropic',
+            'byok_source' => null,
+            'model' => 'claude-sonnet-4-5',
+            'input_schema' => null,
+            'prompt_snapshot' => [
+                'system' => fake()->sentence(),
+                'user' => fake()->paragraph(),
+            ],
+            'raw_output' => ['text' => fake()->paragraph()],
+            'parsed_output' => null,
+            'schema_valid' => true,
+            'input_tokens' => fake()->numberBetween(50, 2000),
+            'output_tokens' => fake()->numberBetween(50, 2000),
+            'cost_credits' => fake()->numberBetween(1, 500),
+            'latency_ms' => fake()->numberBetween(100, 5000),
+            'status' => 'completed',
+            'reasoning_chain' => null,
+            'has_reasoning' => false,
+        ];
+    }
+}

--- a/tests/Feature/Infrastructure/AI/LoopDetection/AgentLoopDetectionTest.php
+++ b/tests/Feature/Infrastructure/AI/LoopDetection/AgentLoopDetectionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\Infrastructure\AI\LoopDetection;
+
+use App\Domain\Agent\Models\AiRun;
+use App\Domain\Experiment\Enums\ExperimentStatus;
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\LoopDetection\Contracts\TurnHistoryStore;
+use App\Infrastructure\AI\LoopDetection\Events\AgentLoopDetected;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\Support\LoopDetection\ArrayTurnHistoryStore;
+use Tests\TestCase;
+
+class AgentLoopDetectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Deterministic, Redis-free turn history for the observer path.
+        $this->app->instance(TurnHistoryStore::class, new ArrayTurnHistoryStore);
+
+        config([
+            'loop_detection.enabled' => true,
+            'loop_detection.on_trip' => 'pause',
+            'loop_detection.stall.repeat_threshold' => 2,
+            'loop_detection.velocity.max_turns' => 100,
+            'loop_detection.similarity.min_turns' => 100,
+        ]);
+    }
+
+    private function makeRun(Team $team, Experiment $experiment, string $output): AiRun
+    {
+        return AiRun::factory()->create([
+            'team_id' => $team->id,
+            'experiment_id' => $experiment->id,
+            'raw_output' => ['text' => $output],
+        ]);
+    }
+
+    public function test_stalled_output_dispatches_loop_event(): void
+    {
+        Event::fake([AgentLoopDetected::class]);
+
+        $team = Team::factory()->create();
+        $experiment = Experiment::factory()->create([
+            'team_id' => $team->id,
+            'status' => ExperimentStatus::Executing,
+        ]);
+
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+
+        Event::assertDispatched(AgentLoopDetected::class, function (AgentLoopDetected $event) use ($experiment) {
+            return $event->run->experiment_id === $experiment->id
+                && $event->signal->tripped();
+        });
+    }
+
+    public function test_disabled_detection_dispatches_nothing(): void
+    {
+        config(['loop_detection.enabled' => false]);
+        Event::fake([AgentLoopDetected::class]);
+
+        $team = Team::factory()->create();
+        $experiment = Experiment::factory()->create([
+            'team_id' => $team->id,
+            'status' => ExperimentStatus::Executing,
+        ]);
+
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+
+        Event::assertNotDispatched(AgentLoopDetected::class);
+    }
+
+    public function test_loop_pauses_the_experiment(): void
+    {
+        $team = Team::factory()->create();
+        $experiment = Experiment::factory()->create([
+            'team_id' => $team->id,
+            'status' => ExperimentStatus::Executing,
+        ]);
+
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+
+        $this->assertSame(
+            ExperimentStatus::Paused,
+            $experiment->fresh()->status,
+        );
+    }
+
+    public function test_alert_mode_records_but_does_not_pause(): void
+    {
+        config(['loop_detection.on_trip' => 'alert']);
+
+        $team = Team::factory()->create();
+        $experiment = Experiment::factory()->create([
+            'team_id' => $team->id,
+            'status' => ExperimentStatus::Executing,
+        ]);
+
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+        $this->makeRun($team, $experiment, 'STUCK OUTPUT');
+
+        $this->assertSame(
+            ExperimentStatus::Executing,
+            $experiment->fresh()->status,
+        );
+    }
+}

--- a/tests/Feature/Mcp/LoopDetectionStatusToolTest.php
+++ b/tests/Feature/Mcp/LoopDetectionStatusToolTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\System\LoopDetectionStatusTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Tests\TestCase;
+
+class LoopDetectionStatusToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $team = Team::create([
+            'name' => 'Loop Team',
+            'slug' => 'loop-team',
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $user->update(['current_team_id' => $team->id]);
+        $this->actingAs($user);
+        app()->instance('mcp.team_id', $team->id);
+    }
+
+    public function test_reports_config(): void
+    {
+        config([
+            'loop_detection.enabled' => true,
+            'loop_detection.on_trip' => 'pause',
+        ]);
+
+        $response = (new LoopDetectionStatusTool)->handle(new Request([]));
+        $payload = json_decode((string) $response->content(), true);
+
+        $this->assertFalse($response->isError());
+        $this->assertTrue($payload['config']['enabled']);
+        $this->assertSame('pause', $payload['config']['on_trip']);
+        $this->assertNull($payload['buffered_turns']);
+    }
+
+    public function test_unknown_experiment_is_not_inspectable(): void
+    {
+        // A random UUID not in the caller's team resolves to null buffered_turns.
+        $response = (new LoopDetectionStatusTool)->handle(new Request([
+            'experiment_id' => '019f0000-0000-7000-8000-000000000000',
+        ]));
+        $payload = json_decode((string) $response->content(), true);
+
+        $this->assertFalse($response->isError());
+        $this->assertNull($payload['buffered_turns']);
+    }
+}

--- a/tests/Support/LoopDetection/ArrayTurnHistoryStore.php
+++ b/tests/Support/LoopDetection/ArrayTurnHistoryStore.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Support\LoopDetection;
+
+use App\Infrastructure\AI\LoopDetection\Contracts\TurnHistoryStore;
+
+/**
+ * In-memory TurnHistoryStore for tests — avoids a Redis dependency while
+ * preserving the newest-first, window-capped semantics of the Redis impl.
+ */
+class ArrayTurnHistoryStore implements TurnHistoryStore
+{
+    /** @var array<string, list<array>> */
+    private array $data = [];
+
+    public function push(string $contextKey, array $turn, int $window, int $ttlSeconds): void
+    {
+        $existing = $this->data[$contextKey] ?? [];
+        array_unshift($existing, $turn);
+        $this->data[$contextKey] = array_slice($existing, 0, $window);
+    }
+
+    public function recent(string $contextKey): array
+    {
+        return $this->data[$contextKey] ?? [];
+    }
+}

--- a/tests/Unit/Infrastructure/AI/LoopDetection/LoopDetectorTest.php
+++ b/tests/Unit/Infrastructure/AI/LoopDetection/LoopDetectorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\AI\LoopDetection;
+
+use App\Infrastructure\AI\LoopDetection\Enums\LoopSignalType;
+use App\Infrastructure\AI\LoopDetection\LoopDetector;
+use Tests\Support\LoopDetection\ArrayTurnHistoryStore;
+use Tests\TestCase;
+
+class LoopDetectorTest extends TestCase
+{
+    private function detector(): LoopDetector
+    {
+        return new LoopDetector(new ArrayTurnHistoryStore);
+    }
+
+    public function test_disabled_never_trips(): void
+    {
+        config(['loop_detection.enabled' => false]);
+        $detector = $this->detector();
+
+        for ($i = 0; $i < 10; $i++) {
+            $signal = $detector->inspectTurn('exp:1', 'same prompt', 'same output', 1000.0 + $i);
+            $this->assertFalse($signal->tripped());
+        }
+    }
+
+    public function test_semantic_loop_trips_after_min_turns(): void
+    {
+        config([
+            'loop_detection.enabled' => true,
+            'loop_detection.similarity.threshold' => 0.9,
+            'loop_detection.similarity.min_turns' => 3,
+            'loop_detection.velocity.max_turns' => 100,
+            'loop_detection.stall.repeat_threshold' => 100,
+        ]);
+        $detector = $this->detector();
+        $prompt = 'summarize the quarterly earnings report for acme corp';
+
+        $this->assertFalse($detector->inspectTurn('exp:1', $prompt, 'out-1', 1000.0)->tripped());
+        $this->assertFalse($detector->inspectTurn('exp:1', $prompt, 'out-2', 1001.0)->tripped());
+
+        $signal = $detector->inspectTurn('exp:1', $prompt, 'out-3', 1002.0);
+
+        $this->assertSame(LoopSignalType::SemanticLoop, $signal->type);
+    }
+
+    public function test_varied_prompts_do_not_trip_semantic(): void
+    {
+        config([
+            'loop_detection.enabled' => true,
+            'loop_detection.similarity.threshold' => 0.9,
+            'loop_detection.similarity.min_turns' => 3,
+            'loop_detection.velocity.max_turns' => 100,
+            'loop_detection.stall.repeat_threshold' => 100,
+        ]);
+        $detector = $this->detector();
+
+        $this->assertFalse($detector->inspectTurn('exp:1', 'analyze customer churn drivers', 'a', 1000.0)->tripped());
+        $this->assertFalse($detector->inspectTurn('exp:1', 'draft a pricing proposal for europe', 'b', 1001.0)->tripped());
+        $this->assertFalse($detector->inspectTurn('exp:1', 'write release notes for version nine', 'c', 1002.0)->tripped());
+    }
+
+    public function test_runaway_velocity_trips(): void
+    {
+        config([
+            'loop_detection.enabled' => true,
+            'loop_detection.velocity.max_turns' => 3,
+            'loop_detection.velocity.window_seconds' => 60,
+            'loop_detection.similarity.min_turns' => 100,
+            'loop_detection.stall.repeat_threshold' => 100,
+        ]);
+        $detector = $this->detector();
+
+        $this->assertFalse($detector->inspectTurn('exp:1', 'p1', 'o1', 1000.0)->tripped());
+        $this->assertFalse($detector->inspectTurn('exp:1', 'p2', 'o2', 1001.0)->tripped());
+        $this->assertFalse($detector->inspectTurn('exp:1', 'p3', 'o3', 1002.0)->tripped());
+
+        $signal = $detector->inspectTurn('exp:1', 'p4', 'o4', 1003.0);
+
+        $this->assertSame(LoopSignalType::Runaway, $signal->type);
+    }
+
+    public function test_stall_trips_on_repeated_output(): void
+    {
+        config([
+            'loop_detection.enabled' => true,
+            'loop_detection.stall.repeat_threshold' => 3,
+            'loop_detection.velocity.max_turns' => 100,
+            'loop_detection.similarity.min_turns' => 100,
+        ]);
+        $detector = $this->detector();
+
+        $this->assertFalse($detector->inspectTurn('exp:1', 'p1', 'IDENTICAL', 1000.0)->tripped());
+        $this->assertFalse($detector->inspectTurn('exp:1', 'p2', 'IDENTICAL', 1001.0)->tripped());
+
+        $signal = $detector->inspectTurn('exp:1', 'p3', 'IDENTICAL', 1002.0);
+
+        $this->assertSame(LoopSignalType::Stall, $signal->type);
+    }
+
+    public function test_contexts_are_isolated(): void
+    {
+        config([
+            'loop_detection.enabled' => true,
+            'loop_detection.stall.repeat_threshold' => 2,
+            'loop_detection.velocity.max_turns' => 100,
+            'loop_detection.similarity.min_turns' => 100,
+        ]);
+        $detector = $this->detector();
+
+        $detector->inspectTurn('exp:A', 'p', 'SAME', 1000.0);
+        // Different context should not see exp:A's history.
+        $this->assertFalse($detector->inspectTurn('exp:B', 'p', 'SAME', 1001.0)->tripped());
+    }
+}

--- a/tests/Unit/Infrastructure/AI/LoopDetection/SimilarityScorerTest.php
+++ b/tests/Unit/Infrastructure/AI/LoopDetection/SimilarityScorerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\AI\LoopDetection;
+
+use App\Infrastructure\AI\LoopDetection\SimilarityScorer;
+use PHPUnit\Framework\TestCase;
+
+class SimilarityScorerTest extends TestCase
+{
+    public function test_identical_text_scores_one(): void
+    {
+        $a = SimilarityScorer::bigrams('the quick brown fox jumps');
+        $b = SimilarityScorer::bigrams('the quick brown fox jumps');
+
+        $this->assertSame(1.0, SimilarityScorer::jaccard($a, $b));
+    }
+
+    public function test_disjoint_text_scores_zero(): void
+    {
+        $a = SimilarityScorer::bigrams('alpha beta gamma delta');
+        $b = SimilarityScorer::bigrams('one two three four');
+
+        $this->assertSame(0.0, SimilarityScorer::jaccard($a, $b));
+    }
+
+    public function test_near_identical_text_scores_high(): void
+    {
+        $a = SimilarityScorer::bigrams('summarize the quarterly earnings report for acme corp');
+        $b = SimilarityScorer::bigrams('summarize the quarterly earnings report for acme inc');
+
+        $score = SimilarityScorer::jaccard($a, $b);
+
+        $this->assertGreaterThan(0.6, $score);
+        $this->assertLessThan(1.0, $score);
+    }
+
+    public function test_two_empty_sets_are_identical(): void
+    {
+        $this->assertSame(1.0, SimilarityScorer::jaccard([], []));
+    }
+
+    public function test_one_empty_set_scores_zero(): void
+    {
+        $this->assertSame(0.0, SimilarityScorer::jaccard(['a b'], []));
+    }
+
+    public function test_bigrams_are_unicode_aware_and_cased(): void
+    {
+        // Cyrillic must survive normalization (control-char strip, not ASCII strip).
+        $bigrams = SimilarityScorer::bigrams('Обработи Данните Сега');
+
+        $this->assertContains('обработи данните', $bigrams);
+        $this->assertContains('данните сега', $bigrams);
+    }
+
+    public function test_token_cap_bounds_bigram_set(): void
+    {
+        $text = str_repeat('word ', 1000);
+
+        $bigrams = SimilarityScorer::bigrams($text, 50);
+
+        // 50 identical tokens collapse to a single distinct bigram.
+        $this->assertLessThanOrEqual(50, count($bigrams));
+    }
+}


### PR DESCRIPTION
## What
Proactive runaway-agent circuit breaker borrowed from [loopers-oss](https://github.com/CURSED-ME/loopers-oss). Inspects every recorded LLM turn and trips **before** budget is exhausted — closing the gap where FleetQ only reacts once spend runs out (`PauseOnBudgetExceeded`) or `WithoutOverlapping`/kill-switch fires.

## Why
Autonomous agents (Crew/Experiment, warm-build, claude-code-vps) can loop and burn the capped Max20x \$200/mo autonomous credit before anything reacts. Research: `docs/research/research_loopers-oss-borrow-eval_2026-07-06.md` (parent repo).

## How
Three deterministic detectors over a per-context Redis ring buffer (locks DB, self-expiring, no new table):
- **Semantic loop** — Bi-Gram Jaccard similarity ≥ threshold across N consecutive prompts
- **Runaway velocity** — too many turns within a rolling window
- **Stall** — identical output repeated N times

Detection hooks `AiRun::created` (observer) — sees the real prompt+output with full context, never touches the hot gateway middleware. On trip (`LOOP_DETECTION_ON_TRIP`): **pause** (default) / **kill** / **alert** the parent experiment, notify the team, emit a Sentry security event. Mirrors `PauseOnBudgetExceeded` and reuses the existing pause machinery.

New MCP tool `loop_detection_status` (read-only, `#[IsReadOnly]`, registered, TeamScope-guarded).

## Rollout
**Dark-shipped: `LOOP_DETECTION_ENABLED=false`.** Detector is wrapped so a bug/Redis blip can never break inference. Recommended: enable with `on_trip=alert` first to gather false-positive data, then flip to `pause`. Thresholds tunable via env (no deploy).

## Tests
19 tests / 44 assertions green (scorer, detector, observer→event→pause, MCP tool). `pint` clean; `php -l` clean; MCP annotation/registration gates pass. phpstan deferred to CI per project policy.

## Deferred (documented)
Per-team/tier runtime thresholds; Crew (`CrewExecution`) enforcement; per-tool MCP cost budget + tool-call breaker; mid-stream SSE token cutoff.

Design + test plan: `docs/design/design-loop-detection.md`, `docs/test-plans/test-plan-loop-detection.md` (parent repo).

🤖 Draft — human review + merge (no auto-merge).