### PR TITLE
fix(memory): skip distillation when the team's only credential is for another provider

### DIFF
--- a/app/Domain/Memory/Actions/DistillTeamEventsAction.php
+++ b/app/Domain/Memory/Actions/DistillTeamEventsAction.php
@@ -5,6 +5,7 @@ namespace App\Domain\Memory\Actions;
 use App\Domain\Audit\Models\AuditEntry;
 use App\Domain\Memory\Enums\MemoryTier;
 use App\Domain\Memory\Enums\MemoryVisibility;
+use App\Domain\Shared\Exceptions\AiAccessUnavailableException;
 use App\Domain\Shared\Models\Team;
 use App\Infrastructure\AI\Contracts\AiGatewayInterface;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
@@ -65,10 +66,20 @@ PROMPT;
         // no BYOK and the platform has no key for the distillation provider.
         // Without this guard the hourly cron fires hundreds of Sentry errors
         // per night on free-tier teams. Sentry issue FLEETQ-81.
+        //
+        // DistillTeamEventsJob's pre-flight gate (TeamAiAccessChecker::canUseAi)
+        // is provider-AGNOSTIC — it passes any team holding *a* credential —
+        // while distil() below demands one specific provider. A BYOK team whose
+        // only key is for a different provider therefore clears the gate and
+        // then throws AiAccessUnavailableException here. That is expected
+        // backpressure, not a defect, so it must be skipped like the
+        // fallback-chain case instead of churning failed_jobs and Sentry
+        // forever. (#824/#847/#1035/#1064)
         try {
             $summary = $this->distil($events, $teamId);
         } catch (RuntimeException $e) {
-            if (! str_contains($e->getMessage(), 'No available providers in fallback chain')) {
+            if (! $e instanceof AiAccessUnavailableException
+                && ! str_contains($e->getMessage(), 'No available providers in fallback chain')) {
                 throw $e;
             }
             Log::info('DistillTeamEventsAction: skipping team (no provider credentials)', [

--- a/tests/Feature/Domain/Memory/DistillTeamEventsActionTest.php
+++ b/tests/Feature/Domain/Memory/DistillTeamEventsActionTest.php
@@ -5,8 +5,10 @@ namespace Tests\Feature\Domain\Memory;
 use App\Domain\Audit\Models\AuditEntry;
 use App\Domain\Memory\Actions\DistillTeamEventsAction;
 use App\Domain\Memory\Actions\StoreMemoryAction;
+use App\Domain\Shared\Exceptions\AiAccessUnavailableException;
 use App\Domain\Shared\Models\Team;
 use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
 use App\Infrastructure\AI\DTOs\AiResponseDTO;
 use App\Infrastructure\AI\DTOs\AiUsageDTO;
 use App\Models\User;
@@ -141,6 +143,36 @@ class DistillTeamEventsActionTest extends TestCase
         $gateway->shouldReceive('complete')
             ->once()
             ->andThrow(new \RuntimeException('No available providers in fallback chain'));
+
+        $store = Mockery::mock(StoreMemoryAction::class);
+        $store->shouldNotReceive('execute');
+
+        $result = (new DistillTeamEventsAction($gateway, $store))->execute($this->team->id);
+
+        $this->assertSame(1, $result['events']);
+        $this->assertSame(0, $result['stored']);
+        $this->assertNotNull($this->team->fresh()->settings['memory']['last_event_distill_at'] ?? null);
+    }
+
+    public function test_skips_when_teams_only_credential_is_for_a_different_provider(): void
+    {
+        // DistillTeamEventsJob's pre-flight gate (TeamAiAccessChecker::canUseAi)
+        // is provider-agnostic, so a BYOK team holding a key for some *other*
+        // provider clears it and reaches this action. PrismAiGateway then throws
+        // AiAccessUnavailableException (resolveCredential: no credential for the
+        // distillation provider, and the plan carries no platform_llm_fallback).
+        // That is expected backpressure — the team must be skipped and its
+        // watermark advanced, not pushed into failed_jobs on every hourly run.
+        // (#824/#847/#1035/#1064)
+        config(['memory.distillation.model' => 'groq/llama-3.3-70b-versatile']);
+
+        $this->auditEntry('experiment.transitioned', now()->subHour());
+
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')
+            ->once()
+            ->with(Mockery::on(fn (AiRequestDTO $request) => $request->provider === 'groq'))
+            ->andThrow(AiAccessUnavailableException::forTeam());
 
         $store = Mockery::mock(StoreMemoryAction::class);
         $store->shouldNotReceive('execute');


### PR DESCRIPTION
fix(memory): skip distillation when the team's only credential is for another provider

The AI availability gate is provider-agnostic; the distillation call site is
provider-specific, and nothing reconciled them.

DistillTeamEventsJob::handle pre-flight-gates on TeamAiAccessChecker::canUseAi
— "does this team have *any* path to AI". DistillTeamEventsAction::distil then
demands one specific provider from config('memory.distillation.model'). A BYOK
team whose only credential is for a different provider (openai, google,
custom_endpoint) therefore clears the gate and then throws
AiAccessUnavailableException from PrismAiGateway::resolveCredential, because it
has no credential for the distillation provider and its plan carries no
platform_llm_fallback.

The guard for this already existed but was too narrow: it matched only the
message 'No available providers in fallback chain', while the real throw arrives
as AiAccessUnavailableException — a purpose-built expected-backpressure type that
BeforeSendFilter and BaseStageJob::isExpectedFailure already treat as such.
Result: the hourly cron pushed these teams into failed_jobs and Sentry on every
run, forever.

Widen the existing catch to recognise the exception type. Skip cleanly and
advance the watermark, exactly as the fallback-chain case already does.

Regression test pins the scenario: distillation configured for one provider, the
gateway throwing AiAccessUnavailableException for it — the action must return a
0-stored result and advance the watermark instead of letting the exception
escape. Verified to fail without the fix.

Sentry: #824, #847, #1035, #1064.
