### PR TITLE
fix(approval): re-check expiry before executing a queued action proposal

### DIFF
--- a/app/Domain/Agent/Services/ToolCallGovernor.php
+++ b/app/Domain/Agent/Services/ToolCallGovernor.php
@@ -165,6 +165,7 @@ class ToolCallGovernor
                 ],
                 agentId: $agent->id,
                 riskLevel: 'high',
+                expiresAt: now()->addHours(24),
             );
         } catch (\Throwable $e) {
             Log::warning('ToolCallGovernor: failed to raise approval proposal', [

--- a/app/Domain/Approval/Jobs/ExecuteActionProposalJob.php
+++ b/app/Domain/Approval/Jobs/ExecuteActionProposalJob.php
@@ -49,6 +49,23 @@ class ExecuteActionProposalJob implements ShouldQueue
             return;
         }
 
+        // Approval is granted against a deadline; the queue can drain after it.
+        // Re-check at the execution seam so a proposal approved just before
+        // expiry can never produce a side effect once the window has closed.
+        if ($proposal->expires_at !== null && $proposal->expires_at->isPast()) {
+            $proposal->update([
+                'status' => ActionProposalStatus::Expired,
+                'execution_error' => 'Approval window closed before the queued execution ran.',
+            ]);
+
+            Log::info('ExecuteActionProposalJob: refusing to execute past expiry', [
+                'proposal_id' => $proposal->id,
+                'expires_at' => $proposal->getAttribute('expires_at'),
+            ]);
+
+            return;
+        }
+
         $actor = $this->resolveActor($proposal);
         if (! $actor) {
             $this->markFailed($proposal, 'Actor user could not be resolved (no actor_user_id and no team owner).');

--- a/tests/Feature/Domain/Agent/ToolCallGovernorTest.php
+++ b/tests/Feature/Domain/Agent/ToolCallGovernorTest.php
@@ -188,6 +188,10 @@ class ToolCallGovernorTest extends TestCase
         $this->assertNotNull($proposal);
         $this->assertSame($this->agent->id, $proposal->actor_agent_id);
         $this->assertSame('charge', $proposal->payload['tool_name']);
+        // Agent-raised proposals carry the same 24h approval window as the
+        // assistant / integration / git gates — without it they never expire.
+        $this->assertNotNull($proposal->expires_at);
+        $this->assertTrue($proposal->expires_at->between(now()->addHours(23), now()->addHours(25)));
     }
 
     public function test_arg_predicate_is_noop_when_subflag_disabled(): void

--- a/tests/Feature/Domain/Approval/ActionProposalAutoExecuteTest.php
+++ b/tests/Feature/Domain/Approval/ActionProposalAutoExecuteTest.php
@@ -312,6 +312,65 @@ class ActionProposalAutoExecuteTest extends TestCase
         app(ActionProposalExecutor::class)->execute($proposal->fresh(), $this->user);
     }
 
+    public function test_job_refuses_to_execute_after_the_approval_window_closed(): void
+    {
+        Queue::fake();
+
+        $proposal = $this->makeProposal();
+        $proposal->update(['expires_at' => now()->addMinutes(5)]);
+
+        // Approved inside the window; the queue then drains after it.
+        app(ApproveActionProposalAction::class)->execute($proposal->fresh(), $this->user);
+
+        $this->travel(10)->minutes();
+
+        $executor = $this->mock(ActionProposalExecutor::class, function ($mock) {
+            $mock->shouldNotReceive('execute');
+        });
+
+        (new ExecuteActionProposalJob($proposal->id))->handle($executor);
+
+        $proposal->refresh();
+        $this->assertSame(ActionProposalStatus::Expired, $proposal->status);
+        $this->assertNull($proposal->executed_at);
+        $this->assertNull($proposal->execution_result);
+        $this->assertStringContainsString('Approval window closed', (string) $proposal->execution_error);
+    }
+
+    public function test_job_executes_when_the_approval_window_is_still_open(): void
+    {
+        $proposal = $this->makeProposal();
+        $proposal->update([
+            'status' => ActionProposalStatus::Approved,
+            'expires_at' => now()->addHour(),
+        ]);
+
+        $executor = $this->mock(ActionProposalExecutor::class, function ($mock) {
+            $mock->shouldReceive('execute')->once()->andReturn(['ok' => true]);
+        });
+
+        (new ExecuteActionProposalJob($proposal->id))->handle($executor);
+
+        $this->assertSame(ActionProposalStatus::Executed, $proposal->fresh()->status);
+    }
+
+    public function test_job_executes_when_the_proposal_has_no_expiry(): void
+    {
+        $proposal = $this->makeProposal();
+        $proposal->update([
+            'status' => ActionProposalStatus::Approved,
+            'expires_at' => null,
+        ]);
+
+        $executor = $this->mock(ActionProposalExecutor::class, function ($mock) {
+            $mock->shouldReceive('execute')->once()->andReturn(['ok' => true]);
+        });
+
+        (new ExecuteActionProposalJob($proposal->id))->handle($executor);
+
+        $this->assertSame(ActionProposalStatus::Executed, $proposal->fresh()->status);
+    }
+
     private function makeProposal(): ActionProposal
     {
         return app(CreateActionProposalAction::class)->execute(


### PR DESCRIPTION
Closes #130.

## Problem

`ExecuteActionProposalJob::handle()` gated only on `status === Approved && executed_at === null`. There was no expiry check there, none in `ActionProposalExecutor`, and `ActionProposal::isExpired()` is pending-gated (`&& $this->isPending()`) so it can never fire for an approved row. `ExpireStaleActionProposalsAction` sweeps only `Pending`.

Net: a proposal approved just before `expires_at` could sit in the queue and still produce a side effect after the window closed.

Practically narrow — TTL is 24h, dispatch is immediate, `tries = 1` — so it needs a last-second approval plus a queue backlog. But side-effecting operations (git push, integration action, tool call) shouldn't rely on the queue draining fast.

## Change

1. **Expiry guard at the execution seam** — past `expires_at` → status `Expired`, `execution_error` set, executor never called. `executed_at` stays null and the proposal keeps its identity, so a redispatch is a no-op (status is no longer `Approved`).
2. **`ToolCallGovernor` now passes the same 24h window.** It was the only one of the four gates creating proposals with `expires_at = NULL` — those had no expiry semantics at all, and the new guard would have been a no-op for them.

## Scope notes

Deliberately **not** in this PR:

- **Re-evaluating the pinned `agent_policy_version_id` at execution.** Re-running `PolicyEvaluator` on a human-approved proposal is semantically wrong — it returns `RequireHuman` for anything not auto-approvable, which would block exactly the legitimate case. Only a narrow "re-check hard deny" would make sense, and that is a separate design question (pinned version or current?).
- **Reverting to `Pending`** (the issue's literal wording). Re-opening a decided proposal from a queue worker is surprising and can loop; `Expired` is the existing explicit non-executable state.

Two parts of the reporter's invariant were **already** satisfied and are unchanged: `tries = 1` plus the `executed_at` check means a retry can't become a second business request, and for `target_type='tool_call'` the executor already re-resolves tools against the actor's current role (role downgrade is caught).

## Verification

- `ExecuteActionProposalJob` is the only caller of `ActionProposalExecutor`, and `DispatchActionProposalExecution` is its only dispatch site — the guard sits at a real chokepoint, no bypass path.
- Checked the sibling `ApprovalRequest` model for the same pattern: no gap. Its side effects run synchronously inside `ApproveAction`, and `ApproveAction:45` requires `Pending`, so an expired request can't be approved.
- 3 new regression tests (past-expiry refusal, open-window execution, null-expiry execution) + expiry assertion on the existing governor test.
- 138 tests passed across `Domain/Approval`, `ToolCallGovernorTest`, `GitOperationGateTest`, `IntegrationActionGateTest`, `ActionProposalMcpToolsTest`, `Livewire/Approvals`. Pint clean, phpstan clean on the touched paths.