### PR TITLE
[FleetQ] Fix: Fix bug: RedisException: read error on connection to redis:6379

### DIFF
--- a/app/Infrastructure/Bridge/BridgeRequestRegistry.php
+++ b/app/Infrastructure/Bridge/BridgeRequestRegistry.php
@@ -2,7 +2,9 @@
 
 namespace App\Infrastructure\Bridge;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redis;
+use Predis\Connection\ConnectionException;
 
 /**
  * Manages in-flight bridge relay requests in Redis.
@@ -72,7 +74,7 @@ class BridgeRequestRegistry
      */
     public function popChunk(string $requestId, int $timeoutSeconds = 90): ?array
     {
-        $result = Redis::connection('bridge')->blpop(["bridge:stream:{$requestId}"], $timeoutSeconds);
+        $result = $this->blpopWithRetry(["bridge:stream:{$requestId}"], $timeoutSeconds);
 
         if (! $result) {
             return null;
@@ -159,6 +161,41 @@ class BridgeRequestRegistry
     public function isExpired(string $requestId): bool
     {
         return Redis::connection('bridge')->ttl("bridge:pending:{$requestId}") <= 0;
+    }
+
+    /**
+     * BLPOP against the `bridge` connection, transparently reconnecting once if the
+     * underlying socket was dropped mid-wait (e.g. an idle-connection kill by network
+     * infra during a long-lived block). A dropped connection surfaces as an uncaught
+     * RedisException/ConnectionException rather than a clean timeout, which would
+     * otherwise crash the whole in-flight bridge request.
+     *
+     * @param  list<string>  $keys
+     * @return array{0: string, 1: string}|null
+     */
+    private function blpopWithRetry(array $keys, int $timeoutSeconds): ?array
+    {
+        try {
+            return Redis::connection('bridge')->blpop($keys, $timeoutSeconds);
+        } catch (\RedisException|ConnectionException $e) {
+            Log::warning('Bridge Redis connection dropped during blpop, reconnecting and retrying', [
+                'keys' => $keys,
+                'error' => $e->getMessage(),
+            ]);
+
+            Redis::purge('bridge');
+
+            try {
+                return Redis::connection('bridge')->blpop($keys, $timeoutSeconds);
+            } catch (\RedisException|ConnectionException $e) {
+                Log::error('Bridge Redis connection retry failed after reconnect', [
+                    'keys' => $keys,
+                    'error' => $e->getMessage(),
+                ]);
+
+                return null;
+            }
+        }
     }
 
     /**

--- a/tests/Unit/Infrastructure/Bridge/BridgeRequestRegistryTest.php
+++ b/tests/Unit/Infrastructure/Bridge/BridgeRequestRegistryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\Bridge;
+
+use App\Infrastructure\Bridge\BridgeRequestRegistry;
+use Illuminate\Support\Facades\Redis;
+use Mockery;
+use Tests\TestCase;
+
+class BridgeRequestRegistryTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_pop_chunk_returns_null_on_a_clean_timeout(): void
+    {
+        $connection = Mockery::mock();
+        $connection->shouldReceive('blpop')
+            ->once()
+            ->with(['bridge:stream:req-1'], 5)
+            ->andReturn(null);
+
+        Redis::shouldReceive('connection')->with('bridge')->once()->andReturn($connection);
+        Redis::shouldReceive('purge')->never();
+
+        $registry = new BridgeRequestRegistry;
+
+        $this->assertNull($registry->popChunk('req-1', 5));
+    }
+
+    public function test_pop_chunk_reconnects_and_retries_after_a_redis_read_error(): void
+    {
+        $connection = Mockery::mock();
+        $calls = 0;
+        $connection->shouldReceive('blpop')
+            ->twice()
+            ->with(['bridge:stream:req-2'], 5)
+            ->andReturnUsing(function () use (&$calls) {
+                $calls++;
+
+                if ($calls === 1) {
+                    throw new \RedisException('read error on connection to redis:6379');
+                }
+
+                return [
+                    'bridge:stream:req-2',
+                    json_encode(['chunk' => 'hello', 'done' => true, 'usage' => null]),
+                ];
+            });
+
+        Redis::shouldReceive('connection')->with('bridge')->twice()->andReturn($connection);
+        Redis::shouldReceive('purge')->with('bridge')->once();
+
+        $registry = new BridgeRequestRegistry;
+
+        $result = $registry->popChunk('req-2', 5);
+
+        $this->assertSame(['chunk' => 'hello', 'done' => true, 'usage' => null], $result);
+    }
+
+    public function test_pop_chunk_returns_null_when_the_retry_also_fails(): void
+    {
+        $connection = Mockery::mock();
+        $connection->shouldReceive('blpop')
+            ->twice()
+            ->with(['bridge:stream:req-3'], 5)
+            ->andThrow(new \RedisException('read error on connection to redis:6379'));
+
+        Redis::shouldReceive('connection')->with('bridge')->twice()->andReturn($connection);
+        Redis::shouldReceive('purge')->with('bridge')->once();
+
+        $registry = new BridgeRequestRegistry;
+
+        $this->assertNull($registry->popChunk('req-3', 5));
+    }
+}


### PR DESCRIPTION
Automated fix opened by FleetQ for experiment `019fc6db-c19b-7248-a29f-cc10df71f196`.

**Issue:** Fix bug: RedisException: read error on connection to redis:6379

⚠️ Draft PR — requires human review before merge.