### PR TITLE
test(warm-build): pin the per-team activation gate (security boundary)

### DIFF
--- a/tests/Unit/Domain/GitRepository/WarmRepoManagerGateTest.php
+++ b/tests/Unit/Domain/GitRepository/WarmRepoManagerGateTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Domain\GitRepository;
+
+use App\Domain\GitRepository\Services\WarmRepoManager;
+use App\Domain\Shared\Models\Team;
+use Tests\TestCase;
+
+/**
+ * Pins the warm-build activation gate — a security boundary: an untrusted
+ * tenant must NEVER get the warm-build sandbox by the global flag alone. Pure
+ * config + model logic, no git shell-out (runs anywhere, unlike the Process
+ * integration tests which require real git on the runner).
+ */
+class WarmRepoManagerGateTest extends TestCase
+{
+    public function test_global_off_denies_even_an_allowed_team(): void
+    {
+        config(['experiments.warm_build.enabled' => false]);
+
+        $this->assertFalse(WarmRepoManager::enabled());
+        $this->assertFalse(WarmRepoManager::enabledForTeam(new Team(['warm_build_allowed' => true])));
+    }
+
+    public function test_global_on_but_null_team_is_denied(): void
+    {
+        config(['experiments.warm_build.enabled' => true]);
+
+        $this->assertFalse(WarmRepoManager::enabledForTeam(null));
+    }
+
+    public function test_global_on_but_untrusted_team_is_denied(): void
+    {
+        config(['experiments.warm_build.enabled' => true]);
+
+        $this->assertFalse(WarmRepoManager::enabledForTeam(new Team(['warm_build_allowed' => false])));
+    }
+
+    public function test_missing_flag_defaults_to_denied(): void
+    {
+        config(['experiments.warm_build.enabled' => true]);
+
+        // A team that never had warm_build_allowed set must not be trusted.
+        $this->assertFalse(WarmRepoManager::enabledForTeam(new Team));
+    }
+
+    public function test_global_on_and_trusted_team_is_allowed(): void
+    {
+        config(['experiments.warm_build.enabled' => true]);
+
+        $this->assertTrue(WarmRepoManager::enabledForTeam(new Team(['warm_build_allowed' => true])));
+    }
+}


### PR DESCRIPTION
## What
Adds a direct test for `WarmRepoManager::enabledForTeam()` — the per-team warm-build activation gate.

## Why
The gate is a **security boundary**: an untrusted external tenant must never get the warm-build sandbox by the global flag alone (`global enabled AND team !== null AND team->warm_build_allowed`). It had no direct test — the one genuinely uncovered branch surfaced by the retro's warm-build stabilization review.

## Test (git-free, runs locally)
Unlike the `WarmRepoManager`/`ExecuteWarmDebugBuildAction` integration suites (which shell out to real git via `Process` and only run on CI), this is pure config+model logic:
- global-off denies even an allowed team
- global-on + null team → denied
- global-on + untrusted team → denied
- missing flag defaults to denied
- global-on + `warm_build_allowed` → allowed

5 tests / 6 assertions green. pint clean, phpstan L5 clean.

## Context
Part of the retro's warm-build stabilization action item. Full assessment (why no code rewrite was needed — the churn *was* the stabilization, every failure mode already has a fix + regression test) is in the parent repo: `docs/audits/warm-build-stabilization-assessment-2026-07-06.md`.

🤖 Draft — human review + merge.