### PR TITLE
fix(sentry): pass the Throwable so workflow-generation failures are diagnosable

### DIFF
--- a/app/Domain/Workflow/Actions/GenerateWorkflowFromPromptAction.php
+++ b/app/Domain/Workflow/Actions/GenerateWorkflowFromPromptAction.php
@@ -100,8 +100,12 @@ class GenerateWorkflowFromPromptAction
 
             return ['workflow' => $workflow, 'errors' => $errors];
         } catch (\Throwable $e) {
+            // `exception` (the Throwable, not its message) is what makes
+            // sentry-laravel capture this as an exception with a stacktrace
+            // rather than a bare message — see #1035.
             Log::error('GenerateWorkflowFromPromptAction: LLM call failed', [
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return ['workflow' => null, 'errors' => [$e->getMessage()]];


### PR DESCRIPTION
Part of the fleetq unresolved-issue sweep. Addresses Sentry **#1035** (`GenerateWorkflowFromPromptAction: LLM call failed`).

## Problem

The issue arrived at Sentry as a **bare message** — no exception class, no stacktrace, no application context. Verified against the raw event JSON: `context` held only `monolog.channel` / `monolog.level`, and there was no `log_context`, no `error`, no ids.

Cause: the catch block logged `'error' => $e->getMessage()` — a string. `sentry-laravel`'s handler promotes `context['exception']` to `captureException()` (class + stacktrace + grouping) and otherwise falls back to `captureMessage()`:

```php
// vendor/sentry/sentry-laravel/src/Sentry/Laravel/SentryHandler.php:164
$exception = $record['context']['exception'] ?? null;
$isException = $exception instanceof Throwable;
...
$isException ? $this->hub->captureException($exception) : $this->hub->captureMessage(...);
```

**Confirmed by contrast rather than assumption:** of the four unresolved fleetq issues, only #1030 has a stacktrace — and `OidcSocialController` is the only one of the four call sites that already passes `'exception' => $e`. The other three pass a message string and all three are stacktrace-less.

## Change

One key added to the existing context array. No behaviour change, no new branching.

## Scope note

This makes the **next** occurrence diagnosable; it does not root-cause the LLM failure, because the events Sentry holds today contain nothing to root-cause from. Stating that plainly rather than claiming a fix.

The cloud-layer siblings (#824 `BaseStageJob`, #847 `ProcessAssistantMessageJob`) live in `overrides/` in the private repo and are fixed there — their **base** counterparts already call `SentryEventCapturer` with the Throwable, so community edition was never affected.

## Tests

The equivalent assertion (Throwable reaches the log context) is covered on the OIDC path in the private repo — 14 passed there. This action has no existing test harness and mocking the gateway for a one-key context addition would be scaffolding for its own sake, so it ships untested; pint + phpstan clean.