### PR TITLE
feat(discovery): add agent-readiness discovery surface

### DIFF
--- a/app/Http/Controllers/AgentCardController.php
+++ b/app/Http/Controllers/AgentCardController.php
@@ -16,8 +16,18 @@ class AgentCardController extends Controller
         return response()->json([
             'name' => 'FleetQ',
             'description' => 'AI Agent Mission Control — manage experiments, workflows, crews, approvals, and full agent lifecycle.',
+            // `url` is the pre-0.3 single-endpoint field. Kept alongside
+            // `supportedInterfaces` so older A2A clients still resolve us.
             'url' => config('app.url').'/mcp',
+            'supportedInterfaces' => [
+                [
+                    'url' => config('app.url').'/mcp',
+                    'protocolBinding' => 'JSONRPC',
+                    'protocolVersion' => '1.0',
+                ],
+            ],
             'version' => config('app.version', '1.0.0'),
+            'documentationUrl' => config('app.url').'/docs/mcp-server',
             'authentication' => [
                 'schemes' => ['Bearer'],
             ],

--- a/app/Http/Controllers/AgentSkillsController.php
+++ b/app/Http/Controllers/AgentSkillsController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+
+/**
+ * Serves the Agent Skills discovery index and the SKILL.md artifacts it
+ * points at.
+ *
+ * Artifacts live in resources/agent-skills/{name}/SKILL.md and are templated
+ * with {{APP_URL}} so a self-hosted install advertises its own base URL. The
+ * digest is computed over the rendered body, so it always matches what the
+ * artifact endpoint returns for this host.
+ *
+ * @see https://github.com/cloudflare/agent-skills-discovery-rfc
+ */
+class AgentSkillsController extends Controller
+{
+    private const SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+
+    /** @var array<string, string> */
+    private const SKILLS = [
+        'fleetq-connect' => 'Connect an agent to FleetQ over MCP or the REST API, including obtaining credentials via dynamic client registration.',
+        'fleetq-run-experiment' => 'Create, run, monitor, and recover a FleetQ experiment through its 20-state pipeline.',
+        'fleetq-manage-workflow' => 'Build, validate, cost, and execute FleetQ visual DAG workflows.',
+    ];
+
+    public function index(): JsonResponse
+    {
+        $skills = [];
+
+        foreach (self::SKILLS as $name => $description) {
+            $body = $this->render($name);
+
+            if ($body === null) {
+                continue;
+            }
+
+            $skills[] = [
+                'name' => $name,
+                'type' => 'skill-md',
+                'description' => $description,
+                'url' => url('/.well-known/agent-skills/'.$name.'/SKILL.md'),
+                'digest' => 'sha256:'.hash('sha256', $body),
+            ];
+        }
+
+        return response()->json([
+            '$schema' => self::SCHEMA,
+            'skills' => $skills,
+        ]);
+    }
+
+    public function show(string $name): Response
+    {
+        abort_unless(array_key_exists($name, self::SKILLS), 404);
+
+        $body = $this->render($name);
+
+        abort_if($body === null, 404);
+
+        return response($body, 200, [
+            'Content-Type' => 'text/markdown; charset=utf-8',
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    private function render(string $name): ?string
+    {
+        $path = resource_path('agent-skills/'.$name.'/SKILL.md');
+
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        return str_replace('{{APP_URL}}', rtrim(config('app.url'), '/'), $contents);
+    }
+}

--- a/app/Http/Controllers/ApiCatalogController.php
+++ b/app/Http/Controllers/ApiCatalogController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Serves the RFC 9727 API catalog so agents can discover the REST API and the
+ * MCP endpoint without scraping the docs site.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9727
+ */
+class ApiCatalogController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        return response()->json([
+            'linkset' => [
+                [
+                    'anchor' => url('/api/v1'),
+                    'service-desc' => [
+                        [
+                            'href' => url('/docs/api.json'),
+                            'type' => 'application/vnd.oai.openapi+json;version=3.1',
+                            'title' => 'FleetQ REST API v1 — OpenAPI 3.1 description',
+                        ],
+                    ],
+                    'service-doc' => [
+                        [
+                            'href' => url('/docs/api'),
+                            'type' => 'text/html',
+                            'title' => 'FleetQ REST API v1 — reference documentation',
+                        ],
+                    ],
+                    'status' => [
+                        [
+                            'href' => url('/api/v1/health'),
+                            'type' => 'application/json',
+                            'title' => 'FleetQ platform health',
+                        ],
+                    ],
+                ],
+                [
+                    'anchor' => url('/mcp'),
+                    'service-doc' => [
+                        [
+                            'href' => url('/docs/mcp-server'),
+                            'type' => 'text/html',
+                            'title' => 'FleetQ MCP server — connection guide',
+                        ],
+                    ],
+                    'describedby' => [
+                        [
+                            'href' => url('/.well-known/fleetq'),
+                            'type' => 'application/json',
+                            'title' => 'FleetQ MCP discovery document',
+                        ],
+                    ],
+                ],
+            ],
+        ], 200, [
+            'Content-Type' => 'application/linkset+json',
+        ]);
+    }
+}

--- a/app/Http/Controllers/AuthMdController.php
+++ b/app/Http/Controllers/AuthMdController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Response;
+
+/**
+ * Serves /auth.md — the agent-facing description of how to obtain credentials
+ * for the FleetQ API and MCP endpoint.
+ *
+ * Everything documented here is backed by a live endpoint: RFC 9728 protected
+ * resource metadata, RFC 8414 authorization server metadata, and RFC 7591
+ * dynamic client registration (all registered in routes/ai.php).
+ */
+class AuthMdController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $baseUrl = rtrim(config('app.url'), '/');
+
+        $body = <<<MARKDOWN
+        # auth.md
+
+        How autonomous agents authenticate to FleetQ.
+
+        FleetQ exposes two agent-callable surfaces, both protected by bearer
+        tokens sent in the `Authorization` header:
+
+        - **MCP endpoint** — `POST {$baseUrl}/mcp` (JSON-RPC over HTTP/SSE).
+        - **REST API v1** — `{$baseUrl}/api/v1` ([OpenAPI 3.1]({$baseUrl}/docs/api.json)).
+
+        ## Discovery
+
+        | Document | URL |
+        |---|---|
+        | Protected Resource Metadata (RFC 9728) | `{$baseUrl}/.well-known/oauth-protected-resource` |
+        | Authorization Server Metadata (RFC 8414) | `{$baseUrl}/.well-known/oauth-authorization-server` |
+        | API catalog (RFC 9727) | `{$baseUrl}/.well-known/api-catalog` |
+        | MCP discovery document | `{$baseUrl}/.well-known/fleetq` |
+
+        The protected resource advertises `scopes_supported: ["mcp:use"]` and
+        `bearer_methods_supported: ["header"]`. Its `authorization_servers`
+        entry points at `{$baseUrl}`, whose issuer matches exactly.
+
+        ## Registration
+
+        FleetQ supports **RFC 7591 dynamic client registration**. An agent can
+        self-register an OAuth client without human setup, then run the normal
+        authorization-code flow with PKCE:
+
+        ```json
+        {
+          "agent_auth": {
+            "skill": "{$baseUrl}/.well-known/agent-skills/fleetq-connect/SKILL.md",
+            "register_uri": "{$baseUrl}/oauth/register",
+            "methods": [
+              {
+                "type": "oauth_dynamic_client_registration",
+                "spec": "https://www.rfc-editor.org/rfc/rfc7591",
+                "register_uri": "{$baseUrl}/oauth/register",
+                "authorization_servers": ["{$baseUrl}"],
+                "authorization_endpoint": "{$baseUrl}/oauth/authorize",
+                "token_endpoint": "{$baseUrl}/oauth/token",
+                "revocation_uri": "{$baseUrl}/oauth/revoke",
+                "grant_types_supported": ["authorization_code", "refresh_token"],
+                "code_challenge_methods_supported": ["S256"],
+                "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
+                "scopes_supported": ["mcp:use"],
+                "credential_types_supported": ["oauth_access_token", "oauth_refresh_token"]
+              }
+            ]
+          }
+        }
+        ```
+
+        Registration is rate limited to 20 requests per hour per IP.
+
+        ## Using the credential
+
+        Send the access token as a bearer header on every request:
+
+        ```
+        Authorization: Bearer <access_token>
+        ```
+
+        A `401` means the token is missing, expired, or lacks the `mcp:use`
+        scope. Refresh with the `refresh_token` grant rather than
+        re-registering a client.
+
+        ## Human-issued tokens
+
+        Operators who prefer not to use OAuth can mint a long-lived Sanctum API
+        token from **Team settings → API tokens** in the FleetQ UI and hand it
+        to the agent. Such tokens are scoped to a single team and carry that
+        team's role permissions.
+        MARKDOWN;
+
+        return response($body, 200, [
+            'Content-Type' => 'text/markdown; charset=utf-8',
+            'Cache-Control' => 'public, max-age=3600',
+            'X-Robots-Tag' => 'all',
+        ]);
+    }
+}

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -6,7 +6,8 @@ use Illuminate\Http\Response;
 
 class DocsController extends Controller
 {
-    private array $pages = [
+    /** Public documentation slugs — also the source of truth for the sitemap. */
+    public const PAGES = [
         'introduction',
         'getting-started',
         'experiments',
@@ -53,7 +54,7 @@ class DocsController extends Controller
 
     public function show(string $page = 'introduction'): Response
     {
-        abort_unless(in_array($page, $this->pages, true), 404);
+        abort_unless(in_array($page, self::PAGES, true), 404);
 
         $view = 'docs.'.$page;
 

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Illuminate\Routing\Route as RoutingRoute;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+
+/**
+ * Serves /sitemap.xml per the sitemaps.org protocol.
+ *
+ * The URL list is derived from the router rather than hand-maintained, so
+ * pages added in either the base or the cloud edition appear automatically.
+ * Only parameterless public GET routes are emitted; anything behind auth or
+ * matching a denied prefix is excluded.
+ */
+class SitemapController extends Controller
+{
+    /**
+     * First path segments that are machine surfaces, assets, auth flows, or
+     * tenant-scoped. Matched exactly or as a `segment-*` prefix, which is what
+     * catches Livewire's hashed asset route (`livewire-<hash>/...`).
+     */
+    private const DENY_SEGMENTS = [
+        'api', 'mcp', 'oauth', '.well-known', 'livewire', 'storage', 'build',
+        'horizon', 'telescope', 'pulse', 'metrics', 'broadcasting', 'sanctum',
+        'admin', 'share', 'files', 'shop', 'sso', 'auth', 'up', 'get',
+        'webauthn', 'account', 'authorize', 'continue', 'end-session',
+    ];
+
+    /** Paths that exist publicly but must not be indexed. */
+    private const DENY_PATTERNS = [
+        'login', 'register', 'logout', 'password', 'forgot', 'reset',
+        'two-factor', 'setup', 'onboarding', 'invitations', 'trial',
+        'confirm', 'verify', 'accept',
+    ];
+
+    public function __invoke(): Response
+    {
+        $urls = collect($this->routeUrls())
+            ->merge($this->docsUrls())
+            ->unique()
+            ->sort()
+            ->values();
+
+        $body = $this->renderXml($urls->all());
+
+        return response($body, 200, [
+            'Content-Type' => 'application/xml; charset=utf-8',
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function routeUrls(): array
+    {
+        return collect(Route::getRoutes()->getRoutes())
+            ->filter(fn (RoutingRoute $route) => $this->isPublicPage($route))
+            ->map(fn (RoutingRoute $route) => url('/'.ltrim($route->uri(), '/')))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function docsUrls(): array
+    {
+        return collect(DocsController::PAGES)
+            ->filter(fn (string $slug) => view()->exists('docs.'.$slug))
+            ->map(fn (string $slug) => url('/docs/'.$slug))
+            ->values()
+            ->all();
+    }
+
+    private function isPublicPage(RoutingRoute $route): bool
+    {
+        if (! in_array('GET', $route->methods(), true)) {
+            return false;
+        }
+
+        $uri = trim($route->uri(), '/');
+
+        // Parameterised routes need data we cannot enumerate safely here.
+        if (str_contains($uri, '{')) {
+            return false;
+        }
+
+        if ($uri === '' || $uri === '/') {
+            return true;
+        }
+
+        // A dot in the final segment means a machine document or asset
+        // (api.json, llms.txt, sitemap.xml, livewire.js) — never a page.
+        if (str_contains(basename($uri), '.')) {
+            return false;
+        }
+
+        $firstSegment = explode('/', $uri)[0];
+
+        foreach (self::DENY_SEGMENTS as $segment) {
+            if ($firstSegment === $segment || Str::startsWith($firstSegment, $segment.'-')) {
+                return false;
+            }
+        }
+
+        foreach (self::DENY_PATTERNS as $pattern) {
+            if (str_contains($uri, $pattern)) {
+                return false;
+            }
+        }
+
+        return ! $this->requiresAuth($route);
+    }
+
+    private function requiresAuth(RoutingRoute $route): bool
+    {
+        foreach ($route->gatherMiddleware() as $middleware) {
+            if (! is_string($middleware)) {
+                continue;
+            }
+
+            if ($middleware === 'auth' || Str::startsWith($middleware, ['auth:', 'auth.'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<string>  $urls
+     */
+    private function renderXml(array $urls): string
+    {
+        $entries = implode('', array_map(
+            fn (string $url) => '<url><loc>'.htmlspecialchars($url, ENT_XML1).'</loc></url>',
+            $urls,
+        ));
+
+        return '<?xml version="1.0" encoding="UTF-8"?>'
+            .'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            .$entries
+            .'</urlset>';
+    }
+}

--- a/app/Http/Middleware/AgentDiscoveryLinks.php
+++ b/app/Http/Middleware/AgentDiscoveryLinks.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Advertises the machine-readable discovery surface via RFC 8288 Link headers
+ * so agents can find the API catalog and docs without parsing HTML.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc8288
+ * @see https://www.rfc-editor.org/rfc/rfc9727#section-3
+ */
+class AgentDiscoveryLinks
+{
+    private const LINKS = [
+        '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+        '</docs/api.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"',
+        '</docs/api>; rel="service-doc"; type="text/html"',
+        '</llms.txt>; rel="describedby"; type="text/markdown"',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if (! $request->isMethodCacheable()) {
+            return $response;
+        }
+
+        if (! $this->isHtml($response)) {
+            return $response;
+        }
+
+        foreach (self::LINKS as $link) {
+            $response->headers->set('Link', $link, false);
+        }
+
+        return $response;
+    }
+
+    private function isHtml(Response $response): bool
+    {
+        $contentType = $response->headers->get('Content-Type', '');
+
+        return is_string($contentType) && str_contains($contentType, 'text/html');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Domain\Budget\Exceptions\InsufficientBudgetException;
+use App\Http\Middleware\AgentDiscoveryLinks;
 use App\Http\Middleware\ApplyTenantTracer;
 use App\Http\Middleware\BypassAuth;
 use App\Http\Middleware\EnsureTermsAccepted;
@@ -61,6 +62,7 @@ $app = Application::configure(basePath: dirname(__DIR__))
         $middleware->validateCsrfTokens(except: ['auth/apple/callback']);
         $middleware->append(SecurityHeaders::class);
         $middleware->prepend(ResolveWebsiteByDomain::class);
+        $middleware->appendToGroup('web', AgentDiscoveryLinks::class);
         $middleware->appendToGroup('web', BypassAuth::class);
         $middleware->appendToGroup('web', SetCurrentTeam::class);
         $middleware->appendToGroup('web', EnsureTermsAccepted::class);

--- a/resources/agent-skills/fleetq-connect/SKILL.md
+++ b/resources/agent-skills/fleetq-connect/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: fleetq-connect
+description: Connect an agent to FleetQ over MCP or the REST API, including obtaining credentials via dynamic client registration.
+---
+
+# Connect to FleetQ
+
+FleetQ exposes every platform capability to agents. Use this skill to
+establish a working connection before calling any other FleetQ skill.
+
+## Pick a transport
+
+| Transport | Endpoint | Use when |
+|---|---|---|
+| MCP over HTTP/SSE | `POST {{APP_URL}}/mcp` | Your runtime speaks Model Context Protocol. Preferred — you get typed tools for the whole platform. |
+| REST API v1 | `{{APP_URL}}/api/v1` | You want plain HTTP. Described by [OpenAPI 3.1]({{APP_URL}}/docs/api.json). |
+
+Both use bearer tokens in the `Authorization` header.
+
+## Get a credential
+
+FleetQ supports RFC 7591 dynamic client registration, so an agent can
+self-provision without human setup.
+
+1. Fetch authorization server metadata:
+   `GET {{APP_URL}}/.well-known/oauth-authorization-server`
+2. `POST` your client metadata to the advertised `registration_endpoint`
+   (`{{APP_URL}}/oauth/register`). Rate limit: 20 requests per hour per IP.
+3. Run the authorization-code flow with PKCE (`S256`) against the
+   `authorization_endpoint`, requesting the `mcp:use` scope.
+4. Exchange the code at the `token_endpoint` for an access token.
+
+Full detail: [{{APP_URL}}/auth.md]({{APP_URL}}/auth.md)
+
+Alternatively, a human operator can mint a Sanctum API token from
+**Team settings → API tokens** and pass it to you directly.
+
+## Verify the connection
+
+```
+GET {{APP_URL}}/api/v1/health
+```
+
+Returns platform health without authentication — use it to confirm
+reachability before debugging credentials.
+
+Then confirm your token works:
+
+```
+GET {{APP_URL}}/api/v1/me
+Authorization: Bearer <access_token>
+```
+
+A `401` means the token is missing, expired, or lacks the `mcp:use` scope.
+
+## Discover what you can do
+
+- `{{APP_URL}}/.well-known/fleetq` — machine-readable discovery document.
+- `{{APP_URL}}/.well-known/api-catalog` — RFC 9727 catalog of API surfaces.
+- `{{APP_URL}}/llms.txt` — compact platform index.
+- Over MCP: call `tools/list` to enumerate the available tools directly.
+
+## Notes
+
+- All data is team-scoped. A token carries exactly one team's permissions
+  and role; you cannot read across teams.
+- Write and destructive operations are role-gated. A viewer-role token can
+  read but not mutate.

--- a/resources/agent-skills/fleetq-manage-workflow/SKILL.md
+++ b/resources/agent-skills/fleetq-manage-workflow/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: fleetq-manage-workflow
+description: Build, validate, cost, and execute FleetQ visual DAG workflows — including generating one from a natural-language goal.
+---
+
+# Manage a FleetQ workflow
+
+A *workflow* is a reusable directed graph of work. Nodes are typed:
+`start`, `end`, `agent`, `conditional`, `human_task`, `switch`,
+`dynamic_fork`, `do_while`. Workflows are templates; running one
+materialises an experiment.
+
+Requires a working connection — see the `fleetq-connect` skill first.
+
+## Fastest path: generate from a goal
+
+`workflow_generate` decomposes a natural-language goal into a graph. Use it
+as a starting point, then refine — it produces a draft, not a final answer.
+
+## Build by hand
+
+| Tool | Purpose |
+|---|---|
+| `workflow_create` | Create the workflow shell. |
+| `workflow_node_add` / `workflow_node_update` / `workflow_node_delete` | Manage nodes. |
+| `workflow_edge_add` / `workflow_edge_delete` | Manage edges. |
+| `workflow_save_graph` | Persist a whole graph in one call. |
+
+REST equivalent:
+
+```
+POST {{APP_URL}}/api/v1/workflows
+PUT  {{APP_URL}}/api/v1/workflows/{id}/graph
+```
+
+## Always validate before activating
+
+```
+workflow_validate   →  structural check (unreachable nodes, missing start/end, cycles)
+workflow_estimate_cost  →  projected credit cost per run
+workflow_simulate   →  dry run without spending credits or sending outbound
+workflow_activate   →  make it runnable
+```
+
+`workflow_activate` on an invalid graph fails. Run `workflow_validate`
+first and fix what it reports — the errors name the offending node.
+
+## Execute and observe
+
+- `workflow_execution_chain` — trace what ran, in order.
+- `workflow_snapshot_list` — historical versions of the graph.
+- `workflow_compensation_runs` — compensating actions triggered on failure.
+
+## Portability
+
+`workflow_export_yaml` / `workflow_import_yaml` move a workflow between
+teams or environments as plain YAML. `workflow_duplicate` copies within a
+team.
+
+## Rules that will bite you
+
+- **`human_task` nodes block.** They create an approval request and wait.
+  An unattended agent run will stall there until a human completes it, or
+  until the SLA check escalates or expires the task.
+- **`switch` nodes route on `case_value` on the outgoing edges.** An edge
+  with no matching case is never taken; a switch with no matching edge
+  dead-ends the branch.
+- **Cost estimates are projections, not caps.** Budget enforcement happens
+  at execution time against the team's real balance.

--- a/resources/agent-skills/fleetq-run-experiment/SKILL.md
+++ b/resources/agent-skills/fleetq-run-experiment/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: fleetq-run-experiment
+description: Create, run, monitor, and recover a FleetQ experiment through its 20-state pipeline via MCP tools or the REST API.
+---
+
+# Run a FleetQ experiment
+
+An *experiment* is FleetQ's unit of autonomous work: it moves through a
+20-state pipeline (scoring → planning → building → approval → executing →
+metrics → evaluation) with budget enforcement and an audit trail at every
+step.
+
+Requires a working connection — see the `fleetq-connect` skill first.
+
+## Create and start
+
+MCP tools:
+
+| Tool | Purpose |
+|---|---|
+| `experiment_create` | Create the experiment. |
+| `experiment_start` | Move it out of draft into the pipeline. |
+| `experiment_get` | Read current state, stage, and cost. |
+| `experiment_list` | Enumerate experiments for the team. |
+
+REST equivalent:
+
+```
+POST {{APP_URL}}/api/v1/experiments
+POST {{APP_URL}}/api/v1/experiments/{id}/transition
+GET  {{APP_URL}}/api/v1/experiments/{id}
+```
+
+## Monitor progress
+
+- `experiment_steps` — per-step execution detail.
+- `experiment_stage_telemetry` — timing and stage-level metrics.
+- `experiment_cost` — credits consumed so far.
+- `experiment_valid_transitions` — which transitions are legal right now.
+  Call this before attempting a transition; the state machine rejects
+  anything not in the map.
+
+## Intervene
+
+| Situation | Tool |
+|---|---|
+| Needs to stop temporarily | `experiment_pause` / `experiment_resume` |
+| Needs to stop permanently | `experiment_kill` |
+| A stage failed and you want another attempt | `experiment_retry` |
+| A specific step failed | `experiment_retry_from_step` (resets that step and everything downstream) |
+| Long-running work was interrupted | `experiment_resume_from_checkpoint` |
+| You want to redirect it mid-flight | `experiment_steer` |
+| You want to understand a failure | `experiment_diagnose` |
+
+## Rules that will bite you
+
+- **Transitions are validated.** `ExperimentTransitionMap` rejects illegal
+  moves — always check `experiment_valid_transitions` rather than guessing.
+- **Terminal states are final**: `completed`, `killed`, `discarded`,
+  `expired`. There is no transition out; create a new experiment.
+- **Budget is enforced before execution.** An experiment pauses
+  automatically when the team's credit balance cannot cover the reservation
+  (reservations use a 1.5× multiplier). Check `budget_summary` first if you
+  expect long runs.
+- **Approval gates block execution.** If the experiment enters
+  `awaiting_approval`, a human (or an agent with approval permission) must
+  act via `approval_approve` before it proceeds.

--- a/resources/views/components/layouts/public.blade.php
+++ b/resources/views/components/layouts/public.blade.php
@@ -104,5 +104,7 @@
             aria-label="Back to top">
         <i class="fa-solid fa-chevron-up text-lg" aria-hidden="true"></i>
     </button>
+
+    <x-webmcp-tools />
 </body>
 </html>

--- a/resources/views/components/webmcp-tools.blade.php
+++ b/resources/views/components/webmcp-tools.blade.php
@@ -1,0 +1,58 @@
+{{--
+    WebMCP — exposes FleetQ's public discovery documents as in-page tools so a
+    browser agent visiting the site can learn how to connect without leaving
+    the page.
+
+    Every tool maps to a real, public, unauthenticated GET endpoint. No tool
+    here mutates anything or requires credentials.
+
+    Spec: https://webmachinelearning.github.io/webmcp/
+--}}
+<script>
+(function () {
+    if (!('modelContext' in navigator) || typeof navigator.modelContext.registerTool !== 'function') {
+        return;
+    }
+
+    const controller = new AbortController();
+
+    const fetchText = async (path) => {
+        const response = await fetch(path, { headers: { 'Accept': 'text/plain, application/json' } });
+
+        if (!response.ok) {
+            return `Request to ${path} failed with HTTP ${response.status}.`;
+        }
+
+        return await response.text();
+    };
+
+    const tools = [
+        {
+            name: 'fleetq_connection_info',
+            description: 'Get the FleetQ MCP discovery document: endpoint URLs, supported transports, and how to authenticate.',
+            path: '/.well-known/fleetq',
+        },
+        {
+            name: 'fleetq_platform_index',
+            description: 'Get the compact FleetQ platform index (llms.txt): what the platform does and the main capability areas.',
+            path: '/llms.txt',
+        },
+        {
+            name: 'fleetq_api_catalog',
+            description: 'Get the RFC 9727 API catalog listing the FleetQ REST API, its OpenAPI description, and the MCP endpoint.',
+            path: '/.well-known/api-catalog',
+        },
+    ];
+
+    for (const tool of tools) {
+        navigator.modelContext.registerTool({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+            execute: async () => ({
+                content: [{ type: 'text', text: await fetchText(tool.path) }],
+            }),
+        }, { signal: controller.signal });
+    }
+})();
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,11 @@
 <?php
 
 use App\Http\Controllers\AgentCardController;
+use App\Http\Controllers\AgentSkillsController;
 use App\Http\Controllers\Api\V1\AgentManifestController;
+use App\Http\Controllers\ApiCatalogController;
 use App\Http\Controllers\ArtifactPreviewController;
+use App\Http\Controllers\AuthMdController;
 use App\Http\Controllers\DocsController;
 use App\Http\Controllers\EmailTemplatePreviewController;
 use App\Http\Controllers\IntegrationOAuthController;
@@ -12,6 +15,7 @@ use App\Http\Controllers\PrometheusMetricsController;
 use App\Http\Controllers\PublicExperimentController;
 use App\Http\Controllers\PublicReleaseController;
 use App\Http\Controllers\ReleaseKeysController;
+use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\SkillExportController;
 use App\Http\Controllers\SkillQualityLeaderboardController;
 use App\Http\Controllers\SocialAuthController;
@@ -196,6 +200,39 @@ Route::get('/.well-known/agent.json', AgentCardController::class)
     ->middleware('throttle:60,1');
 Route::get('/.well-known/agent-card.json', AgentCardController::class)
     ->name('a2a.agent-card.spec')
+    ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])
+    ->middleware('throttle:60,1');
+
+// RFC 9727 API catalog — machine-readable index of the REST API and MCP surfaces.
+Route::get('/.well-known/api-catalog', ApiCatalogController::class)
+    ->name('well-known.api-catalog')
+    ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])
+    ->middleware('throttle:60,1');
+
+// Agent Skills discovery (Cloudflare agent-skills-discovery RFC v0.2.0) — index
+// plus the SKILL.md artifacts it references.
+Route::get('/.well-known/agent-skills/index.json', [AgentSkillsController::class, 'index'])
+    ->name('agent-skills.index')
+    ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])
+    ->middleware('throttle:60,1');
+
+Route::get('/.well-known/agent-skills/{name}/SKILL.md', [AgentSkillsController::class, 'show'])
+    ->where('name', '[a-z0-9\-]+')
+    ->name('agent-skills.show')
+    ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])
+    ->middleware('throttle:60,1');
+
+// auth.md — how agents obtain credentials. Complements the RFC 9728/8414
+// metadata registered in routes/ai.php.
+Route::get('/auth.md', AuthMdController::class)
+    ->name('auth.md')
+    ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])
+    ->middleware('throttle:60,1');
+
+// sitemaps.org protocol — derived from the router, so cloud-only pages are
+// included automatically.
+Route::get('/sitemap.xml', SitemapController::class)
+    ->name('sitemap')
     ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])
     ->middleware('throttle:60,1');
 

--- a/tests/Feature/Http/AgentDiscoveryTest.php
+++ b/tests/Feature/Http/AgentDiscoveryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Tests\TestCase;
+
+/**
+ * Covers the agent-readiness discovery surface: sitemap, API catalog, auth.md,
+ * Agent Skills index, and the A2A card's supportedInterfaces field.
+ *
+ * Assertions mirror what external scanners validate, so a regression here is
+ * caught before it shows up as a failed check in production.
+ */
+class AgentDiscoveryTest extends TestCase
+{
+    // No RefreshDatabase — every endpoint under test is a pure render.
+
+    public function test_sitemap_returns_valid_xml_listing_public_pages(): void
+    {
+        $response = $this->get('/sitemap.xml');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/xml; charset=utf-8');
+
+        $body = $response->getContent();
+
+        $xml = simplexml_load_string($body);
+        $this->assertNotFalse($xml, 'sitemap.xml must be well-formed XML');
+        $this->assertSame('urlset', $xml->getName());
+
+        $this->assertStringContainsString('/docs/introduction', $body);
+        $this->assertGreaterThan(5, $xml->count(), 'sitemap should list more than a handful of pages');
+    }
+
+    public function test_sitemap_excludes_auth_and_machine_surfaces(): void
+    {
+        $body = $this->get('/sitemap.xml')->getContent();
+
+        $forbidden = [
+            '/login', '/register', '/api/', '/.well-known/', '/livewire',
+            '/authorize', '/end-session', '/webauthn', '/account',
+            '.json', '.txt', '.xml', '.js',
+        ];
+
+        foreach ($forbidden as $needle) {
+            $this->assertStringNotContainsString(
+                $needle,
+                $body,
+                "sitemap must not list {$needle}",
+            );
+        }
+    }
+
+    public function test_api_catalog_follows_rfc_9727(): void
+    {
+        $response = $this->get('/.well-known/api-catalog');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/linkset+json');
+
+        $linkset = $response->json('linkset');
+
+        $this->assertNotEmpty($linkset);
+        $this->assertArrayHasKey('anchor', $linkset[0]);
+        $this->assertNotEmpty($linkset[0]['service-desc'][0]['href']);
+        $this->assertNotEmpty($linkset[0]['service-doc'][0]['href']);
+    }
+
+    public function test_auth_md_is_markdown_with_conforming_heading(): void
+    {
+        $response = $this->get('/auth.md');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/markdown; charset=utf-8');
+
+        $body = $response->getContent();
+
+        // The scanner requires an H1 containing "auth.md".
+        $this->assertMatchesRegularExpression('/^#\s.*auth\.md/mi', $body);
+        $this->assertStringContainsString('/.well-known/oauth-protected-resource', $body);
+        $this->assertStringContainsString('agent_auth', $body);
+    }
+
+    public function test_agent_skills_index_matches_discovery_schema(): void
+    {
+        $response = $this->get('/.well-known/agent-skills/index.json');
+
+        $response->assertOk();
+        $response->assertJsonPath('$schema', 'https://schemas.agentskills.io/discovery/0.2.0/schema.json');
+
+        $skills = $response->json('skills');
+
+        $this->assertNotEmpty($skills);
+
+        foreach ($skills as $skill) {
+            foreach (['name', 'type', 'description', 'url', 'digest'] as $field) {
+                $this->assertArrayHasKey($field, $skill);
+                $this->assertNotEmpty($skill[$field]);
+            }
+
+            $this->assertSame('skill-md', $skill['type']);
+            $this->assertMatchesRegularExpression('/^sha256:[0-9a-f]{64}$/', $skill['digest']);
+        }
+    }
+
+    public function test_agent_skill_digest_matches_served_artifact(): void
+    {
+        $skills = $this->get('/.well-known/agent-skills/index.json')->json('skills');
+
+        foreach ($skills as $skill) {
+            $artifact = $this->get('/.well-known/agent-skills/'.$skill['name'].'/SKILL.md');
+
+            $artifact->assertOk();
+            $artifact->assertHeader('Content-Type', 'text/markdown; charset=utf-8');
+
+            $this->assertSame(
+                'sha256:'.hash('sha256', $artifact->getContent()),
+                $skill['digest'],
+                "digest mismatch for skill {$skill['name']}",
+            );
+        }
+    }
+
+    public function test_unknown_agent_skill_returns_404(): void
+    {
+        $this->get('/.well-known/agent-skills/not-a-real-skill/SKILL.md')->assertNotFound();
+    }
+
+    public function test_agent_card_declares_supported_interfaces(): void
+    {
+        $response = $this->get('/.well-known/agent-card.json');
+
+        $response->assertOk();
+
+        $interfaces = $response->json('supportedInterfaces');
+
+        $this->assertNotEmpty($interfaces, 'A2A spec requires a non-empty supportedInterfaces');
+        $this->assertNotEmpty($interfaces[0]['url']);
+        $this->assertNotEmpty($interfaces[0]['protocolBinding']);
+    }
+
+    public function test_html_pages_carry_agent_discovery_link_headers(): void
+    {
+        $response = $this->get('/docs/introduction');
+
+        $response->assertOk();
+
+        $links = implode(' ', $response->headers->all('Link'));
+
+        $this->assertStringContainsString('rel="api-catalog"', $links);
+        $this->assertStringContainsString('rel="service-desc"', $links);
+        $this->assertStringContainsString('rel="service-doc"', $links);
+    }
+
+    public function test_non_html_responses_do_not_get_link_headers(): void
+    {
+        $response = $this->get('/llms.txt');
+
+        $response->assertOk();
+        $this->assertEmpty($response->headers->all('Link'));
+    }
+}


### PR DESCRIPTION
Closes the gaps reported by isitagentready.com scanner.

Adds: /sitemap.xml (router-derived), RFC 8288 Link headers, RFC 9727 /.well-known/api-catalog, /auth.md, /.well-known/agent-skills/ index + 3 SKILL.md artifacts, WebMCP in-page tools. Fixes the A2A agent card, which was being rejected as invalid for a missing `supportedInterfaces` field.

Everything points at a live endpoint — no placeholder discovery documents.

Verified: 10 new feature tests, adjacent suites (52 tests) green, Architecture suite green, phpstan clean on changed files, pint clean.

https://claude.ai/code/session_01BT3qWzu1zVjgfKwewNAqr1