### PR TITLE
fix(sentry): carry the Throwable in swallowed-exception error logs across base

### DIFF
--- a/app/Console/Commands/AutoApproveOnLoopApprovalsCommand.php
+++ b/app/Console/Commands/AutoApproveOnLoopApprovalsCommand.php
@@ -47,6 +47,7 @@ class AutoApproveOnLoopApprovalsCommand extends Command
                 Log::error('AutoApproveOnLoop: failed to auto-approve', [
                     'approval_request_id' => $request->id,
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/app/Console/Commands/PingIntegrations.php
+++ b/app/Console/Commands/PingIntegrations.php
@@ -57,6 +57,7 @@ class PingIntegrations extends Command
                 Log::error('PingIntegrations: unexpected error', [
                     'integration_id' => $integration->getKey(),
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
                 $this->error("✗ {$integration->getAttribute('name')} — {$e->getMessage()}");
             }

--- a/app/Console/Commands/PollInputConnectors.php
+++ b/app/Console/Commands/PollInputConnectors.php
@@ -123,6 +123,7 @@ class PollInputConnectors extends Command
                         'connector_id' => $connector->id,
                         'driver' => $connector->driver,
                         'error' => $e->getMessage(),
+                        'exception' => $e,
                     ]);
 
                     $this->error("  → Error: {$e->getMessage()}");

--- a/app/Console/Commands/PollWorkflowTimeGatesCommand.php
+++ b/app/Console/Commands/PollWorkflowTimeGatesCommand.php
@@ -54,6 +54,7 @@ class PollWorkflowTimeGatesCommand extends Command
                     'step_id' => $step->id,
                     'experiment_id' => $step->experiment_id,
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/app/Console/Commands/RecoverStuckTasks.php
+++ b/app/Console/Commands/RecoverStuckTasks.php
@@ -534,6 +534,7 @@ class RecoverStuckTasks extends Command
             Log::error('RecoverStuckTasks: Failed to auto-pause experiment', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }
@@ -660,6 +661,7 @@ class RecoverStuckTasks extends Command
                 'experiment_id' => $experimentId,
                 'to_state' => $toState->value,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Console/Commands/RefreshExpiringIntegrationTokens.php
+++ b/app/Console/Commands/RefreshExpiringIntegrationTokens.php
@@ -46,6 +46,7 @@ class RefreshExpiringIntegrationTokens extends Command
                     'integration_id' => $integration->getKey(),
                     'driver' => $driver,
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
                 $this->error("{$integration->getAttribute('name')}: {$e->getMessage()}");
             }

--- a/app/Console/Commands/RefreshRedditTokens.php
+++ b/app/Console/Commands/RefreshRedditTokens.php
@@ -43,6 +43,7 @@ class RefreshRedditTokens extends Command
                 Log::error('RefreshRedditTokens: failed', [
                     'credential_id' => $credential->getKey(),
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
                 $this->error("{$credential->getAttribute('name')}: {$e->getMessage()}");
             }

--- a/app/Console/Commands/SyncActivepiecesToolsCommand.php
+++ b/app/Console/Commands/SyncActivepiecesToolsCommand.php
@@ -66,6 +66,7 @@ class SyncActivepiecesToolsCommand extends Command
                 Log::error('SyncActivepiecesToolsCommand: sync failed', [
                     'integration_id' => $integration->getKey(),
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/app/Domain/AgentChatProtocol/Listeners/ExecuteAgentOnChatMessage.php
+++ b/app/Domain/AgentChatProtocol/Listeners/ExecuteAgentOnChatMessage.php
@@ -71,6 +71,7 @@ class ExecuteAgentOnChatMessage implements ShouldQueue
             Log::error('Agent chat protocol execution failed', [
                 'message_id' => $message->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $message->forceFill([
                 'status' => MessageStatus::Failed,

--- a/app/Domain/Approval/Actions/CompleteHumanTaskAction.php
+++ b/app/Domain/Approval/Actions/CompleteHumanTaskAction.php
@@ -199,6 +199,7 @@ class CompleteHumanTaskAction
                 'step_id' => $step->id,
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Approval/Actions/CreateHumanTaskAction.php
+++ b/app/Domain/Approval/Actions/CreateHumanTaskAction.php
@@ -192,6 +192,7 @@ class CreateHumanTaskAction
             Log::error('CreateHumanTaskAction: failed to continue workflow after auto-approval', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Budget/Listeners/PauseOnBudgetExceeded.php
+++ b/app/Domain/Budget/Listeners/PauseOnBudgetExceeded.php
@@ -62,6 +62,7 @@ class PauseOnBudgetExceeded
             Log::error('PauseOnBudgetExceeded: Failed to auto-pause', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Chatbot/Jobs/ExecuteChatbotWorkflowJob.php
+++ b/app/Domain/Chatbot/Jobs/ExecuteChatbotWorkflowJob.php
@@ -76,6 +76,7 @@ class ExecuteChatbotWorkflowJob implements ShouldQueue
                 'chatbot_id' => $this->chatbotId,
                 'message_id' => $this->messageId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Chatbot/Jobs/IndexGitRepositoryJob.php
+++ b/app/Domain/Chatbot/Jobs/IndexGitRepositoryJob.php
@@ -82,6 +82,7 @@ class IndexGitRepositoryJob implements ShouldQueue
             Log::error('IndexGitRepositoryJob failed', [
                 'source_id' => $source->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $source->update([
                 'status' => KnowledgeSourceStatus::Failed,

--- a/app/Domain/Chatbot/Jobs/ProcessChatbotSlackMessageJob.php
+++ b/app/Domain/Chatbot/Jobs/ProcessChatbotSlackMessageJob.php
@@ -92,6 +92,7 @@ class ProcessChatbotSlackMessageJob implements ShouldQueue
             Log::error('ProcessChatbotSlackMessageJob: response error', [
                 'chatbot_id' => $this->chatbotId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $this->postToSlack($botToken, $this->slackChannelId, 'I encountered an error. Please try again.');
 

--- a/app/Domain/Chatbot/Jobs/ProcessChatbotTelegramMessageJob.php
+++ b/app/Domain/Chatbot/Jobs/ProcessChatbotTelegramMessageJob.php
@@ -95,6 +95,7 @@ class ProcessChatbotTelegramMessageJob implements ShouldQueue
             Log::error('ProcessChatbotTelegramMessageJob: response error', [
                 'chatbot_id' => $this->chatbotId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $sendReply->execute($botToken, $this->chatId, 'I encountered an error processing your message. Please try again.');
 

--- a/app/Domain/Chatbot/Jobs/ProcessChatbotTicketMessageJob.php
+++ b/app/Domain/Chatbot/Jobs/ProcessChatbotTicketMessageJob.php
@@ -80,6 +80,7 @@ class ProcessChatbotTicketMessageJob implements ShouldQueue
                 'chatbot_id' => $this->chatbotId,
                 'ticket_id' => $this->ticketId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Chatbot/Jobs/ProcessChatbotWebhookMessageJob.php
+++ b/app/Domain/Chatbot/Jobs/ProcessChatbotWebhookMessageJob.php
@@ -76,6 +76,7 @@ class ProcessChatbotWebhookMessageJob implements ShouldQueue
             Log::error('ProcessChatbotWebhookMessageJob: response service failed', [
                 'chatbot_id' => $this->chatbotId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Crew/Jobs/CoordinatorDecisionJob.php
+++ b/app/Domain/Crew/Jobs/CoordinatorDecisionJob.php
@@ -179,6 +179,7 @@ class CoordinatorDecisionJob implements ShouldQueue
             Log::error('Coordinator decision failed', [
                 'execution_id' => $this->crewExecutionId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             $execution->update([

--- a/app/Domain/Crew/Jobs/ExecuteCrewTaskJob.php
+++ b/app/Domain/Crew/Jobs/ExecuteCrewTaskJob.php
@@ -198,6 +198,7 @@ class ExecuteCrewTaskJob implements ShouldQueue
             'task_id' => $this->taskExecutionId,
             'execution_id' => $this->crewExecutionId,
             'error' => $exception->getMessage(),
+            'exception' => $exception,
         ]);
     }
 }

--- a/app/Domain/Crew/Jobs/ValidateCrewTaskJob.php
+++ b/app/Domain/Crew/Jobs/ValidateCrewTaskJob.php
@@ -81,6 +81,7 @@ class ValidateCrewTaskJob implements ShouldQueue
                 'task_id' => $this->taskExecutionId,
                 'execution_id' => $this->crewExecutionId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             // QA agent failure is serious — fail the task
@@ -99,6 +100,7 @@ class ValidateCrewTaskJob implements ShouldQueue
             'task_id' => $this->taskExecutionId,
             'execution_id' => $this->crewExecutionId,
             'error' => $exception->getMessage(),
+            'exception' => $exception,
         ]);
     }
 }

--- a/app/Domain/Crew/Services/CrewExternalMemberDispatcher.php
+++ b/app/Domain/Crew/Services/CrewExternalMemberDispatcher.php
@@ -74,6 +74,7 @@ class CrewExternalMemberDispatcher
                 'task_id' => $task->id,
                 'external_agent_id' => $externalAgent->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             $task->update([

--- a/app/Domain/Crew/Services/CrewOrchestrator.php
+++ b/app/Domain/Crew/Services/CrewOrchestrator.php
@@ -89,6 +89,7 @@ class CrewOrchestrator
             Log::error('Crew orchestration failed', [
                 'execution_id' => $execution->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             if (isset($scope)) {

--- a/app/Domain/Evaluation/Jobs/ExecuteFlowEvaluationJob.php
+++ b/app/Domain/Evaluation/Jobs/ExecuteFlowEvaluationJob.php
@@ -45,6 +45,7 @@ class ExecuteFlowEvaluationJob implements ShouldQueue
             Log::error('ExecuteFlowEvaluationJob failed', [
                 'run_id' => $this->runId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             $run->update([

--- a/app/Domain/Experiment/Listeners/CollectWorkflowArtifactsOnCompletion.php
+++ b/app/Domain/Experiment/Listeners/CollectWorkflowArtifactsOnCompletion.php
@@ -39,6 +39,7 @@ class CollectWorkflowArtifactsOnCompletion
             Log::error('CollectWorkflowArtifactsOnCompletion: Failed to collect artifacts', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
 

--- a/app/Domain/Experiment/Listeners/HandleStuckPattern.php
+++ b/app/Domain/Experiment/Listeners/HandleStuckPattern.php
@@ -66,6 +66,7 @@ class HandleStuckPattern
             Log::error('StuckPatternDetected: failed to pause experiment', [
                 'experiment_id' => $event->experimentId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }
@@ -88,6 +89,7 @@ class HandleStuckPattern
             Log::error('StuckPatternDetected: failed to kill experiment', [
                 'experiment_id' => $event->experimentId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Experiment/Listeners/ResumeParentOnSubWorkflowComplete.php
+++ b/app/Domain/Experiment/Listeners/ResumeParentOnSubWorkflowComplete.php
@@ -83,6 +83,7 @@ class ResumeParentOnSubWorkflowComplete
                 Log::error('ResumeParentOnSubWorkflowComplete: failed to continue parent', [
                     'parent_id' => $parentExperiment->id,
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }
@@ -166,6 +167,7 @@ class ResumeParentOnSubWorkflowComplete
             Log::error('ResumeParentOnSubWorkflowComplete: failed to continue parent after fork', [
                 'parent_id' => $parentExperiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Experiment/Pipeline/BaseStageJob.php
+++ b/app/Domain/Experiment/Pipeline/BaseStageJob.php
@@ -431,6 +431,7 @@ abstract class BaseStageJob implements HasSentryContext, ShouldQueue
                 Log::error('BaseStageJob: Failed to transition to failed state', [
                     'experiment_id' => $this->experimentId,
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/app/Domain/Experiment/Pipeline/PlaybookExecutor.php
+++ b/app/Domain/Experiment/Pipeline/PlaybookExecutor.php
@@ -207,6 +207,7 @@ class PlaybookExecutor
                 'experiment_id' => $experimentId,
                 'group_index' => $completedGroupIndex,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             self::onGroupFailed($experimentId);
@@ -232,6 +233,7 @@ class PlaybookExecutor
             Log::error('PlaybookExecutor: onGroupFailed failed', [
                 'experiment_id' => $experimentId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }
@@ -255,6 +257,7 @@ class PlaybookExecutor
             Log::error('PlaybookExecutor: Failed to transition after playbook completion', [
                 'experiment_id' => $experimentId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Experiment/Pipeline/RunBuildingStage.php
+++ b/app/Domain/Experiment/Pipeline/RunBuildingStage.php
@@ -265,6 +265,7 @@ class RunBuildingStage extends BaseStageJob
                                 Log::error('RunBuildingStage: Failed to transition to BuildingFailed', [
                                     'experiment_id' => $experimentId,
                                     'error' => $e->getMessage(),
+                                    'exception' => $e,
                                 ]);
                             }
                         }

--- a/app/Domain/Project/Actions/ScheduleProjectFromNaturalLanguageAction.php
+++ b/app/Domain/Project/Actions/ScheduleProjectFromNaturalLanguageAction.php
@@ -71,6 +71,7 @@ class ScheduleProjectFromNaturalLanguageAction
             Log::error('ScheduleProjectFromNaturalLanguageAction: failed', [
                 'error' => $e->getMessage(),
                 'title' => $title,
+                'exception' => $e,
             ]);
 
             return json_encode(['error' => $e->getMessage()]);

--- a/app/Domain/Project/Jobs/DeliverWorkflowResultsJob.php
+++ b/app/Domain/Project/Jobs/DeliverWorkflowResultsJob.php
@@ -99,6 +99,7 @@ class DeliverWorkflowResultsJob implements ShouldQueue
                 'run_id' => $run->id,
                 'channel' => $channel,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Project/Jobs/DispatchScheduledProjectsJob.php
+++ b/app/Domain/Project/Jobs/DispatchScheduledProjectsJob.php
@@ -60,7 +60,10 @@ class DispatchScheduledProjectsJob implements ShouldQueue
                     Log::info("Heartbeat triggered run for project {$project->id}");
                 }
             } catch (\Throwable $e) {
-                Log::error("Heartbeat failed for project {$project->id}: {$e->getMessage()}");
+                Log::error("Heartbeat failed for project {$project->id}: {$e->getMessage()}", [
+                    'project_id' => $project->id,
+                    'exception' => $e,
+                ]);
             }
         }
     }

--- a/app/Domain/Shared/Actions/InitializeTeamKeyEscrowAction.php
+++ b/app/Domain/Shared/Actions/InitializeTeamKeyEscrowAction.php
@@ -48,6 +48,7 @@ class InitializeTeamKeyEscrowAction
             Log::error('Failed to initialize team key escrow', [
                 'team_id' => $team->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return null;

--- a/app/Domain/Signal/Jobs/RefreshExpiringWebhooksJob.php
+++ b/app/Domain/Signal/Jobs/RefreshExpiringWebhooksJob.php
@@ -94,6 +94,7 @@ class RefreshExpiringWebhooksJob implements ShouldQueue
                 'subscription_id' => $subscription->id,
                 'driver' => $subscription->driver,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Signal/Listeners/ReDelegateOnReporterFollowupListener.php
+++ b/app/Domain/Signal/Listeners/ReDelegateOnReporterFollowupListener.php
@@ -92,6 +92,7 @@ class ReDelegateOnReporterFollowupListener
                 'signal_id' => $signal->id,
                 'comment_id' => $comment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return;

--- a/app/Domain/Signal/Services/IntegrationSignalBridge.php
+++ b/app/Domain/Signal/Services/IntegrationSignalBridge.php
@@ -76,6 +76,7 @@ class IntegrationSignalBridge
                 'subscription_id' => $subscription->id,
                 'driver' => $subscription->driver,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return 0;

--- a/app/Domain/Skill/Actions/ProposeNewSkillFromExperimentAction.php
+++ b/app/Domain/Skill/Actions/ProposeNewSkillFromExperimentAction.php
@@ -176,6 +176,7 @@ class ProposeNewSkillFromExperimentAction
             Log::error('ProposeNewSkillFromExperimentAction: LLM synthesis failed', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return null;

--- a/app/Domain/Skill/Jobs/ProposeNewSkillFromExperimentJob.php
+++ b/app/Domain/Skill/Jobs/ProposeNewSkillFromExperimentJob.php
@@ -54,6 +54,7 @@ class ProposeNewSkillFromExperimentJob implements ShouldQueue
             Log::error('ProposeNewSkillFromExperimentJob: Failed', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Skill/Jobs/SkillImprovementIterationJob.php
+++ b/app/Domain/Skill/Jobs/SkillImprovementIterationJob.php
@@ -81,6 +81,7 @@ class SkillImprovementIterationJob implements ShouldQueue
             Log::error('SkillImprovementIterationJob: unrecoverable error', [
                 'benchmark_id' => $this->benchmarkId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             // The RunSkillIterationAction already catches per-iteration errors and logs them.
@@ -112,6 +113,7 @@ class SkillImprovementIterationJob implements ShouldQueue
         Log::error('SkillImprovementIterationJob failed', [
             'benchmark_id' => $this->benchmarkId,
             'error' => $exception->getMessage(),
+            'exception' => $exception,
         ]);
     }
 }

--- a/app/Domain/Skill/Services/AutoSkillCreationService.php
+++ b/app/Domain/Skill/Services/AutoSkillCreationService.php
@@ -204,6 +204,7 @@ class AutoSkillCreationService
                 'team_id' => $teamId,
                 'cluster_size' => count($cluster),
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return null;

--- a/app/Domain/Trigger/Jobs/EvaluateTriggerRulesJob.php
+++ b/app/Domain/Trigger/Jobs/EvaluateTriggerRulesJob.php
@@ -77,6 +77,7 @@ class EvaluateTriggerRulesJob implements ShouldQueue
                     'rule_id' => $rule->id,
                     'signal_id' => $signal->id,
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/app/Domain/Website/Actions/GenerateWebsiteWithCrewAction.php
+++ b/app/Domain/Website/Actions/GenerateWebsiteWithCrewAction.php
@@ -70,6 +70,7 @@ class GenerateWebsiteWithCrewAction
             Log::error('GenerateWebsiteWithCrewAction: crew setup failed', [
                 'website_id' => $website->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             // Fall back to draft so the user can retry

--- a/app/Domain/Website/Actions/MaterializeWebsiteFromCrewAction.php
+++ b/app/Domain/Website/Actions/MaterializeWebsiteFromCrewAction.php
@@ -72,6 +72,7 @@ class MaterializeWebsiteFromCrewAction
                 'execution_id' => $execution->id,
                 'website_id' => $website->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             $website->update(['status' => WebsiteStatus::Draft, 'name' => 'Generated Website']);

--- a/app/Domain/Workflow/Actions/DispatchSubWorkflowAction.php
+++ b/app/Domain/Workflow/Actions/DispatchSubWorkflowAction.php
@@ -106,6 +106,7 @@ class DispatchSubWorkflowAction
             Log::error('DispatchSubWorkflowAction: failed to spawn sub-workflow', [
                 'step_id' => $step->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             $step->update([

--- a/app/Domain/Workflow/Actions/DynamicForkFanOutAction.php
+++ b/app/Domain/Workflow/Actions/DynamicForkFanOutAction.php
@@ -162,6 +162,7 @@ class DynamicForkFanOutAction
             Log::error('DynamicForkFanOutAction: failed to spawn fan-out', [
                 'step_id' => $step->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             $step->update([

--- a/app/Domain/Workflow/Executors/BitbucketPrMergeNodeExecutor.php
+++ b/app/Domain/Workflow/Executors/BitbucketPrMergeNodeExecutor.php
@@ -96,6 +96,7 @@ class BitbucketPrMergeNodeExecutor implements NodeExecutorInterface
             Log::error('BitbucketPrMergeNodeExecutor: unexpected error', [
                 'pr_url' => $prUrl,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return [

--- a/app/Domain/Workflow/Jobs/ExecuteCompensationJob.php
+++ b/app/Domain/Workflow/Jobs/ExecuteCompensationJob.php
@@ -81,6 +81,7 @@ class ExecuteCompensationJob implements ShouldQueue
                 'compensation_node_id' => $this->compensationNodeId,
                 'original_step_id' => $this->originalStepId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Workflow/Services/WorkflowGraphExecutor.php
+++ b/app/Domain/Workflow/Services/WorkflowGraphExecutor.php
@@ -186,6 +186,7 @@ class WorkflowGraphExecutor
                     Log::error('WorkflowGraphExecutor: Transition failed', [
                         'experiment_id' => $experiment->id,
                         'error' => $e->getMessage(),
+                        'exception' => $e,
                     ]);
                 }
             }
@@ -349,6 +350,7 @@ class WorkflowGraphExecutor
                 'node_id' => $nodeId,
                 'ref_workflow_id' => $refWorkflowId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $step = $ctx->steps[$nodeId] ?? null;
             if ($step) {
@@ -672,6 +674,7 @@ class WorkflowGraphExecutor
             Log::error('WorkflowGraphExecutor: continueAfterBatch failed', [
                 'experiment_id' => $experimentId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             self::handleBatchFailureStatic($experimentId);
@@ -710,6 +713,7 @@ class WorkflowGraphExecutor
             Log::error('WorkflowGraphExecutor: handleBatchFailure failed', [
                 'experiment_id' => $experimentId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Domain/Workflow/Services/WorkflowNodeDispatcher.php
+++ b/app/Domain/Workflow/Services/WorkflowNodeDispatcher.php
@@ -132,6 +132,7 @@ class WorkflowNodeDispatcher
                 'step_id' => $step->id,
                 'node_type' => $nodeType,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $step->update([
                 'status' => 'failed',
@@ -171,6 +172,7 @@ class WorkflowNodeDispatcher
             Log::error('WorkflowGraphExecutor: Failed to create human task', [
                 'step_id' => $step->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $step->update([
                 'status' => 'failed',
@@ -188,6 +190,7 @@ class WorkflowNodeDispatcher
             Log::error('WorkflowGraphExecutor: Failed to activate time gate', [
                 'step_id' => $step->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $step->update([
                 'status' => 'failed',
@@ -205,6 +208,7 @@ class WorkflowNodeDispatcher
             Log::error('WorkflowGraphExecutor: Failed to dispatch sub-workflow', [
                 'step_id' => $step->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
             $step->update([
                 'status' => 'failed',

--- a/app/Domain/Workflow/Services/WorkflowSuggestionEngine.php
+++ b/app/Domain/Workflow/Services/WorkflowSuggestionEngine.php
@@ -76,6 +76,7 @@ class WorkflowSuggestionEngine
             Log::error('WorkflowSuggestionEngine: LLM call failed', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             // Fallback: rule-based suggestions without LLM

--- a/app/Http/Controllers/Api/V1/BridgeController.php
+++ b/app/Http/Controllers/Api/V1/BridgeController.php
@@ -418,6 +418,7 @@ class BridgeController extends Controller
             Log::error('BridgeController: MCP call exception', [
                 'request_id' => $requestId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return response()->json([
@@ -475,6 +476,7 @@ class BridgeController extends Controller
                 'bridge_id' => $bridge->id,
                 'endpoint_url' => $bridge->endpoint_url,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return response()->json([
@@ -566,6 +568,7 @@ class BridgeController extends Controller
                 'bridge_id' => $bridge->id,
                 'endpoint_url' => $bridge->endpoint_url,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return response()->json([

--- a/app/Http/Controllers/TrackingController.php
+++ b/app/Http/Controllers/TrackingController.php
@@ -75,6 +75,7 @@ class TrackingController extends Controller
                 Log::error('TrackingController: Failed to record click', [
                     'error' => $e->getMessage(),
                     'experiment_id' => $experimentId,
+                    'exception' => $e,
                 ]);
             }
         }
@@ -128,6 +129,7 @@ class TrackingController extends Controller
                 Log::error('TrackingController: Failed to record open', [
                     'error' => $e->getMessage(),
                     'experiment_id' => $experimentId,
+                    'exception' => $e,
                 ]);
             }
         }

--- a/app/Infrastructure/AI/LoopDetection/Listeners/HandleAgentLoop.php
+++ b/app/Infrastructure/AI/LoopDetection/Listeners/HandleAgentLoop.php
@@ -70,6 +70,7 @@ class HandleAgentLoop
             Log::error('LoopDetection: failed to '.$action.' experiment', [
                 'experiment_id' => $experiment->id,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Jobs/Middleware/CheckKmsAvailable.php
+++ b/app/Jobs/Middleware/CheckKmsAvailable.php
@@ -49,6 +49,7 @@ class CheckKmsAvailable
                 'provider' => $e->provider ?? 'unknown',
                 'reason' => $e->getMessage(),
                 'job' => class_basename($job),
+                'exception' => $e,
             ]);
 
             $this->notifyTeamAdmins($teamId, $e->getMessage());

--- a/app/Jobs/VerifyBorunaBundlesBatchJob.php
+++ b/app/Jobs/VerifyBorunaBundlesBatchJob.php
@@ -55,6 +55,7 @@ class VerifyBorunaBundlesBatchJob implements ShouldQueue
                 Log::error('Boruna bundle verification threw exception', [
                     'decision_id' => $decision->id,
                     'error' => $e->getMessage(),
+                    'exception' => $e,
                 ]);
             }
         }

--- a/app/Listeners/Alerts/SendAlertEmail.php
+++ b/app/Listeners/Alerts/SendAlertEmail.php
@@ -33,6 +33,7 @@ final class SendAlertEmail
             Log::error('SendAlertEmail: failed to dispatch PlatformAlert mail', [
                 'rule' => $event->rule->metricName,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Livewire/Experiments/ExperimentTasksPanel.php
+++ b/app/Livewire/Experiments/ExperimentTasksPanel.php
@@ -37,6 +37,7 @@ class ExperimentTasksPanel extends Component
                 'experiment_id' => $this->experiment->id,
                 'step_id' => $stepId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Livewire/Experiments/WorkflowProgressPanel.php
+++ b/app/Livewire/Experiments/WorkflowProgressPanel.php
@@ -93,6 +93,7 @@ class WorkflowProgressPanel extends Component
                 'experiment_id' => $this->experimentId,
                 'step_id' => $stepId,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
         }
     }

--- a/app/Mcp/Tools/Assistant/AssistantConversationCompactTool.php
+++ b/app/Mcp/Tools/Assistant/AssistantConversationCompactTool.php
@@ -64,6 +64,7 @@ class AssistantConversationCompactTool extends Tool
             Log::error('AssistantConversationCompactTool: compaction failed', [
                 'conversation_id' => $request->get('conversation_id'),
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return $this->errorResponse(AppMcpErrorCode::Internal, 'Compaction failed. Please try again.');

--- a/app/Mcp/Tools/Signal/WebclawCrawlTool.php
+++ b/app/Mcp/Tools/Signal/WebclawCrawlTool.php
@@ -112,6 +112,7 @@ class WebclawCrawlTool extends Tool
             Log::error('WebclawCrawlTool: Error crawling URL', [
                 'url' => $url,
                 'error' => $e->getMessage(),
+                'exception' => $e,
             ]);
 
             return $this->internalError('Crawl failed: '.$e->getMessage());


### PR DESCRIPTION
Completes the instrumentation sweep behind #824 / #847 / #1035, which arrived at Sentry as bare messages — no exception class, no stacktrace, no context.

`sentry-laravel` promotes a `context['exception']` that is a `Throwable` to `captureException()`; anything else becomes `captureMessage()`:

```php
// vendor/sentry/sentry-laravel/src/Sentry/Laravel/SentryHandler.php:164
$exception = $record['context']['exception'] ?? null;
$isException ? $this->hub->captureException($exception) : $this->hub->captureMessage(...);
```

## Scope: 77 sites, 61 files

All of them **catch-and-swallow** paths in FleetQ's own logic — pipeline, workflow, crew, skill, project, chatbot, approval, listeners, console commands, controllers. Where the log is the only thing Sentry ever sees, it now carries the Throwable.

## Deliberately left alone

**34 sites where the failure is a third party, not a FleetQ defect.** A stacktrace-carrying issue there is pure noise, which is the opposite of the goal:

`Domain/Signal/Connectors` (24) · `Domain/Outbound/Connectors` · `Domain/Tool/Services` (MCP clients) · `Infrastructure/Bridge` · Telegram / Webhook / Integration delivery actions · the Helicone pricing fetch · the OpenAI embedding call.

**Sites that rethrow** are also untouched — the framework handler already captures those, so adding the key would duplicate the event. Same reasoning as base `BaseStageJob`, which keeps its `SentryEventCapturer` call separate from the log.

## Correctness of a 77-site mechanical edit

The first pass used a line-window heuristic to find the enclosing `catch`, which bound `$e` in three `failed(\Throwable $exception)` methods where the catch above had already closed scope — phpstan caught them as `Undefined variable: $e` (Crew Execute/Validate jobs, `SkillImprovementIterationJob`). Fixed.

Because phpstan only catches the case where the variable does not exist at all, **every one of the 77 insertions was then verified programmatically** to bind the variable of its own enclosing `catch (...)` or `failed(Throwable $x)` parameter. Zero mismatches remain.

## Verification

- **Full base suite: 4856 passed**, 15 skipped, 0 failures
- phpstan: 0 new errors; the 14 that remain are pre-existing and confirmed to be in files this PR does not touch (optional `Webklex\PHPIMAP` package + unrelated Mcp property access)
- pint clean