### PR TITLE
fix(experiment): clear error when a playbook step's agent is missing

### DIFF
--- a/app/Domain/Experiment/Pipeline/ExecutePlaybookStepJob.php
+++ b/app/Domain/Experiment/Pipeline/ExecutePlaybookStepJob.php
@@ -293,15 +293,21 @@ class ExecutePlaybookStepJob implements HasSentryContext, ShouldQueue
                     experimentId: $experiment->id,
                 );
             } else {
+                $agent = $step->agent;
+
+                if (! $agent) {
+                    throw new \RuntimeException("Agent {$step->agent_id} not found for step {$this->stepId}.");
+                }
+
                 Log::info('ExecutePlaybookStepJob: calling executeAgent', [
                     'step_id' => $this->stepId,
-                    'agent' => $step->agent?->name,
+                    'agent' => $agent->name,
                     'input_keys' => array_keys($input),
                     'attempt' => $this->attempts(),
                 ]);
 
                 $result = $executeAgent->execute(
-                    agent: $step->agent,
+                    agent: $agent,
                     input: $input,
                     teamId: $experiment->team_id,
                     userId: $experiment->user_id,

--- a/tests/Feature/Domain/Experiment/PlaybookStepRetryTest.php
+++ b/tests/Feature/Domain/Experiment/PlaybookStepRetryTest.php
@@ -160,4 +160,30 @@ class PlaybookStepRetryTest extends TestCase
         $this->assertEquals('failed', $this->step->status, 'Step should be failed after all retries exhausted');
         $this->assertStringContainsString('Permanent API error', $this->step->error_message);
     }
+
+    public function test_step_with_missing_agent_throws_clear_error_not_type_error(): void
+    {
+        // Soft-delete the agent so PlaybookStep::agent resolves to null while
+        // agent_id stays set — the job must raise a clear domain error, not a
+        // cryptic TypeError from the non-nullable ExecuteAgentAction::execute().
+        Agent::withoutGlobalScopes()->findOrFail($this->step->agent_id)->delete();
+
+        $job = new ExecutePlaybookStepJob(
+            stepId: $this->step->id,
+            experimentId: $this->experiment->id,
+            teamId: $this->team->id,
+        );
+
+        try {
+            $job->handle(
+                app(ExecuteAgentAction::class),
+                app(ExecuteSkillAction::class),
+            );
+            $this->fail('Expected a RuntimeException for the missing agent.');
+        } catch (\TypeError $e) {
+            $this->fail('Got a TypeError instead of a clear RuntimeException: '.$e->getMessage());
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('not found for step', $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Fixes Sentry fleetq #975 / #977 (`TypeError: ExecuteAgentAction::execute(): Argument #1 ($agent) must be of type Agent`).

**Root cause:** `ExecutePlaybookStepJob` passed `$step->agent` (nullable — the relation returns null when the agent is soft-deleted or unresolved) straight into `ExecuteAgentAction::execute(Agent $agent, ...)`, which is non-nullable. Result was a cryptic `TypeError` instead of a diagnosable failure. The log line right above already used `$step->agent?->name`, acknowledging the null.

**Fix:** guard the null and throw a clear `RuntimeException("Agent {id} not found for step {id}.")`, mirroring the existing skill-branch pattern.

**Test:** `test_step_with_missing_agent_throws_clear_error_not_type_error` — soft-deletes the agent and asserts a `RuntimeException` (not a `TypeError`).

https://claude.ai/code/session_01Vhj1boRXKWGHjUaAQd9SX9