### PR TITLE
fix(security): stop trustProxies('*') from collapsing every visitor onto one IP

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -55,7 +55,15 @@ $app = Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->trustProxies(at: '*');
+        // NOT '*': Laravel reads that as "trust only the calling IP", so the rightmost
+        // proxy in X-Forwarded-For is reported as the client and every visitor collapses
+        // onto one address. Trust the private ranges the request actually traverses.
+        $middleware->trustProxies(at: [
+            '10.0.0.0/8',
+            '172.16.0.0/12',
+            '192.168.0.0/16',
+            '127.0.0.1/32',
+        ]);
         // Apple Sign In uses response_mode=form_post → a cross-site POST with no
         // CSRF token. Exempt it via the framework's public API (not a route-level
         // withoutMiddleware on a hardcoded CSRF class name, which silently broke

--- a/tests/Feature/Http/TrustProxiesTest.php
+++ b/tests/Feature/Http/TrustProxiesTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Http;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+/**
+ * Guards against the `trustProxies(at: '*')` regression: Laravel reads '*' as
+ * "trust only the immediate calling IP", so Symfony stops walking X-Forwarded-For
+ * at the first untrusted hop (an internal proxy) and every visitor collapses onto
+ * one address. Self-hosted deployments of this standalone entrypoint typically sit
+ * behind a reverse proxy on a private network, so those ranges must be trusted
+ * explicitly instead.
+ */
+class TrustProxiesTest extends TestCase
+{
+    // No RefreshDatabase — pure middleware/request-object assertions.
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::get('/__trust-proxies-probe', fn () => response()->json([
+            'ip' => request()->ip(),
+            'secure' => request()->isSecure(),
+        ]));
+    }
+
+    public function test_resolves_the_original_client_ip_through_the_full_proxy_chain(): void
+    {
+        $response = $this->call('GET', '/__trust-proxies-probe', server: [
+            'REMOTE_ADDR' => '172.20.0.5',
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.77, 172.24.0.23',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+        ]);
+
+        $response->assertOk();
+        $response->assertJson(['ip' => '203.0.113.77']);
+    }
+
+    public function test_trusts_the_forwarded_proto_from_the_proxy_chain(): void
+    {
+        $response = $this->call('GET', '/__trust-proxies-probe', server: [
+            'REMOTE_ADDR' => '172.20.0.5',
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.77, 172.24.0.23',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+        ]);
+
+        $response->assertJson(['secure' => true]);
+    }
+
+    public function test_does_not_believe_a_forwarded_for_header_from_a_public_peer(): void
+    {
+        // A direct caller from a public IP is not a trusted proxy, so its own
+        // X-Forwarded-For claim must be ignored — otherwise any caller could
+        // spoof its reported IP.
+        $response = $this->call('GET', '/__trust-proxies-probe', server: [
+            'REMOTE_ADDR' => '203.0.113.9',
+            'HTTP_X_FORWARDED_FOR' => '1.2.3.4',
+        ]);
+
+        $response->assertJson(['ip' => '203.0.113.9']);
+    }
+}


### PR DESCRIPTION
## Summary
- `bootstrap/app.php` (this repo's standalone entrypoint, used when `base/` is deployed without the cloud wrapper): `trustProxies(at: '*')` → explicit private ranges. Laravel reads `'*'` as "trust only the immediate calling IP" — Symfony then stops walking `X-Forwarded-For` at the first untrusted hop and reports that hop's address for every visitor. Self-hosted deployments of this entrypoint typically sit behind a reverse proxy on a private network.
- Adds `tests/Feature/Http/TrustProxiesTest.php` covering the full proxy chain: correct `ip()`, correct `isSecure()` via `X-Forwarded-Proto`, and rejection of a spoofed `X-Forwarded-For` from a public (non-proxy) peer.

Same defect and fix as agent-fleet PR #75 (the cloud edition's `bootstrap/app.php`, already merged and deployed). This is a separate, independent entrypoint with its own copy of the same bug — found while first attempting to add this exact test here, which failed on this repo's own CI (PR #127, closed/superseded) because the fix hadn't been applied yet.

## Verification
- PR #127 (closed) already demonstrated the vacuity check on this repo's real CI: the identical test, run against the unfixed `at: '*')`, failed 2 of 3 assertions.
- Local verification of this PR's test is unreliable here — this checkout's `vendor/` is symlinked to the parent cloud repo's vendor for convenience, so `Tests\TestCase::createApplication()` detects the Cloud namespace and loads the *parent's* (already-fixed) `bootstrap/app.php` instead of this repo's own — meaning a local run passes regardless of this file's content. This repo's own CI runs a clean, non-symlinked `composer install`, so it's the only environment that genuinely exercises this specific bootstrap file.

## Test plan
- [x] Same test previously verified to fail without the fix (PR #127, real CI)
- [ ] CI green on this PR — this is the actual verification for this specific file, given the local caveat above