### PR TITLE
fix(memory): team-scoped memories were never stored — null agent_id threw a swallowed TypeError

### DIFF
--- a/app/Domain/Memory/Actions/StoreMemoryAction.php
+++ b/app/Domain/Memory/Actions/StoreMemoryAction.php
@@ -163,7 +163,7 @@ PROMPT;
      */
     private function storeChunk(
         string $teamId,
-        string $agentId,
+        ?string $agentId,
         string $chunk,
         string $sourceType,
         ?string $projectId,
@@ -225,7 +225,7 @@ PROMPT;
      */
     private function evaluateWriteGate(
         string $teamId,
-        string $agentId,
+        ?string $agentId,
         string $contentHash,
         string $embedding,
     ): WriteGateResult {
@@ -304,7 +304,7 @@ PROMPT;
         string $newContent,
         string $newEmbedding,
         string $teamId,
-        string $agentId,
+        ?string $agentId,
         float $newConfidence,
         float $newImportance,
         array $newTags,
@@ -347,7 +347,7 @@ PROMPT;
 
     private function handleAdd(
         string $teamId,
-        string $agentId,
+        ?string $agentId,
         string $chunk,
         string $embedding,
         string $contentHash,
@@ -409,7 +409,7 @@ PROMPT;
     /**
      * LLM-assisted merge of two related facts.
      */
-    private function mergeContent(string $existing, string $new, string $teamId, string $agentId): ?string
+    private function mergeContent(string $existing, string $new, string $teamId, ?string $agentId): ?string
     {
         if (! $this->gateway) {
             return null;

--- a/tests/Unit/Domain/Memory/Actions/StoreMemoryActionTest.php
+++ b/tests/Unit/Domain/Memory/Actions/StoreMemoryActionTest.php
@@ -35,6 +35,28 @@ class StoreMemoryActionTest extends TestCase
         $this->assertStringContainsString('A', $chunks[0]);
     }
 
+    public function test_team_level_memory_accepts_a_null_agent_id(): void
+    {
+        // execute() advertises `?string $agentId`, but storeChunk() and the
+        // write-gate helpers below it declared a non-nullable `string`. Every
+        // team-scoped write — DistillTeamEventsAction passes `agentId: null`
+        // explicitly — therefore threw a TypeError that execute()'s catch
+        // swallowed into a Log::warning, so nothing was ever stored and no
+        // error surfaced. Production had 0 rows in `memories`.
+        $action = new StoreMemoryAction;
+
+        foreach (['storeChunk', 'evaluateWriteGate', 'handleUpdate', 'handleAdd', 'mergeContent'] as $name) {
+            $param = collect((new \ReflectionMethod($action, $name))->getParameters())
+                ->firstWhere(fn (\ReflectionParameter $p) => $p->getName() === 'agentId');
+
+            $this->assertNotNull($param, "{$name}() should take an \$agentId");
+            $this->assertTrue(
+                $param->getType()?->allowsNull(),
+                "{$name}() must accept a null \$agentId — team-scoped memories have no agent",
+            );
+        }
+    }
+
     public function test_execute_returns_empty_array_when_content_is_empty(): void
     {
         $action = new StoreMemoryAction;


### PR DESCRIPTION
## The bug

`StoreMemoryAction::execute()` advertises `?string $agentId`, but `storeChunk()` and every write-gate helper below it declared a **non-nullable** `string`. Any team-scoped write throws:

```
StoreMemoryAction::storeChunk(): Argument #2 ($agentId) must be of type string,
null given, called in .../StoreMemoryAction.php on line 88
```

`execute()` wraps the chunk loop in `try/catch` and logs that at **WARNING**, so it never surfaced anywhere: the job reports success, the distillation watermark advances past the events, and nothing is stored. Silent, permanent data loss for every team-level memory.

`DistillTeamEventsAction` passes `agentId: null` explicitly, so the nightly digest has never worked.

## Reproduced on production

```
memories total: 0            # zero rows, ever
```

A live distil run for a real team:

```
{"team_id":"019cb001…","events":61,"stored":0,"window_start":"2026-08-03T09:09:20+00:00"}
memories before=0  after=0
```

…while the model had produced a perfectly good 625-character digest, and the gateway, embeddings and config were all healthy. Calling `StoreMemoryAction::execute(agentId: null)` directly reproduced the exact TypeError above in the swallowed warning.

## Fix

Widen `$agentId` to `?string` through `storeChunk`, `evaluateWriteGate`, `handleUpdate`, `handleAdd`, `mergeContent`.

The `where('agent_id', $agentId)` lookups need no change — Laravel's `where()` maps a null value to `whereNull`.

## How it was found

By validating the `failed_jobs` backlog rather than accepting that the recent silence meant the failures were fixed. The nightly `DistillTeamEventsJob` failures stopped on 2026-07-29 — **two days before** the fix that supposedly addressed them (#131, 2026-08-01), so that fix could not be the reason. Chasing the real reason led here.

Worth noting: #131 made the *symptom* quiet by catching `AiAccessUnavailableException` and advancing the watermark. This PR fixes the case where there is no exception to catch at all.

## Verification

- 196 tests pass across `Unit/Domain/Memory` + `Feature/Domain/Memory`
- Regression test asserts all five signatures accept a null `$agentId`
- pint clean; phpstan reports zero errors in the touched files (the 73 in that path are pre-existing — identical count with the change stashed)