### PR TITLE
fix(sentry): drop Redis connect-time failures from the container-restart race

### DIFF
--- a/app/Infrastructure/Sentry/BeforeSendFilter.php
+++ b/app/Infrastructure/Sentry/BeforeSendFilter.php
@@ -6,6 +6,7 @@ use App\Domain\Shared\Exceptions\AiAccessUnavailableException;
 use ErrorException;
 use Illuminate\Database\QueryException;
 use Illuminate\Queue\MaxAttemptsExceededException;
+use Predis\Connection\Resource\Exception\StreamInitException;
 use Sentry\Event;
 use Sentry\EventHint;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyConsoleRuntimeException;
@@ -49,6 +50,29 @@ final class BeforeSendFilter
 
         // SQLSTATE[08006] — postgres connection_failure on container restart race.
         if ($e instanceof QueryException && str_contains($msg, 'SQLSTATE[08006]')) {
+            return null;
+        }
+
+        // Redis unreachable at CONNECT time — the same container-restart race as
+        // 08006 above, for the other datastore (deploy --force-recreate, redis
+        // recreate, DNS not yet resolving). Bursty, not chronic: the 100 most
+        // recent events of #957 fell into three windows (2026-07-21, -07-22,
+        // -08-03) with days of silence between, and 808 events since 2026-07-01
+        // buried the rest of the fleetq project.
+        //
+        // Scoped to StreamInitException on purpose — Predis throws it only from
+        // StreamFactory during stream init, so a read/write error on an already
+        // established connection (a different defect class) still reports.
+        // A SUSTAINED outage stays visible: HealthController pings Redis and
+        // flips /api/v1/health to 503 `degraded`.
+        if ($e instanceof StreamInitException) {
+            return null;
+        }
+
+        // Same restart race reaching the /metrics scrape — the prometheus client
+        // wraps the Redis connect failure in its own storage exception, so the
+        // class check above can't catch it. (#1082)
+        if (str_contains($msg, "Can't connect to Redis server")) {
             return null;
         }
 

--- a/tests/Unit/Infrastructure/Sentry/BeforeSendFilterWebhookTest.php
+++ b/tests/Unit/Infrastructure/Sentry/BeforeSendFilterWebhookTest.php
@@ -5,6 +5,10 @@ namespace Tests\Unit\Infrastructure\Sentry;
 use App\Domain\Shared\Exceptions\AiAccessUnavailableException;
 use App\Infrastructure\Sentry\BeforeSendFilter;
 use PHPUnit\Framework\Attributes\Test;
+use Predis\Connection\ConnectionException;
+use Predis\Connection\Parameters;
+use Predis\Connection\Resource\Exception\StreamInitException;
+use Predis\Connection\StreamConnection;
 use RuntimeException;
 use Sentry\Event;
 use Sentry\EventHint;
@@ -80,6 +84,48 @@ class BeforeSendFilterWebhookTest extends TestCase
         );
 
         $this->assertNull($result);
+    }
+
+    #[Test]
+    public function it_drops_redis_connect_failures_from_the_restart_race(): void
+    {
+        $result = BeforeSendFilter::filter(
+            Event::createEvent(),
+            $this->hintFor(new StreamInitException('Connection refused [tcp://agent-fleet-redis:6379]')),
+        );
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function it_drops_prometheus_redis_connect_failures(): void
+    {
+        $result = BeforeSendFilter::filter(
+            Event::createEvent(),
+            $this->hintFor(new RuntimeException(
+                "Can't connect to Redis server. php_network_getaddresses: getaddrinfo for agent-fleet-redis failed",
+            )),
+        );
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function it_keeps_redis_read_errors_on_established_connections(): void
+    {
+        // The restart-race filter must not swallow this class — a read error on
+        // an open connection is a different defect (fixed separately in 16c2b9f2).
+        $event = Event::createEvent();
+
+        $result = BeforeSendFilter::filter(
+            $event,
+            $this->hintFor(new ConnectionException(
+                new StreamConnection(new Parameters(['host' => 'agent-fleet-redis'])),
+                'read error on connection to agent-fleet-redis:6379',
+            )),
+        );
+
+        $this->assertSame($event, $result);
     }
 
     private function hintFor(\Throwable $e): EventHint


### PR DESCRIPTION
Fixes the noise behind Sentry issue **#957** (`Predis\Connection\Resource\Exception\StreamInitException: Connection refused [tcp://agent-fleet-redis:6379]`) and **#1082** (prometheus client wrapper of the same failure).

## Why this is noise, not an outage

957 has 808 events since 2026-07-01 and was burying the fleetq project. It is **bursty, not chronic** — the 100 most recent events fall into three windows:

| Window | Events |
|---|---|
| 2026-07-21 19Z | 76 |
| 2026-07-22 13Z | 22 |
| 2026-08-03 12Z | 2 |

Days of silence in between. Each burst lines up with a container recreate or redis config change (prod carries a `.env.bak-redis-20260722075736` from the 07-22 window; the 08-03 pair is the deploy of #133). Culprit is `/var/www/artisan` — scheduler and queue workers reconnecting while redis is still coming up.

This is the same failure mode the filter already suppresses for Postgres one branch above:

```php
// SQLSTATE[08006] — postgres connection_failure on container restart race.
```

## Scope — what still reports

Deliberately narrow, because blanket-suppressing Redis errors would hide real defects:

- Matches `StreamInitException` only. Predis throws it **exclusively from `StreamFactory` during stream init**, i.e. connect time. A read/write error on an already-established connection (the class fixed in `16c2b9f2`) is untouched — there is a regression test asserting exactly that.
- A **sustained** outage stays visible: `HealthController` pings Redis and flips `/api/v1/health` to `503 degraded`. Verified in the controller, not assumed.
- The prometheus branch matches by message because the client wraps the failure in its own storage exception class, which the `instanceof` check cannot catch.

## Tests

3 added to `BeforeSendFilterWebhookTest`: drops `StreamInitException`, drops the prometheus wrapper, and **keeps** a `ConnectionException` read error. 9 passed. Pint + phpstan clean on the touched paths.