### PR TITLE
feat(warm-build): best-of-N + writable-roots + Landlock write-jail (Shepherd borrows)

### DIFF
--- a/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
+++ b/app/Domain/Experiment/Actions/ExecuteWarmDebugBuildAction.php
@@ -3,16 +3,23 @@
 namespace App\Domain\Experiment\Actions;
 
 use App\Domain\Agent\Models\Agent;
+use App\Domain\Experiment\DTOs\WarmBuildCandidate;
 use App\Domain\Experiment\Enums\ExperimentStatus;
 use App\Domain\Experiment\Enums\ExperimentTrack;
 use App\Domain\Experiment\Enums\StageStatus;
 use App\Domain\Experiment\Enums\StageType;
 use App\Domain\Experiment\Models\Experiment;
 use App\Domain\Experiment\Models\ExperimentStage;
+use App\Domain\Experiment\Services\WarmBuildCandidatePolicy;
+use App\Domain\Experiment\Services\WarmBuildCandidateScorer;
+use App\Domain\GitRepository\DTOs\WarmBuildChangeset;
+use App\Domain\GitRepository\DTOs\WritableRootsGrant;
 use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\ChangesetPolicyValidator;
 use App\Domain\GitRepository\Services\GitCloneUrlResolver;
 use App\Domain\GitRepository\Services\GitOperationRouter;
 use App\Domain\GitRepository\Services\WarmRepoManager;
+use App\Domain\GitRepository\Services\WritableRootsPolicy;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
 use App\Infrastructure\AI\Exceptions\VpsLocalAgentException;
 use App\Infrastructure\AI\Gateways\LocalAgentGateway;
@@ -24,6 +31,14 @@ use Illuminate\Support\Facades\Process;
  * agent, this checks the target repo out into a warm worktree on the VPS, runs
  * claude-code-vps agentically inside it to apply the fix, then commits, pushes a
  * branch, opens a DRAFT pull request, and completes the building stage.
+ *
+ * Best-of-N (Shepherd borrow #1): when experiments.warm_build.candidates > 1 the
+ * agent is run N times from the same base ref, each in its own worktree; the
+ * candidate changesets are scored deterministically (WarmBuildCandidateScorer)
+ * and only the winner is pushed into the single draft PR. N=1 (default) is
+ * behaviourally identical to the legacy single-run path. Every candidate's
+ * changeset is validated against the writable-roots grant (#3); a scope-violating
+ * change loses to a compliant one and, if it still wins, is flagged in the PR.
  *
  * Dispatched from RunBuildingStage only when experiments.warm_build.enabled is on
  * AND a repository can be resolved; otherwise the legacy bridge-wait path stands.
@@ -37,6 +52,10 @@ class ExecuteWarmDebugBuildAction
         private readonly GitOperationRouter $gitRouter,
         private readonly CompleteBuildingAction $completeBuilding,
         private readonly TransitionExperimentAction $transition,
+        private readonly WritableRootsPolicy $writableRoots,
+        private readonly ChangesetPolicyValidator $changesetValidator,
+        private readonly WarmBuildCandidatePolicy $candidatePolicy,
+        private readonly WarmBuildCandidateScorer $scorer,
     ) {}
 
     public function execute(Experiment $experiment): void
@@ -54,57 +73,61 @@ class ExecuteWarmDebugBuildAction
 
         $ref = 'origin/'.($repo->default_branch ?: 'main');
         $cloneUrl = $this->cloneUrls->authenticatedUrl($repo);
-        $worktree = null;
+        $grant = $this->writableRoots->resolve($repo, $experiment);
+        $n = $this->candidatePolicy->count($repo);
+
+        /** @var list<WarmBuildCandidate> $candidates */
+        $candidates = [];
+        /** @var list<string> $worktrees */
+        $worktrees = [];
         $prUrls = [];
+        $winner = null;
 
         // Build phase: any failure here flips the experiment to BuildingFailed.
         // Completion (the AwaitingApproval transition) is deliberately AFTER this
         // block so a throwing downstream transition listener can't be mistaken
         // for a build failure and re-transition an already-completed experiment.
         try {
-            $worktree = $this->warmRepo->checkout($repo, $ref, $experiment->id, $cloneUrl);
-
-            $baseSha = $this->git($worktree, ['rev-parse', 'HEAD']);
-
-            // Resolve by class (not constructor DI): the cloud edition binds
-            // LocalAgentGateway::class to DisabledLocalAgentGateway (implements
-            // AiGatewayInterface, not a subclass — DI-hinting the concrete class
-            // would TypeError). Disabled delegates vps_only providers to a real
-            // gateway, so calling complete() directly preserves workingDirectory.
-            app(LocalAgentGateway::class)->complete($this->buildRequest($experiment, $worktree));
-
-            // The agent edits files with the CLI's own tools; capture whatever it
-            // changed as a single commit (a no-op when it already committed).
-            if (trim($this->git($worktree, ['status', '--porcelain'])) !== '') {
-                $this->git($worktree, ['add', '-A']);
-                $this->git($worktree, [
-                    '-c', 'user.email=agent@fleetq.ai',
-                    '-c', 'user.name=FleetQ Agent',
-                    'commit', '-m', 'Fix: '.$experiment->title,
-                ]);
+            for ($i = 1; $i <= $n; $i++) {
+                try {
+                    $candidates[] = $this->runCandidate($experiment, $repo, $ref, $cloneUrl, $grant, $i, $worktrees);
+                } catch (VpsLocalAgentException $e) {
+                    // Transient capacity (VPS concurrency cap): the slot is acquired
+                    // before any agent work, so nothing was spent. If we already have
+                    // a usable candidate, stop and select among what we have; if none
+                    // yet, surface it so the job re-dispatches after a backoff.
+                    if ($e->retryable) {
+                        if ($this->hasViable($candidates)) {
+                            break;
+                        }
+                        throw $e;
+                    }
+                    $candidates[] = $this->failedCandidate($i, $experiment, $e, $cloneUrl);
+                } catch (\Throwable $e) {
+                    // One bad candidate must not sink the whole build — record it and
+                    // let the remaining candidates (or none) decide the outcome.
+                    $candidates[] = $this->failedCandidate($i, $experiment, $e, $cloneUrl);
+                }
             }
 
-            if ($this->git($worktree, ['rev-parse', 'HEAD']) === $baseSha) {
-                $this->fail($experiment, 'Agent produced no changes — nothing to open a PR for.');
+            $winner = $this->scorer->pick($candidates);
+            if ($winner === null || $winner->worktree === null) {
+                $this->fail($experiment, $this->noUsableChangeReason($candidates));
 
                 return;
             }
 
-            $branch = 'fleetq/fix-'.substr($experiment->id, 0, 8);
-            $this->git($worktree, ['push', 'origin', 'HEAD:refs/heads/'.$branch, '--force']);
+            $this->git($winner->worktree, ['push', 'origin', 'HEAD:refs/heads/'.$winner->branch(), '--force']);
 
             $pr = $this->gitRouter->resolve($repo)->createPullRequest(
                 title: '[FleetQ] Fix: '.$experiment->title,
-                body: $this->prBody($experiment),
-                head: $branch,
+                body: $this->prBody($experiment, $winner, count($candidates)),
+                head: $winner->branch(),
                 base: (string) ($repo->default_branch ?: 'main'),
                 draft: true,
             );
             $prUrls = array_filter([$pr['pr_url']]);
         } catch (\Throwable $e) {
-            // Transient capacity (VPS concurrency cap): the slot is acquired before
-            // any agent work, so nothing was spent — surface it so the job can
-            // re-dispatch after a backoff rather than failing the run.
             if ($e instanceof VpsLocalAgentException && $e->retryable) {
                 throw $e;
             }
@@ -114,16 +137,16 @@ class ExecuteWarmDebugBuildAction
 
             return;
         } finally {
-            if ($worktree !== null) {
-                $this->warmRepo->release($repo, $worktree);
-                $this->warmRepo->prune($repo);
+            foreach ($worktrees as $wt) {
+                $this->warmRepo->release($repo, $wt);
             }
+            $this->warmRepo->prune($repo);
         }
 
         $this->completeBuilding->execute(
             experiment: $experiment,
             prUrls: $prUrls,
-            summary: 'Warm-build agent opened a draft PR on '.$repo->name.'.',
+            summary: $this->summary($repo, count($candidates)),
             completedBy: 'agent_warm_build',
         );
 
@@ -131,7 +154,94 @@ class ExecuteWarmDebugBuildAction
             'experiment_id' => $experiment->id,
             'repo_id' => $repo->id,
             'pr_urls' => $prUrls,
+            'candidates' => count($candidates),
+            'winner_index' => $winner->index,
+            'winner_within_roots' => $winner->withinRoots,
         ]);
+    }
+
+    /**
+     * Run a single best-of-N candidate: check out its own worktree, run the agent
+     * in it, capture + score the changeset. The worktree is tracked in $worktrees
+     * (by reference) so the caller releases every candidate's tree in finally{}.
+     *
+     * @param  list<string>  $worktrees
+     */
+    private function runCandidate(
+        Experiment $experiment,
+        GitRepository $repo,
+        string $ref,
+        ?string $cloneUrl,
+        WritableRootsGrant $grant,
+        int $index,
+        array &$worktrees,
+    ): WarmBuildCandidate {
+        // Distinct per-candidate run id → distinct worktree slot + branch, so
+        // concurrent candidates never collide on the shared .git/worktrees/ state.
+        $runId = $experiment->id.'-c'.$index;
+        $worktree = $this->warmRepo->checkout($repo, $ref, $runId, $cloneUrl);
+        $worktrees[] = $worktree;
+
+        $baseSha = $this->git($worktree, ['rev-parse', 'HEAD']);
+
+        // Resolve by class (not constructor DI): the cloud edition binds
+        // LocalAgentGateway::class to DisabledLocalAgentGateway (implements
+        // AiGatewayInterface, not a subclass — DI-hinting the concrete class
+        // would TypeError). Disabled delegates vps_only providers to a real
+        // gateway, so calling complete() directly preserves workingDirectory.
+        app(LocalAgentGateway::class)->complete($this->buildRequest($experiment, $worktree, $grant));
+
+        // The agent edits files with the CLI's own tools; capture whatever it
+        // changed as a single commit (a no-op when it already committed).
+        if (trim($this->git($worktree, ['status', '--porcelain'])) !== '') {
+            $this->git($worktree, ['add', '-A']);
+            $this->git($worktree, [
+                '-c', 'user.email=agent@fleetq.ai',
+                '-c', 'user.name=FleetQ Agent',
+                'commit', '-m', 'Fix: '.$experiment->title,
+            ]);
+        }
+
+        $changeset = WarmBuildChangeset::capture($worktree, $baseSha);
+
+        return new WarmBuildCandidate(
+            index: $index,
+            runId: $runId,
+            worktree: $worktree,
+            changeset: $changeset,
+            withinRoots: $this->changesetValidator->isWithinRoots($changeset, $grant),
+            verify: $this->verify($worktree, $repo, $changeset),
+        );
+    }
+
+    /**
+     * Optional per-repo verification (tests/lint) for the changeset. Runs the
+     * team-configured command in the candidate's worktree; pass/fail feeds the
+     * scorer. Absent command → UNKNOWN (neutral). Never throws — a broken verify
+     * command must not fail the build, only rank the candidate.
+     */
+    private function verify(string $worktree, GitRepository $repo, WarmBuildChangeset $changeset): int
+    {
+        if (! $changeset->hasChanges()) {
+            return WarmBuildCandidate::VERIFY_UNKNOWN;
+        }
+
+        $command = $repo->config['warm_build_verify_command'] ?? null;
+        if (! is_string($command) || trim($command) === '') {
+            return WarmBuildCandidate::VERIFY_UNKNOWN;
+        }
+
+        try {
+            $result = Process::path($worktree)
+                ->timeout((int) config('experiments.warm_build.verify_timeout_seconds', 300))
+                ->run($command);
+
+            return $result->successful() ? WarmBuildCandidate::VERIFY_PASS : WarmBuildCandidate::VERIFY_FAIL;
+        } catch (\Throwable $e) {
+            Log::info('ExecuteWarmDebugBuildAction: verify command errored', ['error' => $e->getMessage()]);
+
+            return WarmBuildCandidate::VERIFY_FAIL;
+        }
     }
 
     /**
@@ -141,6 +251,54 @@ class ExecuteWarmDebugBuildAction
     public function failCapacityExhausted(Experiment $experiment): void
     {
         $this->fail($experiment, 'Warm build deferred: VPS capacity unavailable after repeated retries.');
+    }
+
+    /**
+     * @param  list<WarmBuildCandidate>  $candidates
+     */
+    private function hasViable(array $candidates): bool
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate->hasChanges()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function failedCandidate(int $index, Experiment $experiment, \Throwable $e, ?string $cloneUrl): WarmBuildCandidate
+    {
+        $reason = $this->scrub($e->getMessage(), $cloneUrl);
+        Log::warning('ExecuteWarmDebugBuildAction: candidate failed', [
+            'experiment_id' => $experiment->id,
+            'candidate' => $index,
+            'reason' => $reason,
+        ]);
+
+        return new WarmBuildCandidate(
+            index: $index,
+            runId: $experiment->id.'-c'.$index,
+            worktree: null,
+            changeset: null,
+            withinRoots: false,
+            failed: true,
+            reason: $reason,
+        );
+    }
+
+    /**
+     * @param  list<WarmBuildCandidate>  $candidates
+     */
+    private function noUsableChangeReason(array $candidates): string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate->failed && $candidate->reason !== null) {
+                return 'Warm build failed: '.$candidate->reason;
+            }
+        }
+
+        return 'Agent produced no changes — nothing to open a PR for.';
     }
 
     private function resolveRepository(Experiment $experiment): ?GitRepository
@@ -170,7 +328,7 @@ class ExecuteWarmDebugBuildAction
             ?? ($repos->count() === 1 ? $repos->first() : null);
     }
 
-    private function buildRequest(Experiment $experiment, string $worktree): AiRequestDTO
+    private function buildRequest(Experiment $experiment, string $worktree, WritableRootsGrant $grant): AiRequestDTO
     {
         $system = 'You are a senior software engineer fixing a reported bug in the checked-out '
             .'repository (your current working directory). Make the smallest correct change that '
@@ -188,14 +346,35 @@ class ExecuteWarmDebugBuildAction
             experimentId: $experiment->id,
             purpose: 'experiment.debug_build',
             workingDirectory: $worktree,
+            writableRoots: $this->writableRoots->absoluteWritablePaths($grant, $worktree),
         );
     }
 
-    private function prBody(Experiment $experiment): string
+    private function prBody(Experiment $experiment, WarmBuildCandidate $winner, int $n): string
     {
-        return "Automated fix opened by FleetQ for experiment `{$experiment->id}`.\n\n"
-            ."**Issue:** {$experiment->title}\n\n"
-            .'⚠️ Draft PR — requires human review before merge.';
+        $body = "Automated fix opened by FleetQ for experiment `{$experiment->id}`.\n\n"
+            ."**Issue:** {$experiment->title}\n\n";
+
+        if ($n > 1) {
+            $files = count($winner->changeset->files ?? []);
+            $lines = ($winner->changeset->added ?? 0) + ($winner->changeset->removed ?? 0);
+            $roots = $winner->withinRoots ? 'within writable-roots' : '⚠️ writable-roots violation';
+            $body .= "Selected candidate {$winner->index} of {$n} (best-of-N): {$roots}, "
+                ."{$files} file(s) / {$lines} line(s) changed.\n\n";
+        }
+
+        if (! $winner->withinRoots) {
+            $body .= "⚠️ This change touches paths outside the configured writable-roots — review carefully.\n\n";
+        }
+
+        return $body.'⚠️ Draft PR — requires human review before merge.';
+    }
+
+    private function summary(GitRepository $repo, int $n): string
+    {
+        return $n > 1
+            ? "Warm-build agent opened a draft PR on {$repo->name} (best of {$n})."
+            : 'Warm-build agent opened a draft PR on '.$repo->name.'.';
     }
 
     private function fail(Experiment $experiment, string $reason): void

--- a/app/Domain/Experiment/DTOs/WarmBuildCandidate.php
+++ b/app/Domain/Experiment/DTOs/WarmBuildCandidate.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Domain\Experiment\DTOs;
+
+use App\Domain\GitRepository\DTOs\WarmBuildChangeset;
+
+/**
+ * The result of one best-of-N warm-build candidate run (Shepherd borrow #1):
+ * its worktree, what it changed, and the deterministic signals the scorer ranks
+ * on. A failed run is recorded (not thrown away) so one bad candidate never
+ * sinks the whole build.
+ */
+final readonly class WarmBuildCandidate
+{
+    public const VERIFY_FAIL = 0;
+
+    public const VERIFY_UNKNOWN = 1;   // no verify command configured
+
+    public const VERIFY_PASS = 2;
+
+    public function __construct(
+        public int $index,
+        public string $runId,
+        public ?string $worktree,
+        public ?WarmBuildChangeset $changeset,
+        public bool $withinRoots,
+        public int $verify = self::VERIFY_UNKNOWN,
+        public bool $failed = false,
+        public ?string $reason = null,
+    ) {}
+
+    public function hasChanges(): bool
+    {
+        return ! $this->failed && $this->changeset !== null && $this->changeset->hasChanges();
+    }
+
+    public function branch(): string
+    {
+        return 'fleetq/fix-'.substr($this->runId, 0, 8);
+    }
+}

--- a/app/Domain/Experiment/Services/WarmBuildCandidatePolicy.php
+++ b/app/Domain/Experiment/Services/WarmBuildCandidatePolicy.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Domain\Experiment\Services;
+
+use App\Domain\GitRepository\Models\GitRepository;
+
+/**
+ * Resolves how many best-of-N candidates a warm-build run should attempt
+ * (Shepherd borrow #1). Default 1 = the legacy single-run behaviour. A per-repo
+ * override (GitRepository.config['warm_build_candidates']) can raise it, but the
+ * result is always clamped to [1, candidates_max] so a mis-set value can never
+ * fan out unbounded on the capped credit.
+ */
+class WarmBuildCandidatePolicy
+{
+    public function count(GitRepository $repo): int
+    {
+        $max = max(1, (int) config('experiments.warm_build.candidates_max', 3));
+
+        $override = $repo->config['warm_build_candidates'] ?? null;
+        $requested = is_numeric($override)
+            ? (int) $override
+            : (int) config('experiments.warm_build.candidates', 1);
+
+        return max(1, min($max, $requested));
+    }
+}

--- a/app/Domain/Experiment/Services/WarmBuildCandidateScorer.php
+++ b/app/Domain/Experiment/Services/WarmBuildCandidateScorer.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Domain\Experiment\Services;
+
+use App\Domain\Experiment\DTOs\WarmBuildCandidate;
+
+/**
+ * Deterministic best-of-N selection for warm-build candidates (Shepherd borrow
+ * #1). No LLM judge — a fixed, explainable ordering so the same candidates
+ * always yield the same winner:
+ *
+ *   1. has changes            (a no-op candidate can never win)
+ *   2. within writable-roots  (a scope-violating change loses to a compliant one)
+ *   3. verify result          (pass > unknown > fail, when a verify cmd is set)
+ *   4. smallest change        (fewer files, then fewer lines — "smallest correct change")
+ *
+ * pick() returns the best candidate, or null when none produced a usable change.
+ */
+class WarmBuildCandidateScorer
+{
+    /**
+     * Comparable score tuple, higher-is-better, compared lexicographically.
+     *
+     * @return list<int>
+     */
+    public function score(WarmBuildCandidate $c): array
+    {
+        $changeset = $c->changeset;
+        $fileCount = $changeset !== null ? count($changeset->files) : 0;
+        $lines = $changeset !== null ? $changeset->added + $changeset->removed : 0;
+
+        return [
+            $c->hasChanges() ? 1 : 0,
+            $c->withinRoots ? 1 : 0,
+            $c->verify,
+            -$fileCount,   // negated so "fewer" ranks higher
+            -$lines,
+        ];
+    }
+
+    /**
+     * @param  list<WarmBuildCandidate>  $candidates
+     */
+    public function pick(array $candidates): ?WarmBuildCandidate
+    {
+        $viable = array_values(array_filter($candidates, static fn (WarmBuildCandidate $c): bool => $c->hasChanges()));
+        if ($viable === []) {
+            return null;
+        }
+
+        $winner = $viable[0];
+        $best = $this->score($winner);
+        foreach (array_slice($viable, 1) as $candidate) {
+            $tuple = $this->score($candidate);
+            if ($this->greater($tuple, $best)) {
+                $winner = $candidate;
+                $best = $tuple;
+            }
+        }
+
+        return $winner;
+    }
+
+    /**
+     * @param  list<int>  $a
+     * @param  list<int>  $b
+     */
+    private function greater(array $a, array $b): bool
+    {
+        foreach ($a as $i => $value) {
+            if ($value !== $b[$i]) {
+                return $value > $b[$i];
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Domain/GitRepository/DTOs/WarmBuildChangeset.php
+++ b/app/Domain/GitRepository/DTOs/WarmBuildChangeset.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Domain\GitRepository\DTOs;
+
+use Illuminate\Support\Facades\Process;
+
+/**
+ * Immutable summary of what one warm-build candidate changed, relative to the
+ * base ref (Shepherd borrow #1). Built from `git diff --numstat` over the
+ * committed range so best-of-N can score candidates deterministically without
+ * an LLM judge.
+ */
+final readonly class WarmBuildChangeset
+{
+    /**
+     * @param  list<string>  $files  Repo-relative paths changed between base and HEAD.
+     */
+    public function __construct(
+        public array $files,
+        public int $added,
+        public int $removed,
+        public string $headSha,
+    ) {}
+
+    public function hasChanges(): bool
+    {
+        return $this->headSha !== '' && $this->files !== [];
+    }
+
+    /**
+     * Capture the changeset of $worktree between $baseSha and its current HEAD.
+     * `--no-renames` keeps every touched path visible so the policy validator
+     * sees both sides of a move; numstat is tab-separated `added\tremoved\tpath`.
+     */
+    public static function capture(string $worktree, string $baseSha): self
+    {
+        $head = trim(Process::timeout(60)
+            ->run(['git', '-C', $worktree, 'rev-parse', 'HEAD'])->output());
+
+        if ($head === '' || $head === $baseSha) {
+            return new self(files: [], added: 0, removed: 0, headSha: $head);
+        }
+
+        $numstat = Process::timeout(60)->run([
+            'git', '-C', $worktree, 'diff', '--numstat', '--no-renames', $baseSha, $head,
+        ])->output();
+
+        $files = [];
+        $added = 0;
+        $removed = 0;
+        foreach (preg_split('/\R/', trim($numstat)) ?: [] as $line) {
+            if ($line === '') {
+                continue;
+            }
+            $parts = preg_split('/\t/', $line);
+            if (! is_array($parts) || count($parts) < 3) {
+                continue;
+            }
+            // Binary files report '-' for added/removed; count them as 0 lines.
+            $added += is_numeric($parts[0]) ? (int) $parts[0] : 0;
+            $removed += is_numeric($parts[1]) ? (int) $parts[1] : 0;
+            $files[] = $parts[2];
+        }
+
+        return new self(files: $files, added: $added, removed: $removed, headSha: $head);
+    }
+}

--- a/app/Domain/GitRepository/DTOs/WritableRootsGrant.php
+++ b/app/Domain/GitRepository/DTOs/WritableRootsGrant.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Domain\GitRepository\DTOs;
+
+/**
+ * The writable-roots capability grant for a warm-build agent run (Shepherd
+ * borrow #3). Declares which repo-relative paths the agent's changeset is
+ * permitted to touch: an allow-list of subtrees plus a deny-list of globs that
+ * are never writable (migrations, workflows, env files by default).
+ *
+ * Resolved by WritableRootsPolicy. Consumed post-run by ChangesetPolicyValidator
+ * (application layer, always on) and — when non-empty — compiled into a Landlock
+ * ruleset by WriteJail (#2, kernel layer, flag-off).
+ */
+final readonly class WritableRootsGrant
+{
+    /**
+     * @param  list<string>  $allowedRoots  Repo-relative dirs that may be written. EMPTY = the whole
+     *                                      repo is writable EXCEPT $deniedGlobs.
+     * @param  list<string>  $deniedGlobs  fnmatch globs (repo-relative) that are never writable; win
+     *                                     over $allowedRoots.
+     */
+    public function __construct(
+        public array $allowedRoots,
+        public array $deniedGlobs,
+    ) {}
+
+    /**
+     * Is a repo-relative changed path permitted by this grant? Deny globs are
+     * absolute (checked first); an empty allow-list means "anything not denied".
+     */
+    public function permits(string $relativePath): bool
+    {
+        $path = ltrim(str_replace('\\', '/', $relativePath), '/');
+
+        foreach ($this->deniedGlobs as $glob) {
+            // PHP fnmatch default flags: '*' spans '/', so '**' and '*' both match
+            // across path segments — 'database/migrations/**' matches nested files.
+            if (fnmatch($glob, $path)) {
+                return false;
+            }
+        }
+
+        if ($this->allowedRoots === []) {
+            return true;
+        }
+
+        foreach ($this->allowedRoots as $root) {
+            $root = trim(str_replace('\\', '/', $root), '/');
+            if ($root === '' || $path === $root || str_starts_with($path, $root.'/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Domain/GitRepository/Services/ChangesetPolicyValidator.php
+++ b/app/Domain/GitRepository/Services/ChangesetPolicyValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Domain\GitRepository\Services;
+
+use App\Domain\GitRepository\DTOs\WarmBuildChangeset;
+use App\Domain\GitRepository\DTOs\WritableRootsGrant;
+
+/**
+ * Validates a warm-build candidate's changeset against its writable-roots grant
+ * (Shepherd borrow #3). Pure over the changeset's file list — no git, no writes —
+ * so it is deterministic and trivially testable. The git capture lives in
+ * WarmBuildChangeset::capture().
+ */
+class ChangesetPolicyValidator
+{
+    /**
+     * Repo-relative changed paths that the grant does NOT permit.
+     *
+     * @return list<string>
+     */
+    public function violations(WarmBuildChangeset $changeset, WritableRootsGrant $grant): array
+    {
+        return array_values(array_filter(
+            $changeset->files,
+            static fn (string $path): bool => ! $grant->permits($path),
+        ));
+    }
+
+    public function isWithinRoots(WarmBuildChangeset $changeset, WritableRootsGrant $grant): bool
+    {
+        return $this->violations($changeset, $grant) === [];
+    }
+}

--- a/app/Domain/GitRepository/Services/WritableRootsPolicy.php
+++ b/app/Domain/GitRepository/Services/WritableRootsPolicy.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Domain\GitRepository\Services;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\GitRepository\DTOs\WritableRootsGrant;
+use App\Domain\GitRepository\Models\GitRepository;
+
+/**
+ * Resolves the writable-roots grant (Shepherd borrow #3) for a warm-build run.
+ *
+ * Precedence, most specific last:
+ *   config('experiments.warm_build.writable_roots')                 platform default
+ *     → GitRepository.config['warm_build_writable_roots']           per-repo override
+ *       → Experiment.constraints['warm_build_writable_roots']       per-task grant
+ *
+ * The per-task layer is the actual "signature is the permission surface" borrow:
+ * a task declares the roots it needs up front. Deny globs ACCUMULATE across all
+ * layers (a stricter layer can only add denials); allow-roots take the most
+ * specific non-empty list.
+ */
+class WritableRootsPolicy
+{
+    public function resolve(GitRepository $repo, ?Experiment $experiment = null): WritableRootsGrant
+    {
+        $default = (array) config('experiments.warm_build.writable_roots', []);
+        $repoOverride = $this->layer($repo->config['warm_build_writable_roots'] ?? null);
+        $taskOverride = $this->layer($experiment?->constraints['warm_build_writable_roots'] ?? null);
+
+        $denied = array_values(array_unique(array_merge(
+            $this->stringList($default['denied_globs'] ?? []),
+            $repoOverride['denied_globs'],
+            $taskOverride['denied_globs'],
+        )));
+
+        // Most specific non-empty allow-list wins; empty everywhere = whole repo.
+        $allowed = $taskOverride['allowed_roots']
+            ?: ($repoOverride['allowed_roots']
+                ?: $this->stringList($default['allowed_roots'] ?? []));
+
+        return new WritableRootsGrant(allowedRoots: $allowed, deniedGlobs: $denied);
+    }
+
+    /**
+     * Absolute writable subtrees under $worktree for the Landlock jail (#2).
+     * An empty allow-list yields the whole worktree — the deny globs are then
+     * enforced by ChangesetPolicyValidator at the application layer, since a
+     * positive Landlock allow-list can't express "everything except migrations".
+     *
+     * @return list<string>
+     */
+    public function absoluteWritablePaths(WritableRootsGrant $grant, string $worktree): array
+    {
+        $worktree = rtrim(str_replace('\\', '/', $worktree), '/');
+
+        if ($grant->allowedRoots === []) {
+            return [$worktree];
+        }
+
+        $paths = [];
+        foreach ($grant->allowedRoots as $root) {
+            $paths[] = $worktree.'/'.trim(str_replace('\\', '/', $root), '/');
+        }
+
+        return $paths;
+    }
+
+    /**
+     * @param  mixed  $raw
+     * @return array{allowed_roots: list<string>, denied_globs: list<string>}
+     */
+    private function layer($raw): array
+    {
+        $raw = is_array($raw) ? $raw : [];
+
+        return [
+            'allowed_roots' => $this->stringList($raw['allowed_roots'] ?? []),
+            'denied_globs' => $this->stringList($raw['denied_globs'] ?? []),
+        ];
+    }
+
+    /**
+     * @param  mixed  $raw
+     * @return list<string>
+     */
+    private function stringList($raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map(static fn ($v): string => is_string($v) ? trim($v) : '', $raw),
+            static fn (string $v): bool => $v !== '',
+        ));
+    }
+}

--- a/app/Infrastructure/AI/DTOs/AiRequestDTO.php
+++ b/app/Infrastructure/AI/DTOs/AiRequestDTO.php
@@ -78,6 +78,16 @@ final readonly class AiRequestDTO
          * Null = no per-request ceiling (standing cap still applies).
          */
         public ?int $maxCostCredits = null,
+        /**
+         * Absolute writable subtrees for a sandboxed local-agent run (Shepherd
+         * borrow #2 — warm-build write-jail). When set on a claude-code-vps repo
+         * build, LocalAgentGateway compiles these into a Landlock ruleset so the
+         * agent can only write under them. Null = no jail (default; every non
+         * warm-build caller is unaffected).
+         *
+         * @var list<string>|null
+         */
+        public ?array $writableRoots = null,
     ) {}
 
     /**
@@ -122,6 +132,7 @@ final readonly class AiRequestDTO
             parentTraceId: $this->parentTraceId,
             parentSpanId: $this->parentSpanId,
             maxCostCredits: $this->maxCostCredits,
+            writableRoots: $this->writableRoots,
         );
     }
 
@@ -167,6 +178,7 @@ final readonly class AiRequestDTO
             parentTraceId: $this->parentTraceId,
             parentSpanId: $this->parentSpanId,
             maxCostCredits: $this->maxCostCredits,
+            writableRoots: $this->writableRoots,
         );
     }
 

--- a/app/Infrastructure/AI/Gateways/LocalAgentGateway.php
+++ b/app/Infrastructure/AI/Gateways/LocalAgentGateway.php
@@ -18,6 +18,7 @@ use App\Infrastructure\AI\Services\LocalAgentDiscovery;
 use App\Infrastructure\AI\Services\RunSecretVault;
 use App\Infrastructure\AI\Services\SecretProxyInjector;
 use App\Infrastructure\AI\Services\TranscriptIngestor;
+use App\Infrastructure\Sandbox\WriteJail;
 use App\Models\User;
 use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Support\Facades\Http;
@@ -376,6 +377,16 @@ class LocalAgentGateway implements AiGatewayInterface
             'timeout' => $timeout,
             'streaming' => $useStreaming,
         ]);
+
+        // Write-jail (Shepherd borrow #2): for an in-repo build, restrict the agent
+        // process to writing only under the run's writable-roots (+ ephemeral HOME).
+        // Inert no-op unless the Landlock launcher is enabled and available.
+        if ($isRepoBuild) {
+            $args = app(WriteJail::class)->wrap(
+                $args,
+                array_values(array_filter(array_merge($request->writableRoots ?? [], [$workdir]))),
+            );
+        }
 
         $startTime = hrtime(true);
         $exitCode = null;

--- a/app/Infrastructure/Sandbox/WriteJail.php
+++ b/app/Infrastructure/Sandbox/WriteJail.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Infrastructure\Sandbox;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Write-jail launcher (Shepherd borrow #2). Prefixes a to-be-spawned agent
+ * command with a native-sandbox launcher (Linux Landlock) so the process may
+ * only WRITE under an explicit allow-list of paths — the warm-build worktree's
+ * writable-roots plus its ephemeral HOME and /tmp. Everything else on the host
+ * filesystem is read-only to the agent at the kernel level.
+ *
+ * INERT BY DEFAULT — and defensively inert: wrap() returns the command unchanged
+ * whenever the jail is disabled, the OS isn't Linux, or the launcher binary is
+ * absent/not-executable. Warm-build must never break because the jail can't be
+ * applied; it is defense-in-depth, not a hard dependency. Real kernel enforcement
+ * requires the reference helper (base/docker/writejail) built into the image and
+ * verified on the VPS; until then the launcher env is unset and this is a no-op.
+ */
+class WriteJail
+{
+    /**
+     * @param  list<string>  $command  The full command to spawn (binary + args).
+     * @param  list<string>  $writablePaths  Absolute paths the jailed process may write.
+     * @return list<string> The wrapped command, or $command verbatim when inert.
+     */
+    public function wrap(array $command, array $writablePaths): array
+    {
+        $reason = $this->inertReason();
+        if ($reason !== null) {
+            Log::info('WriteJail: inert — running unjailed', ['reason' => $reason]);
+
+            return $command;
+        }
+
+        $launcher = (string) config('experiments.warm_build.write_jail.launcher');
+        $prefix = [$launcher];
+        foreach ($this->writablePaths($writablePaths) as $path) {
+            $prefix[] = '--writable';
+            $prefix[] = $path;
+        }
+        $prefix[] = '--';
+
+        Log::info('WriteJail: jailing agent process', [
+            'launcher' => $launcher,
+            'writable_count' => count($writablePaths),
+        ]);
+
+        return array_merge($prefix, $command);
+    }
+
+    public function enabled(): bool
+    {
+        return (bool) config('experiments.warm_build.write_jail.enabled', false);
+    }
+
+    /**
+     * Why the jail can't be applied, or null when it can. Ordered cheapest-first.
+     */
+    public function inertReason(): ?string
+    {
+        if (! $this->enabled()) {
+            return 'disabled';
+        }
+        if (PHP_OS_FAMILY !== 'Linux') {
+            return 'not-linux';
+        }
+        $launcher = config('experiments.warm_build.write_jail.launcher');
+        if (! is_string($launcher) || $launcher === '') {
+            return 'launcher-unset';
+        }
+        if (! @is_executable($launcher)) {
+            return 'launcher-missing';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return list<string>
+     */
+    private function writablePaths(array $paths): array
+    {
+        $extra = config('experiments.warm_build.write_jail.extra_writable', []);
+        $all = array_merge($paths, is_array($extra) ? $extra : []);
+
+        return array_values(array_unique(array_filter(
+            $all,
+            static fn ($p): bool => is_string($p) && $p !== '',
+        )));
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -286,6 +286,7 @@ use App\Mcp\Tools\Experiment\ReasoningBankListTool;
 use App\Mcp\Tools\Experiment\ReasoningBankSearchTool;
 use App\Mcp\Tools\Experiment\UncertaintyEmitTool;
 use App\Mcp\Tools\Experiment\UncertaintyResolveTool;
+use App\Mcp\Tools\Experiment\WarmBuildGuardrailsStatusTool;
 use App\Mcp\Tools\Experiment\WorkflowSnapshotListTool;
 use App\Mcp\Tools\Experiment\WorklogAppendTool;
 use App\Mcp\Tools\Experiment\WorklogReadTool;
@@ -946,6 +947,7 @@ class AgentFleetServer extends Server
         ExperimentShareTool::class,
         ExperimentSearchHistoryTool::class,
         ExperimentContextHealthTool::class,
+        WarmBuildGuardrailsStatusTool::class,
         ExperimentSkipStageTool::class,
         ExperimentDoneJudgeRunTool::class,
         ExperimentUpdateTool::class,

--- a/app/Mcp/Tools/Experiment/WarmBuildGuardrailsStatusTool.php
+++ b/app/Mcp/Tools/Experiment/WarmBuildGuardrailsStatusTool.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Mcp\Tools\Experiment;
+
+use App\Domain\Experiment\Services\WarmBuildCandidatePolicy;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\WritableRootsPolicy;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\Sandbox\WriteJail;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[IsIdempotent]
+class WarmBuildGuardrailsStatusTool extends Tool
+{
+    protected string $name = 'warm_build_guardrails_status';
+
+    protected string $description = 'Report the warm-build guardrails resolved for a git repository: best-of-N candidate count, the writable-roots grant (allowed roots + denied globs), and the write-jail (Landlock) state. Read-only, team-scoped.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'git_repository_id' => $schema->string()->description('The UUID of the git repository')->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+
+        $repo = GitRepository::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->findOrFail($request->get('git_repository_id'));
+
+        $grant = app(WritableRootsPolicy::class)->resolve($repo);
+        $jail = app(WriteJail::class);
+        $teamAllowed = (bool) Team::withoutGlobalScopes()->whereKey($repo->team_id)->value('warm_build_allowed');
+
+        return Response::text((string) json_encode([
+            'git_repository_id' => $repo->id,
+            'warm_build' => [
+                'globally_enabled' => (bool) config('experiments.warm_build.enabled', false),
+                'team_allowed' => $teamAllowed,
+            ],
+            'best_of_n' => [
+                'candidates' => app(WarmBuildCandidatePolicy::class)->count($repo),
+                'candidates_max' => (int) config('experiments.warm_build.candidates_max', 3),
+                'verify_command_set' => is_string($repo->config['warm_build_verify_command'] ?? null),
+            ],
+            'writable_roots' => [
+                'allowed_roots' => $grant->allowedRoots,
+                'denied_globs' => $grant->deniedGlobs,
+            ],
+            'write_jail' => [
+                'enabled' => $jail->enabled(),
+                // null = active/enforcing; otherwise why it's inert (disabled/not-linux/launcher-*)
+                'inert_reason' => $jail->inertReason(),
+            ],
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/app/Mcp/Tools/Experiment/WarmBuildGuardrailsStatusTool.php
+++ b/app/Mcp/Tools/Experiment/WarmBuildGuardrailsStatusTool.php
@@ -39,7 +39,9 @@ class WarmBuildGuardrailsStatusTool extends Tool
 
         $grant = app(WritableRootsPolicy::class)->resolve($repo);
         $jail = app(WriteJail::class);
-        $teamAllowed = (bool) Team::withoutGlobalScopes()->whereKey($repo->team_id)->value('warm_build_allowed');
+        // Team is the tenant root (no TeamScope), so a plain primary-key lookup is
+        // already tenant-safe; $repo->team_id was team-verified by the query above.
+        $teamAllowed = (bool) Team::whereKey($repo->team_id)->value('warm_build_allowed');
 
         return Response::text((string) json_encode([
             'git_repository_id' => $repo->id,

--- a/config/experiments.php
+++ b/config/experiments.php
@@ -194,6 +194,48 @@ return [
         // Age-based worktree GC threshold. Must exceed the max build time so an
         // in-flight worktree is never pruned by a sibling run. Default 2h.
         'worktree_ttl_seconds' => (int) env('EXPERIMENTS_WARM_BUILD_WORKTREE_TTL', 7200),
+
+        // Best-of-N (Shepherd borrow #1): run N candidate agent attempts from the
+        // same base ref, score each changeset deterministically, and push only the
+        // winner into the single draft PR. Default 1 = exactly the legacy single-run
+        // behaviour (dark-ship). Sequential — N never self-contends the claude-code-vps
+        // concurrency cap. `candidates_max` is a hard ceiling so a mis-set value (or a
+        // per-repo override) can't fan out unbounded on the capped credit.
+        'candidates' => (int) env('EXPERIMENTS_WARM_BUILD_CANDIDATES', 1),
+        'candidates_max' => (int) env('EXPERIMENTS_WARM_BUILD_CANDIDATES_MAX', 3),
+        // Timeout (seconds) for an optional per-repo verification command
+        // (GitRepository.config['warm_build_verify_command']) run in each candidate
+        // worktree; pass/fail feeds the best-of-N scorer.
+        'verify_timeout_seconds' => (int) env('EXPERIMENTS_WARM_BUILD_VERIFY_TIMEOUT', 300),
+
+        // Writable-roots grant (Shepherd borrow #3): the changeset a warm-build agent
+        // produces is validated against this allow/deny policy. `allowed_roots` empty =
+        // the whole repo is writable EXCEPT `denied_globs`; a non-empty list restricts
+        // writes to those subtrees only. Migrations are denied by default so an
+        // autonomous fix can never silently rewrite a migration. Per-repo override:
+        // GitRepository.config['warm_build_writable_roots'] = ['allowed_roots'=>[], 'denied_globs'=>[]].
+        'writable_roots' => [
+            'denied_globs' => [
+                'database/migrations/**',
+                '**/migrations/**',
+                '.github/workflows/**',
+                '**/.env',
+                '**/.env.*',
+            ],
+            'allowed_roots' => [],
+        ],
+
+        // Write-jail (Shepherd borrow #2): wrap the claude-code-vps process in a native
+        // Linux Landlock ruleset restricting writes to the worktree writable-roots +
+        // ephemeral HOME + tmp. Kernel-level defense-in-depth for the parked
+        // hostile-isolation surface. INERT by default: with `enabled` off or `launcher`
+        // unset the agent runs exactly as today. Real enforcement needs the reference
+        // helper (base/docker/writejail) built into the image and verified on the VPS.
+        'write_jail' => [
+            'enabled' => (bool) env('EXPERIMENTS_WARM_BUILD_WRITEJAIL', false),
+            'launcher' => env('EXPERIMENTS_WARM_BUILD_WRITEJAIL_LAUNCHER'),
+            'extra_writable' => ['/tmp'],
+        ],
     ],
 
     /*

--- a/docker/writejail/README.md
+++ b/docker/writejail/README.md
@@ -1,0 +1,69 @@
+# writejail — warm-build Landlock launcher (Shepherd borrow #2)
+
+Reference helper that jails the `claude-code-vps` agent process so it can only
+**write** under an explicit allow-list of directories (the run's writable-roots
++ its ephemeral HOME + `/tmp`), while reading the rest of the tree normally.
+Enforced at the kernel via [Landlock](https://landlock.io/) (Linux ≥ 5.13).
+
+## Status: NOT wired into the image yet
+
+The application path (`App\Infrastructure\Sandbox\WriteJail`) is **inert by
+default** — it returns the agent command unchanged unless:
+
+1. `EXPERIMENTS_WARM_BUILD_WRITEJAIL=true`, **and**
+2. `EXPERIMENTS_WARM_BUILD_WRITEJAIL_LAUNCHER` points at an executable, **and**
+3. the OS is Linux.
+
+So shipping this source changes nothing at runtime. Enabling real enforcement is
+an explicit infra step (below) that must be verified on the VPS.
+
+## Build
+
+```sh
+cd base/docker/writejail
+go mod download
+CGO_ENABLED=0 go build -o /usr/local/bin/writejail .
+```
+
+## Install into the app/horizon image
+
+Add to the Dockerfile (multi-stage; keep Go out of the final image):
+
+```dockerfile
+FROM golang:1.23-alpine AS writejail
+WORKDIR /src
+COPY base/docker/writejail/ .
+RUN CGO_ENABLED=0 go build -o /writejail .
+
+# ... in the final php-fpm stage:
+COPY --from=writejail /writejail /usr/local/bin/writejail
+```
+
+Then set on the VPS `.env`:
+
+```
+EXPERIMENTS_WARM_BUILD_WRITEJAIL=true
+EXPERIMENTS_WARM_BUILD_WRITEJAIL_LAUNCHER=/usr/local/bin/writejail
+```
+
+## Verify (required before trusting it)
+
+The container must allow Landlock — the default Docker seccomp profile permits
+the `landlock_*` syscalls on modern kernels, but confirm:
+
+```sh
+# inside the app container:
+writejail --writable /tmp -- sh -c 'echo ok > /tmp/x && echo WROTE_TMP; \
+  (echo nope > /usr/x 2>/dev/null && echo WROTE_USR || echo BLOCKED_USR)'
+# expect: WROTE_TMP then BLOCKED_USR
+```
+
+If it prints `WROTE_USR`, Landlock is not being enforced (old kernel / blocked
+syscall) — do NOT rely on the jail; the app-layer `ChangesetPolicyValidator`
+(#3) remains the backstop that flags out-of-roots writes on the changeset.
+
+## Behaviour on unsupported kernels
+
+`landlock.V5.BestEffort()` degrades to a weaker ruleset (or none) rather than
+failing, so a build never breaks because the kernel is too old. That is exactly
+why enforcement must be positively verified, not assumed.

--- a/docker/writejail/go.mod
+++ b/docker/writejail/go.mod
@@ -1,0 +1,5 @@
+module fleetq/writejail
+
+go 1.23
+
+require github.com/landlock-lsm/go-landlock v0.0.0-20240715193425-db0c8d6f89dc

--- a/docker/writejail/main.go
+++ b/docker/writejail/main.go
@@ -1,0 +1,108 @@
+// writejail — a minimal Landlock launcher for the FleetQ warm-build write-jail
+// (Shepherd borrow #2). It restricts the process it execs so that it may only
+// WRITE under an explicit allow-list of directories, while still being able to
+// READ the rest of the filesystem. Everything the agent needs to write (the
+// worktree's writable-roots, its ephemeral HOME, /tmp) is passed with repeated
+// --writable flags; anything else is read-only at the kernel level.
+//
+// Usage:
+//
+//	writejail --writable /path/a --writable /path/b -- <command> [args...]
+//
+// This is REFERENCE SOURCE. It is intentionally NOT compiled into the app image
+// in this sprint — the application path (App\Infrastructure\Sandbox\WriteJail)
+// stays inert until this binary is built, installed on PATH, and the launcher is
+// pointed at it via EXPERIMENTS_WARM_BUILD_WRITEJAIL_LAUNCHER, then verified with
+// a real kernel round-trip on the VPS (Linux >= 5.13 for Landlock ABI v1).
+//
+// Build: see README.md in this directory.
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/landlock-lsm/go-landlock/landlock"
+)
+
+func main() {
+	args := os.Args[1:]
+
+	var writable []string
+	var command []string
+	i := 0
+	for ; i < len(args); i++ {
+		if args[i] == "--" {
+			command = args[i+1:]
+			break
+		}
+		if args[i] == "--writable" && i+1 < len(args) {
+			writable = append(writable, args[i+1])
+			i++
+			continue
+		}
+		fatalf("writejail: unexpected argument %q", args[i])
+	}
+
+	if len(command) == 0 {
+		fatalf("writejail: no command after --")
+	}
+
+	// Read the whole tree; write only under the allow-listed dirs. BestEffort so
+	// that on a kernel without Landlock we degrade to running the command rather
+	// than hard-failing the build (the app layer's ChangesetPolicyValidator is the
+	// backstop in that case).
+	rules := []landlock.Rule{landlock.RODirs("/")}
+	for _, w := range writable {
+		if _, err := os.Stat(w); err == nil {
+			rules = append(rules, landlock.RWDirs(w))
+		}
+	}
+	if err := landlock.V5.BestEffort().RestrictPaths(rules...); err != nil {
+		fatalf("writejail: failed to apply landlock ruleset: %v", err)
+	}
+
+	bin, err := lookPath(command[0])
+	if err != nil {
+		fatalf("writejail: %v", err)
+	}
+	if err := syscall.Exec(bin, command, os.Environ()); err != nil {
+		fatalf("writejail: exec %q failed: %v", bin, err)
+	}
+}
+
+func lookPath(name string) (string, error) {
+	if len(name) > 0 && (name[0] == '/' || name[0] == '.') {
+		return name, nil
+	}
+	for _, dir := range splitPath(os.Getenv("PATH")) {
+		candidate := dir + "/" + name
+		if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%q not found in PATH", name)
+}
+
+func splitPath(p string) []string {
+	var out []string
+	cur := ""
+	for _, r := range p {
+		if r == ':' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}
+
+func fatalf(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
+	os.Exit(127)
+}

--- a/tests/Feature/Domain/Experiment/ExecuteWarmDebugBuildActionTest.php
+++ b/tests/Feature/Domain/Experiment/ExecuteWarmDebugBuildActionTest.php
@@ -147,13 +147,45 @@ class ExecuteWarmDebugBuildActionTest extends TestCase
         $this->app->instance(LocalAgentGateway::class, $gw);
     }
 
+    /**
+     * Fake the VPS agent per best-of-N call: invocation i writes the files in
+     * $filesPerCall[i] (['relative/path' => content]) into that candidate's own
+     * worktree. A null entry means "throw" (candidate failure); pass throwOn to
+     * throw on a specific call index instead.
+     *
+     * @param  list<array<string,string>>  $filesPerCall
+     */
+    private function fakeAgentPerCall(array $filesPerCall, ?int $throwOn = null): void
+    {
+        $i = 0;
+        $gw = Mockery::mock(LocalAgentGateway::class);
+        $gw->shouldReceive('complete')->andReturnUsing(function ($request) use (&$i, $filesPerCall, $throwOn) {
+            $call = $i;
+            $i++;
+            if ($throwOn !== null && $call === $throwOn) {
+                throw new \RuntimeException('agent crashed on candidate '.$call);
+            }
+            foreach ($filesPerCall[$call] ?? [] as $rel => $content) {
+                $path = $request->workingDirectory.'/'.$rel;
+                File::ensureDirectoryExists(dirname($path));
+                File::put($path, $content);
+            }
+
+            return new AiResponseDTO(
+                content: 'done', parsedOutput: null, usage: new AiUsageDTO(0, 0, 0),
+                provider: 'claude-code-vps', model: '', latencyMs: 1,
+            );
+        });
+        $this->app->instance(LocalAgentGateway::class, $gw);
+    }
+
     /** Fake the git client so createPullRequest returns a PR and records the draft flag. */
     private function fakePrClient(array &$captured): void
     {
         $client = Mockery::mock(GitClientInterface::class);
         $client->shouldReceive('createPullRequest')
             ->andReturnUsing(function ($title, $body, $head, $base, $draft = false) use (&$captured) {
-                $captured = compact('title', 'head', 'base', 'draft');
+                $captured = compact('title', 'body', 'head', 'base', 'draft');
 
                 return ['pr_number' => '7', 'pr_url' => 'https://example.test/pr/7', 'title' => $title, 'status' => 'open'];
             });
@@ -250,6 +282,117 @@ class ExecuteWarmDebugBuildActionTest extends TestCase
 
         $exp->refresh();
         $this->assertSame(ExperimentStatus::AwaitingApproval, $exp->status);
+    }
+
+    public function test_best_of_two_selects_smaller_within_roots_candidate(): void
+    {
+        config(['experiments.warm_build.candidates' => 2]);
+        $repo = $this->repo();
+        $exp = $this->experiment(['git_repository_id' => $repo->id]);
+        // candidate 1: two files; candidate 2: one file (smaller) — both within roots.
+        $this->fakeAgentPerCall([
+            ['app/a.php' => 'x', 'app/b.php' => 'y'],
+            ['app/a.php' => 'z'],
+        ]);
+        $captured = [];
+        $this->fakePrClient($captured);
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $exp->refresh();
+        $this->assertSame(ExperimentStatus::AwaitingApproval, $exp->status);
+        $this->assertTrue($captured['draft']);
+        $this->assertStringContainsString('Selected candidate 2 of 2', $captured['body']);
+        $this->assertStringContainsString('within writable-roots', $captured['body']);
+
+        $stage = ExperimentStage::where('experiment_id', $exp->id)->where('stage', StageType::Building)->first();
+        $this->assertStringContainsString('best of 2', (string) $stage->output_snapshot['summary']);
+    }
+
+    public function test_best_of_two_discards_migration_violating_candidate(): void
+    {
+        config(['experiments.warm_build.candidates' => 2]);
+        $repo = $this->repo();
+        $exp = $this->experiment(['git_repository_id' => $repo->id]);
+        // candidate 1 rewrites a migration (out of roots); candidate 2 edits app/.
+        $this->fakeAgentPerCall([
+            ['database/migrations/2026_07_08_000000_x.php' => 'evil'],
+            ['app/fix.php' => 'good'],
+        ]);
+        $captured = [];
+        $this->fakePrClient($captured);
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $exp->refresh();
+        $this->assertSame(ExperimentStatus::AwaitingApproval, $exp->status);
+        $this->assertStringContainsString('Selected candidate 2 of 2', $captured['body']);
+        // The winning branch must contain the app fix, not the migration edit.
+        $show = Process::run(['git', '-C', $this->bare, 'show', '--stat', 'fleetq/fix-'.substr($exp->id, 0, 8)])->output();
+        $this->assertStringContainsString('app/fix.php', $show);
+        $this->assertStringNotContainsString('database/migrations', $show);
+    }
+
+    public function test_one_candidate_crash_does_not_sink_the_build(): void
+    {
+        config(['experiments.warm_build.candidates' => 2]);
+        $repo = $this->repo();
+        $exp = $this->experiment(['git_repository_id' => $repo->id]);
+        // candidate 1 crashes; candidate 2 succeeds.
+        $this->fakeAgentPerCall([[], ['app/fix.php' => 'good']], throwOn: 0);
+        $captured = [];
+        $this->fakePrClient($captured);
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $exp->refresh();
+        $this->assertSame(ExperimentStatus::AwaitingApproval, $exp->status);
+        $this->assertTrue($captured['draft']);
+    }
+
+    public function test_all_candidates_violate_roots_still_opens_flagged_pr(): void
+    {
+        config(['experiments.warm_build.candidates' => 2]);
+        $repo = $this->repo();
+        $exp = $this->experiment(['git_repository_id' => $repo->id]);
+        // Both candidates only touch migrations: pick returns the best-scoring one
+        // but flags the violation for the human reviewer (design: don't hard-fail).
+        $this->fakeAgentPerCall([
+            ['database/migrations/a.php' => 'x'],
+            ['database/migrations/b.php' => 'y'],
+        ]);
+        $captured = [];
+        $this->fakePrClient($captured);
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $exp->refresh();
+        $this->assertSame(ExperimentStatus::AwaitingApproval, $exp->status);
+        $this->assertStringContainsString('writable-roots violation', $captured['body']);
+    }
+
+    public function test_default_candidates_is_one_run(): void
+    {
+        // No candidates config → exactly one agent invocation (parity with legacy).
+        $repo = $this->repo();
+        $exp = $this->experiment(['git_repository_id' => $repo->id]);
+        $calls = 0;
+        $gw = Mockery::mock(LocalAgentGateway::class);
+        $gw->shouldReceive('complete')->andReturnUsing(function ($request) use (&$calls) {
+            $calls++;
+            File::put($request->workingDirectory.'/fix.txt', 'patched');
+
+            return new AiResponseDTO(content: 'done', parsedOutput: null, usage: new AiUsageDTO(0, 0, 0), provider: 'claude-code-vps', model: '', latencyMs: 1);
+        });
+        $this->app->instance(LocalAgentGateway::class, $gw);
+        $captured = [];
+        $this->fakePrClient($captured);
+
+        app(ExecuteWarmDebugBuildAction::class)->execute($exp);
+
+        $this->assertSame(1, $calls, 'default config must run exactly one candidate');
+        // N=1 PR body must NOT contain best-of-N framing.
+        $this->assertStringNotContainsString('Selected candidate', $captured['body']);
     }
 
     public function test_transient_capacity_rethrows_and_leaves_run_building(): void

--- a/tests/Feature/Mcp/WarmBuildGuardrailsStatusToolTest.php
+++ b/tests/Feature/Mcp/WarmBuildGuardrailsStatusToolTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\Experiment\WarmBuildGuardrailsStatusTool;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Tests\TestCase;
+
+class WarmBuildGuardrailsStatusToolTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'WB Team', 'slug' => 'wb-'.Str::random(6),
+            'owner_id' => $this->user->id, 'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->actingAs($this->user);
+        app()->instance('mcp.team_id', $this->team->id);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    private function repo(Team $team, array $config = []): GitRepository
+    {
+        return GitRepository::create([
+            'team_id' => $team->id, 'name' => 'r', 'url' => 'https://example.test/r.git',
+            'default_branch' => 'main', 'config' => $config,
+        ]);
+    }
+
+    public function test_reports_default_guardrails(): void
+    {
+        $repo = $this->repo($this->team);
+
+        $out = $this->decode((new WarmBuildGuardrailsStatusTool)->handle(new Request([
+            'git_repository_id' => $repo->id,
+        ])));
+
+        $this->assertSame($repo->id, $out['git_repository_id']);
+        $this->assertSame(1, $out['best_of_n']['candidates'], 'default N is 1 (dark-ship)');
+        $this->assertContains('database/migrations/**', $out['writable_roots']['denied_globs']);
+        $this->assertSame([], $out['writable_roots']['allowed_roots']);
+        $this->assertFalse($out['write_jail']['enabled']);
+        $this->assertSame('disabled', $out['write_jail']['inert_reason']);
+    }
+
+    public function test_reflects_repo_overrides(): void
+    {
+        config(['experiments.warm_build.candidates_max' => 3]);
+        $repo = $this->repo($this->team, [
+            'warm_build_candidates' => 2,
+            'warm_build_writable_roots' => ['allowed_roots' => ['app']],
+            'warm_build_verify_command' => 'php artisan test',
+        ]);
+
+        $out = $this->decode((new WarmBuildGuardrailsStatusTool)->handle(new Request([
+            'git_repository_id' => $repo->id,
+        ])));
+
+        $this->assertSame(2, $out['best_of_n']['candidates']);
+        $this->assertTrue($out['best_of_n']['verify_command_set']);
+        $this->assertSame(['app'], $out['writable_roots']['allowed_roots']);
+    }
+
+    public function test_cross_tenant_repo_is_not_visible(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other', 'slug' => 'other-'.Str::random(6),
+            'owner_id' => $otherUser->id, 'settings' => [],
+        ]);
+        $foreignRepo = $this->repo($otherTeam);
+
+        $this->expectException(ModelNotFoundException::class);
+        (new WarmBuildGuardrailsStatusTool)->handle(new Request([
+            'git_repository_id' => $foreignRepo->id,
+        ]));
+    }
+}

--- a/tests/Unit/Domain/Experiment/WarmBuildCandidateScorerTest.php
+++ b/tests/Unit/Domain/Experiment/WarmBuildCandidateScorerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Unit\Domain\Experiment;
+
+use App\Domain\Experiment\DTOs\WarmBuildCandidate;
+use App\Domain\Experiment\Services\WarmBuildCandidatePolicy;
+use App\Domain\Experiment\Services\WarmBuildCandidateScorer;
+use App\Domain\GitRepository\DTOs\WarmBuildChangeset;
+use App\Domain\GitRepository\Models\GitRepository;
+use Tests\TestCase;
+
+class WarmBuildCandidateScorerTest extends TestCase
+{
+    private function scorer(): WarmBuildCandidateScorer
+    {
+        return new WarmBuildCandidateScorer;
+    }
+
+    /**
+     * @param  list<string>  $files
+     */
+    private function cand(
+        int $i,
+        array $files,
+        bool $withinRoots = true,
+        int $verify = WarmBuildCandidate::VERIFY_UNKNOWN,
+        int $added = 5,
+        int $removed = 0,
+        bool $failed = false,
+    ): WarmBuildCandidate {
+        $changeset = $failed
+            ? null
+            : new WarmBuildChangeset(files: $files, added: $added, removed: $removed, headSha: $files === [] ? '' : 'sha'.$i);
+
+        return new WarmBuildCandidate(
+            index: $i,
+            runId: 'exp-c'.$i,
+            worktree: $failed ? null : '/wt/'.$i,
+            changeset: $changeset,
+            withinRoots: $withinRoots,
+            verify: $verify,
+            failed: $failed,
+        );
+    }
+
+    // ---- pick ----
+
+    public function test_pick_empty_returns_null(): void
+    {
+        $this->assertNull($this->scorer()->pick([]));
+    }
+
+    public function test_pick_all_no_change_returns_null(): void
+    {
+        $this->assertNull($this->scorer()->pick([
+            $this->cand(1, []),
+            $this->cand(2, [], failed: true),
+        ]));
+    }
+
+    public function test_has_changes_beats_no_change(): void
+    {
+        $winner = $this->scorer()->pick([
+            $this->cand(1, []),                 // no change
+            $this->cand(2, ['app/Foo.php']),    // change
+        ]);
+        $this->assertSame(2, $winner?->index);
+    }
+
+    public function test_within_roots_beats_violation_same_diff(): void
+    {
+        $winner = $this->scorer()->pick([
+            $this->cand(1, ['database/migrations/x.php'], withinRoots: false),
+            $this->cand(2, ['app/Foo.php'], withinRoots: true),
+        ]);
+        $this->assertSame(2, $winner?->index);
+    }
+
+    public function test_verify_pass_beats_unknown_beats_fail(): void
+    {
+        $winner = $this->scorer()->pick([
+            $this->cand(1, ['app/A.php'], verify: WarmBuildCandidate::VERIFY_FAIL),
+            $this->cand(2, ['app/B.php'], verify: WarmBuildCandidate::VERIFY_UNKNOWN),
+            $this->cand(3, ['app/C.php'], verify: WarmBuildCandidate::VERIFY_PASS),
+        ]);
+        $this->assertSame(3, $winner?->index);
+    }
+
+    public function test_tie_breaks_to_smaller_change(): void
+    {
+        $winner = $this->scorer()->pick([
+            $this->cand(1, ['app/A.php', 'app/B.php'], added: 40),  // 2 files
+            $this->cand(2, ['app/A.php'], added: 10),               // 1 file — smaller
+        ]);
+        $this->assertSame(2, $winner?->index);
+    }
+
+    public function test_fewer_lines_breaks_tie_on_equal_file_count(): void
+    {
+        $winner = $this->scorer()->pick([
+            $this->cand(1, ['app/A.php'], added: 80),
+            $this->cand(2, ['app/B.php'], added: 3),  // smaller diff
+        ]);
+        $this->assertSame(2, $winner?->index);
+    }
+
+    public function test_all_violate_roots_returns_best_scoring_flagged(): void
+    {
+        // Every candidate is out of roots; pick still returns the best-scoring one,
+        // flagged (withinRoots=false) so the PR body can warn the reviewer.
+        $winner = $this->scorer()->pick([
+            $this->cand(1, ['database/migrations/a.php', 'database/migrations/b.php'], withinRoots: false, added: 50),
+            $this->cand(2, ['database/migrations/a.php'], withinRoots: false, added: 10),
+        ]);
+        $this->assertSame(2, $winner?->index);
+        $this->assertFalse($winner->withinRoots);
+    }
+
+    // ---- WarmBuildCandidatePolicy::count ----
+
+    public function test_count_default_is_one(): void
+    {
+        config(['experiments.warm_build.candidates' => 1, 'experiments.warm_build.candidates_max' => 3]);
+        $this->assertSame(1, (new WarmBuildCandidatePolicy)->count(new GitRepository));
+    }
+
+    public function test_count_reads_config(): void
+    {
+        config(['experiments.warm_build.candidates' => 3, 'experiments.warm_build.candidates_max' => 3]);
+        $this->assertSame(3, (new WarmBuildCandidatePolicy)->count(new GitRepository));
+    }
+
+    public function test_count_clamped_to_max(): void
+    {
+        config(['experiments.warm_build.candidates' => 99, 'experiments.warm_build.candidates_max' => 3]);
+        $this->assertSame(3, (new WarmBuildCandidatePolicy)->count(new GitRepository));
+    }
+
+    public function test_count_floored_to_one(): void
+    {
+        config(['experiments.warm_build.candidates' => 0, 'experiments.warm_build.candidates_max' => 3]);
+        $this->assertSame(1, (new WarmBuildCandidatePolicy)->count(new GitRepository));
+    }
+
+    public function test_count_repo_override_wins(): void
+    {
+        config(['experiments.warm_build.candidates' => 1, 'experiments.warm_build.candidates_max' => 3]);
+        $repo = new GitRepository;
+        $repo->config = ['warm_build_candidates' => 2];
+        $this->assertSame(2, (new WarmBuildCandidatePolicy)->count($repo));
+    }
+}

--- a/tests/Unit/Domain/GitRepository/WritableRootsPolicyTest.php
+++ b/tests/Unit/Domain/GitRepository/WritableRootsPolicyTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Unit\Domain\GitRepository;
+
+use App\Domain\Experiment\Models\Experiment;
+use App\Domain\GitRepository\DTOs\WarmBuildChangeset;
+use App\Domain\GitRepository\DTOs\WritableRootsGrant;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\ChangesetPolicyValidator;
+use App\Domain\GitRepository\Services\WritableRootsPolicy;
+use Tests\TestCase;
+
+class WritableRootsPolicyTest extends TestCase
+{
+    private function policy(): WritableRootsPolicy
+    {
+        return new WritableRootsPolicy;
+    }
+
+    private function changeset(array $files): WarmBuildChangeset
+    {
+        return new WarmBuildChangeset(files: $files, added: 1, removed: 0, headSha: 'deadbeef');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['experiments.warm_build.writable_roots' => [
+            'denied_globs' => ['database/migrations/**', '**/migrations/**'],
+            'allowed_roots' => [],
+        ]]);
+    }
+
+    // ---- WritableRootsGrant::permits ----
+
+    public function test_empty_allow_roots_permits_anything_not_denied(): void
+    {
+        $grant = new WritableRootsGrant(allowedRoots: [], deniedGlobs: ['database/migrations/**']);
+        $this->assertTrue($grant->permits('app/Domain/Foo.php'));
+        $this->assertTrue($grant->permits('tests/FooTest.php'));
+    }
+
+    public function test_denied_glob_blocks_migration(): void
+    {
+        $grant = new WritableRootsGrant(allowedRoots: [], deniedGlobs: ['database/migrations/**', '**/migrations/**']);
+        $this->assertFalse($grant->permits('database/migrations/2026_07_08_x.php'));
+        $this->assertFalse($grant->permits('modules/Billing/database/migrations/x.php'));
+    }
+
+    public function test_non_empty_allow_roots_restrict_writes(): void
+    {
+        $grant = new WritableRootsGrant(allowedRoots: ['app', 'tests'], deniedGlobs: []);
+        $this->assertTrue($grant->permits('app/Foo.php'));
+        $this->assertTrue($grant->permits('tests/Bar.php'));
+        $this->assertFalse($grant->permits('config/app.php'));
+    }
+
+    public function test_deny_wins_over_allow(): void
+    {
+        // migrations denied even though its parent dir is an allowed root
+        $grant = new WritableRootsGrant(allowedRoots: ['database'], deniedGlobs: ['database/migrations/**']);
+        $this->assertTrue($grant->permits('database/seeders/X.php'));
+        $this->assertFalse($grant->permits('database/migrations/X.php'));
+    }
+
+    // ---- WritableRootsPolicy::resolve (layering) ----
+
+    public function test_resolve_default_grant(): void
+    {
+        $grant = $this->policy()->resolve(new GitRepository);
+        $this->assertSame([], $grant->allowedRoots);
+        $this->assertContains('database/migrations/**', $grant->deniedGlobs);
+    }
+
+    public function test_repo_override_adds_denied_and_sets_allowed(): void
+    {
+        $repo = new GitRepository;
+        $repo->config = ['warm_build_writable_roots' => [
+            'allowed_roots' => ['app'],
+            'denied_globs' => ['config/**'],
+        ]];
+
+        $grant = $this->policy()->resolve($repo);
+
+        $this->assertSame(['app'], $grant->allowedRoots);
+        $this->assertContains('config/**', $grant->deniedGlobs);
+        // default denials accumulate — repo layer can only ADD denials
+        $this->assertContains('database/migrations/**', $grant->deniedGlobs);
+    }
+
+    public function test_task_override_wins_allowed_and_accumulates_denied(): void
+    {
+        $repo = new GitRepository;
+        $repo->config = ['warm_build_writable_roots' => ['allowed_roots' => ['app']]];
+        $exp = new Experiment;
+        $exp->constraints = ['warm_build_writable_roots' => [
+            'allowed_roots' => ['src'],
+            'denied_globs' => ['src/legacy/**'],
+        ]];
+
+        $grant = $this->policy()->resolve($repo, $exp);
+
+        $this->assertSame(['src'], $grant->allowedRoots, 'task allow-list is most specific');
+        $this->assertContains('src/legacy/**', $grant->deniedGlobs);
+        $this->assertContains('database/migrations/**', $grant->deniedGlobs);
+    }
+
+    // ---- absoluteWritablePaths (for #2 Landlock) ----
+
+    public function test_absolute_paths_whole_tree_when_no_allow_roots(): void
+    {
+        $grant = new WritableRootsGrant(allowedRoots: [], deniedGlobs: ['x']);
+        $this->assertSame(['/wt/run'], $this->policy()->absoluteWritablePaths($grant, '/wt/run/'));
+    }
+
+    public function test_absolute_paths_map_allow_roots_under_worktree(): void
+    {
+        $grant = new WritableRootsGrant(allowedRoots: ['app', 'tests'], deniedGlobs: []);
+        $this->assertSame(
+            ['/wt/run/app', '/wt/run/tests'],
+            $this->policy()->absoluteWritablePaths($grant, '/wt/run'),
+        );
+    }
+
+    // ---- ChangesetPolicyValidator ----
+
+    public function test_validator_flags_only_out_of_root_paths(): void
+    {
+        $grant = new WritableRootsGrant(allowedRoots: [], deniedGlobs: ['database/migrations/**']);
+        $changeset = $this->changeset([
+            'app/Domain/Foo.php',
+            'database/migrations/2026_07_08_x.php',
+            'tests/FooTest.php',
+        ]);
+
+        $violations = (new ChangesetPolicyValidator)->violations($changeset, $grant);
+
+        $this->assertSame(['database/migrations/2026_07_08_x.php'], $violations);
+        $this->assertFalse((new ChangesetPolicyValidator)->isWithinRoots($changeset, $grant));
+    }
+
+    public function test_validator_clean_changeset_within_roots(): void
+    {
+        $grant = new WritableRootsGrant(allowedRoots: [], deniedGlobs: ['database/migrations/**']);
+        $changeset = $this->changeset(['app/Foo.php', 'tests/Bar.php']);
+
+        $this->assertSame([], (new ChangesetPolicyValidator)->violations($changeset, $grant));
+        $this->assertTrue((new ChangesetPolicyValidator)->isWithinRoots($changeset, $grant));
+    }
+}

--- a/tests/Unit/Infrastructure/Sandbox/WriteJailTest.php
+++ b/tests/Unit/Infrastructure/Sandbox/WriteJailTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\Sandbox;
+
+use App\Infrastructure\Sandbox\WriteJail;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class WriteJailTest extends TestCase
+{
+    private function jail(): WriteJail
+    {
+        return new WriteJail;
+    }
+
+    private array $command = ['claude', '-p', '--model', 'x'];
+
+    protected function tearDown(): void
+    {
+        foreach (glob(sys_get_temp_dir().'/wjail-*') ?: [] as $f) {
+            @unlink($f);
+        }
+        parent::tearDown();
+    }
+
+    public function test_disabled_returns_command_verbatim(): void
+    {
+        config(['experiments.warm_build.write_jail.enabled' => false]);
+        $this->assertSame($this->command, $this->jail()->wrap($this->command, ['/wt']));
+        $this->assertSame('disabled', $this->jail()->inertReason());
+    }
+
+    public function test_enabled_but_launcher_unset_is_inert(): void
+    {
+        config([
+            'experiments.warm_build.write_jail.enabled' => true,
+            'experiments.warm_build.write_jail.launcher' => null,
+        ]);
+        if (PHP_OS_FAMILY !== 'Linux') {
+            $this->assertSame('not-linux', $this->jail()->inertReason());
+
+            return;
+        }
+        $this->assertSame('launcher-unset', $this->jail()->inertReason());
+        $this->assertSame($this->command, $this->jail()->wrap($this->command, ['/wt']));
+    }
+
+    public function test_enabled_but_launcher_missing_is_inert(): void
+    {
+        config([
+            'experiments.warm_build.write_jail.enabled' => true,
+            'experiments.warm_build.write_jail.launcher' => '/does/not/exist/landlock-helper',
+        ]);
+        if (PHP_OS_FAMILY !== 'Linux') {
+            $this->markTestSkipped('launcher checks only reached on Linux');
+        }
+        $this->assertSame('launcher-missing', $this->jail()->inertReason());
+        $this->assertSame($this->command, $this->jail()->wrap($this->command, ['/wt']));
+    }
+
+    public function test_enabled_with_executable_launcher_wraps_command(): void
+    {
+        if (PHP_OS_FAMILY !== 'Linux') {
+            $this->markTestSkipped('Landlock jail only wraps on Linux');
+        }
+
+        $launcher = sys_get_temp_dir().'/wjail-'.Str::random(8);
+        File::put($launcher, "#!/bin/sh\nexec \"\$@\"\n");
+        chmod($launcher, 0755);
+
+        config([
+            'experiments.warm_build.write_jail.enabled' => true,
+            'experiments.warm_build.write_jail.launcher' => $launcher,
+            'experiments.warm_build.write_jail.extra_writable' => ['/tmp'],
+        ]);
+
+        $wrapped = $this->jail()->wrap($this->command, ['/wt/run/app', '/home/ephemeral']);
+
+        $this->assertSame($launcher, $wrapped[0]);
+        // writable paths + the separator + the original command are all present.
+        $this->assertContains('/wt/run/app', $wrapped);
+        $this->assertContains('/home/ephemeral', $wrapped);
+        $this->assertContains('/tmp', $wrapped);
+        $sep = array_search('--', $wrapped, true);
+        $this->assertIsInt($sep);
+        $this->assertSame($this->command, array_values(array_slice($wrapped, $sep + 1)));
+        // every '--writable' is immediately followed by a path, never '--'
+        foreach ($wrapped as $k => $tok) {
+            if ($tok === '--writable') {
+                $this->assertNotSame('--', $wrapped[$k + 1] ?? '--');
+            }
+        }
+    }
+
+    public function test_duplicate_writable_paths_collapsed(): void
+    {
+        if (PHP_OS_FAMILY !== 'Linux') {
+            $this->markTestSkipped('Landlock jail only wraps on Linux');
+        }
+        $launcher = sys_get_temp_dir().'/wjail-'.Str::random(8);
+        File::put($launcher, "#!/bin/sh\nexec \"\$@\"\n");
+        chmod($launcher, 0755);
+        config([
+            'experiments.warm_build.write_jail.enabled' => true,
+            'experiments.warm_build.write_jail.launcher' => $launcher,
+            'experiments.warm_build.write_jail.extra_writable' => ['/tmp'],
+        ]);
+
+        $wrapped = $this->jail()->wrap($this->command, ['/wt', '/wt', '/tmp']);
+
+        $this->assertSame(1, array_count_values($wrapped)['/wt'] ?? 0, '/wt appears once');
+    }
+}


### PR DESCRIPTION
Three warm-build guardrails borrowed from `shepherd-agents/shepherd`, **all dark-shipped (default off)** on the autonomous claude-code-vps path. Draft — human review + merge (autonomy feature, no auto-merge).

## What
- **#1 Best-of-N** — `experiments.warm_build.candidates` (default **1** = legacy single-run). Runs N candidate agent attempts from the same base ref, scores each changeset deterministically (within-roots → optional per-repo verify command → smallest diff), pushes only the winner into the single draft PR. Sequential; clamped to `candidates_max` (default 3) so it can't fan out unbounded on the capped credit.
- **#3 Writable-roots grant** — layered config/repo/task allow+deny policy (migrations denied by default). Changeset validated post-run; a scope-violating candidate loses to a compliant one and, if it still wins, is flagged in the PR body.
- **#2 Write-jail** — wraps the claude-code-vps process in a native **Landlock** ruleset (reference helper in `docker/writejail/`). **Inert by default** — no-op unless enabled AND launcher present AND Linux. Kernel enforcement requires building the helper into the image + verifying on the VPS (see `docker/writejail/README.md`); **not done in this PR**.
- `warm_build_guardrails_status` MCP tool (`#[IsReadOnly]`).

## Safety
- **N=1 is behaviourally identical to today** (`test_default_candidates_is_one_run`, `test_happy_path`).
- Sits behind existing budget reservation + shipped loop-detection breaker + 2/team concurrency cap.
- Transient-cap retry semantics preserved (`test_transient_capacity_rethrows`).

## Tests
52 tests / 174 assertions green; pint clean; phpstan clean (only the known DisposableEmail Docker-quirk remains, passes on CI).

Design/arch/test-plan docs are in the parent repo PR (`docs/{design,architecture,test-plans}/*-warm-build-guardrails.md`).