### PR TITLE
fix(queue): prune the failed_jobs table on a schedule

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -113,6 +113,11 @@ Schedule::command('marketplace:aggregate-quality')->everySixHours();
 // Prune growing tables: llm_request_logs (30d), semantic_cache_entries (expired+90d), assistant_messages (90d)
 Schedule::command('model:prune')->dailyAt('04:00');
 
+// failed_jobs was never pruned and had grown to 1916 rows on production (oldest
+// 2026-04) — every row a resolved incident, drowning the recent ones that still
+// matter. 30 days is long enough to investigate a failure after the fact.
+Schedule::command('queue:prune-failed --hours=720')->dailyAt('04:15');
+
 // Version update check
 Schedule::command('system:check-updates')->hourly()->runInBackground();
 


### PR DESCRIPTION
## Finding

`failed_jobs` on production holds **1916 rows**, oldest from **2026-04**, and had never been pruned — there is no `queue:prune-failed` anywhere in the scheduler.

This is not cosmetic. `queue:failed` prints the tail, so the table reads as "a few old entries from April" when it is actually nearly two thousand rows spanning four months. That is exactly how the recent, still-relevant failures get missed.

## Change

```php
Schedule::command('queue:prune-failed --hours=720')->dailyAt('04:15');
```

30 days is long enough to investigate a failure after the fact. Verified the entry registers on the container: `15 4 * * * php artisan queue:prune-failed --hours=720 — Next Due: 19 hours`. The first run prunes the backlog; no manual deletion of production rows needed.

## What the failures actually were (validated, not assumed)

17 failures since 2026-07-24:

| Job | Count | Last | Status |
|---|---|---|---|
| `DistillTeamEventsJob` (`AiAccessUnavailableException` + a 401 `x-api-key header is required`) | 15 | 2026-07-29 | fixed by #131 (2026-08-01) |
| `RunPlanningStage` (AI access, then MaxAttempts) | 2 | 2026-07-28 | same root cause |
| `BuildArtifactJob` (`tool call validation failed … /max_steps`) | 1 | 2026-08-04 | fixed by #136 |

The distill job ran nightly at 01:31 and failed every night from 2026-06-25 to 2026-07-29, then stopped.

**"Stopped failing" was checked against "stopped running":** `memory:distill-events` is still registered (`30 1 * * *`, next due in 16h), so the six clean nights since are the fix working, not a job that quietly fell out of the schedule.

Older classes in the table follow the same shape — each stops at the date its fix shipped (e.g. 39 × `ExperimentTransitioned | BroadcastException` ending 2026-06-29).

## Verification

pint + phpstan clean; schedule entry confirmed live on the production container.