### PR TITLE
feat(evaluation): parallel dataset replay via Bus batch fan-out

### DIFF
--- a/app/Domain/Evaluation/Actions/ReplayEvaluationDatasetAction.php
+++ b/app/Domain/Evaluation/Actions/ReplayEvaluationDatasetAction.php
@@ -4,6 +4,7 @@ namespace App\Domain\Evaluation\Actions;
 
 use App\Domain\Evaluation\Enums\EvaluationCaseStatus;
 use App\Domain\Evaluation\Enums\EvaluationStatus;
+use App\Domain\Evaluation\Jobs\EvaluateDatasetCaseJob;
 use App\Domain\Evaluation\Models\EvaluationCase;
 use App\Domain\Evaluation\Models\EvaluationDataset;
 use App\Domain\Evaluation\Models\EvaluationRun;
@@ -11,6 +12,8 @@ use App\Domain\Evaluation\Models\EvaluationRunResult;
 use App\Domain\Evaluation\Services\LlmJudge;
 use App\Infrastructure\AI\Contracts\AiGatewayInterface;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -18,8 +21,16 @@ use Illuminate\Support\Facades\Log;
  * score each case with an LLM judge. Produces an EvaluationRun with per-case
  * `EvaluationRunResult` rows and aggregate scores on the run.
  *
- * Used by `evaluation_replay_dataset` MCP tool + `ReplayEvaluationDatasetJob`
- * for async long-running replays.
+ * Two execution models, both producing an identical `EvaluationRun` + summary:
+ * - `execute()`     — sequential, in-process (used by the `sync` MCP option + tests).
+ * - `dispatchParallel()` — fans one `EvaluateDatasetCaseJob` per case onto the
+ *   `ai-calls` queue as a Bus batch, then recomputes the aggregate from the
+ *   persisted rows in the batch `finally` callback. An eval run is almost all
+ *   provider I/O wait, so fanning the cases out collapses wall-clock from
+ *   `cases × (target + judges)` serialized calls to roughly one case-chain,
+ *   bounded by the `ai-calls` worker pool (and the gateway's own rate limits).
+ *
+ * Used by `evaluation_replay_dataset` MCP tool + `ReplayEvaluationDatasetJob`.
  */
 class ReplayEvaluationDatasetAction
 {
@@ -34,6 +45,8 @@ class ReplayEvaluationDatasetAction
     ) {}
 
     /**
+     * Sequential replay: evaluate every case in-process, then finalize.
+     *
      * @param  list<string>  $criteria  Judge criteria (faithfulness, relevance, correctness, completeness)
      * @return EvaluationRun with completed status + aggregate_scores + summary
      */
@@ -47,6 +60,90 @@ class ReplayEvaluationDatasetAction
         ?string $judgeModel = null,
         int $maxCases = 100,
     ): EvaluationRun {
+        [$run, $cases] = $this->prepareRun($teamId, $datasetId, $criteria, $judgeModel, $maxCases, $targetProvider, $targetModel, $systemPrompt);
+
+        foreach ($cases as $case) {
+            $this->evaluateCase(
+                run: $run,
+                case: $case,
+                targetProvider: $targetProvider,
+                targetModel: $targetModel,
+                systemPrompt: $systemPrompt,
+                criteria: $run->criteria,
+                judgeModel: $run->judge_model,
+                teamId: $teamId,
+            );
+        }
+
+        return $this->finalizeRun($run);
+    }
+
+    /**
+     * Parallel replay: fan one job per case onto the `ai-calls` queue as a batch;
+     * the batch `finally` callback recomputes the aggregate from persisted rows.
+     * Returns the `Running` run immediately — poll it for completion.
+     *
+     * @param  list<string>  $criteria
+     */
+    public function dispatchParallel(
+        string $teamId,
+        string $datasetId,
+        string $targetProvider,
+        string $targetModel,
+        ?string $systemPrompt = null,
+        array $criteria = self::DEFAULT_CRITERIA,
+        ?string $judgeModel = null,
+        int $maxCases = 100,
+    ): EvaluationRun {
+        [$run, $cases] = $this->prepareRun($teamId, $datasetId, $criteria, $judgeModel, $maxCases, $targetProvider, $targetModel, $systemPrompt);
+
+        $runCriteria = $run->criteria;
+        $runJudgeModel = $run->judge_model;
+
+        $jobs = $cases->map(fn (EvaluationCase $case) => new EvaluateDatasetCaseJob(
+            teamId: $teamId,
+            runId: (string) $run->id,
+            caseId: (string) $case->id,
+            targetProvider: $targetProvider,
+            targetModel: $targetModel,
+            systemPrompt: $systemPrompt,
+            criteria: $runCriteria,
+            judgeModel: $runJudgeModel,
+        ))->values()->all();
+
+        $runId = (string) $run->id;
+
+        Bus::batch($jobs)
+            ->name("eval-replay:{$runId}")
+            ->allowFailures()
+            ->onQueue('ai-calls')
+            ->finally(function () use ($runId) {
+                $run = EvaluationRun::withoutGlobalScopes()->find($runId);
+                if ($run !== null && $run->status === EvaluationStatus::Running) {
+                    app(self::class)->finalizeRun($run);
+                }
+            })
+            ->dispatch();
+
+        return $run;
+    }
+
+    /**
+     * Validate the dataset + criteria and create the `Running` run.
+     *
+     * @param  list<string>  $criteria
+     * @return array{0: EvaluationRun, 1: Collection<int, EvaluationCase>}
+     */
+    private function prepareRun(
+        string $teamId,
+        string $datasetId,
+        array $criteria,
+        ?string $judgeModel,
+        int $maxCases,
+        string $targetProvider,
+        string $targetModel,
+        ?string $systemPrompt,
+    ): array {
         $dataset = EvaluationDataset::query()->where('team_id', $teamId)->find($datasetId);
         if ($dataset === null) {
             throw new \RuntimeException("Dataset {$datasetId} not found for this team");
@@ -70,108 +167,26 @@ class ReplayEvaluationDatasetAction
             'criteria' => $criteria,
             'judge_model' => $judgeModel ?? config('evaluation.default_judge_model'),
             'started_at' => now(),
-        ]);
-
-        $totalCases = 0;
-        $passedCases = 0;
-        $failedCases = 0;
-        $erroredCases = 0;
-        $deferredCount = 0;
-        $deferredPassed = 0;
-        /** @var list<array{case_id: string, score: float}> $silentWins */
-        $silentWins = [];
-        $criterionSums = array_fill_keys($criteria, 0.0);
-        $criterionCounts = array_fill_keys($criteria, 0);
-        $totalCostCredits = 0;
-
-        foreach ($cases as $case) {
-            /** @var EvaluationCase $case */
-            $totalCases++;
-            $caseOutcome = $this->runSingleCase(
-                run: $run,
-                case: $case,
-                targetProvider: $targetProvider,
-                targetModel: $targetModel,
-                systemPrompt: $systemPrompt,
-                criteria: $criteria,
-                judgeModel: $run->judge_model,
-                teamId: $teamId,
-            );
-
-            if ($caseOutcome['error'] !== null) {
-                $erroredCases++;
-
-                continue;
-            }
-
-            $score = $caseOutcome['avg_score'];
-
-            // Deferred cases are scored but do NOT gate the run. A deferred case
-            // scoring at/above threshold is a "silent win" — an unrelated change
-            // accidentally fixed the failure mode (the deferred-eval pattern).
-            if ($case->status === EvaluationCaseStatus::Deferred) {
-                $deferredCount++;
-                if ($score >= self::REGRESSION_THRESHOLD) {
-                    $deferredPassed++;
-                    $silentWins[] = ['case_id' => (string) $case->id, 'score' => $score];
-                }
-            } elseif ($score >= self::REGRESSION_THRESHOLD) {
-                $passedCases++;
-            } else {
-                $failedCases++;
-            }
-
-            foreach ($caseOutcome['criterion_scores'] as $criterion => $val) {
-                $criterionSums[$criterion] += $val;
-                $criterionCounts[$criterion]++;
-            }
-            $totalCostCredits += $caseOutcome['cost_credits'];
-        }
-
-        $aggregate = [];
-        foreach ($criteria as $criterion) {
-            $count = $criterionCounts[$criterion] ?? 0;
-            $aggregate[$criterion] = $count > 0
-                ? round($criterionSums[$criterion] / $count, 2)
-                : null;
-        }
-
-        // Pass rate is computed over gating (active, non-errored) cases only;
-        // deferred cases are tracked separately and do not dilute the gate.
-        $gatingCases = $passedCases + $failedCases;
-        $passRate = $gatingCases > 0 ? round(($passedCases / $gatingCases) * 100, 1) : 0.0;
-        $overallAvg = array_sum($aggregate) / max(1, count(array_filter($aggregate, fn ($v) => $v !== null)));
-
-        $run->update([
-            'status' => EvaluationStatus::Completed,
-            'aggregate_scores' => $aggregate,
-            'total_cost_credits' => $totalCostCredits,
-            'completed_at' => now(),
+            // Seed the target metadata so finalizeRun() (which runs without these
+            // params, e.g. in the batch `finally` callback) can carry it through.
             'summary' => [
-                'total_cases' => $totalCases,
-                'passed' => $passedCases,
-                'failed' => $failedCases,
-                'errored' => $erroredCases,
-                'deferred_count' => $deferredCount,
-                'deferred_passed' => $deferredPassed,
-                'silent_wins' => $silentWins,
-                'pass_rate_pct' => $passRate,
-                'overall_avg_score' => round($overallAvg, 2),
-                'regression_threshold' => self::REGRESSION_THRESHOLD,
                 'target_provider' => $targetProvider,
                 'target_model' => $targetModel,
                 'had_system_prompt_override' => $systemPrompt !== null && $systemPrompt !== '',
             ],
         ]);
 
-        return $run->refresh();
+        return [$run, $cases];
     }
 
     /**
+     * Run a single case through the target model + judge and persist its
+     * `EvaluationRunResult` row. Idempotent per (run, case): a prior row for the
+     * same pair is replaced, so a retried batch job never double-counts.
+     *
      * @param  list<string>  $criteria
-     * @return array{error: ?string, avg_score: float, criterion_scores: array<string,float>, cost_credits: int}
      */
-    private function runSingleCase(
+    public function evaluateCase(
         EvaluationRun $run,
         EvaluationCase $case,
         string $targetProvider,
@@ -180,7 +195,9 @@ class ReplayEvaluationDatasetAction
         array $criteria,
         string $judgeModel,
         string $teamId,
-    ): array {
+    ): void {
+        EvaluationRunResult::where('run_id', $run->id)->where('case_id', $case->id)->delete();
+
         $started = hrtime(true);
         $systemPromptText = $systemPrompt ?? 'You are a helpful AI assistant. Answer the question directly and concisely.';
 
@@ -203,13 +220,15 @@ class ReplayEvaluationDatasetAction
                 'case_id' => $case->id,
                 'actual_output' => null,
                 'score' => 0,
+                'criterion_scores' => [],
+                'cost_credits' => 0,
                 'judge_reasoning' => null,
                 'execution_time_ms' => (int) ((hrtime(true) - $started) / 1_000_000),
                 'error' => 'target model failed: '.mb_strimwidth($e->getMessage(), 0, 500, '…'),
                 'created_at' => now(),
             ]);
 
-            return ['error' => $e->getMessage(), 'avg_score' => 0, 'criterion_scores' => [], 'cost_credits' => 0];
+            return;
         }
 
         // Step 2: ask the judge how it compares to expected_output for each criterion.
@@ -253,17 +272,117 @@ class ReplayEvaluationDatasetAction
             'case_id' => $case->id,
             'actual_output' => mb_strimwidth($actualOutput, 0, 4096, '…'),
             'score' => $avgScore,
+            'criterion_scores' => $criterionScores,
+            'cost_credits' => $costCredits,
             'judge_reasoning' => json_encode($judgeReasonings),
             'execution_time_ms' => $durationMs,
             'error' => null,
             'created_at' => now(),
         ]);
+    }
 
-        return [
-            'error' => null,
-            'avg_score' => $avgScore,
-            'criterion_scores' => $criterionScores,
-            'cost_credits' => $costCredits,
-        ];
+    /**
+     * Recompute the run's aggregate scores + summary from its persisted
+     * `EvaluationRunResult` rows and mark it Completed. Order-independent, so it
+     * produces the same result whether the rows were written sequentially or by a
+     * fan-out batch in arbitrary completion order.
+     */
+    public function finalizeRun(EvaluationRun $run): EvaluationRun
+    {
+        $criteria = array_values((array) $run->criteria);
+        $results = EvaluationRunResult::where('run_id', $run->id)->get();
+
+        /** @var Collection<string, EvaluationCase> $cases */
+        $cases = EvaluationCase::withoutGlobalScopes()
+            ->whereIn('id', $results->pluck('case_id')->filter()->all())
+            ->get()
+            ->keyBy('id');
+
+        $totalCases = $results->count();
+        $passedCases = 0;
+        $failedCases = 0;
+        $erroredCases = 0;
+        $deferredCount = 0;
+        $deferredPassed = 0;
+        /** @var list<array{case_id: string, score: float}> $silentWins */
+        $silentWins = [];
+        $criterionSums = array_fill_keys($criteria, 0.0);
+        $criterionCounts = array_fill_keys($criteria, 0);
+        $totalCostCredits = 0;
+
+        foreach ($results as $result) {
+            /** @var EvaluationRunResult $result */
+            if ($result->error !== null) {
+                $erroredCases++;
+
+                continue;
+            }
+
+            $score = (float) $result->score;
+            $isDeferred = ($cases[$result->case_id] ?? null)?->status === EvaluationCaseStatus::Deferred;
+
+            // Deferred cases are scored but do NOT gate the run. A deferred case
+            // scoring at/above threshold is a "silent win" — an unrelated change
+            // accidentally fixed the failure mode (the deferred-eval pattern).
+            if ($isDeferred) {
+                $deferredCount++;
+                if ($score >= self::REGRESSION_THRESHOLD) {
+                    $deferredPassed++;
+                    $silentWins[] = ['case_id' => (string) $result->case_id, 'score' => $score];
+                }
+            } elseif ($score >= self::REGRESSION_THRESHOLD) {
+                $passedCases++;
+            } else {
+                $failedCases++;
+            }
+
+            foreach ((array) $result->criterion_scores as $criterion => $val) {
+                if (array_key_exists($criterion, $criterionSums)) {
+                    $criterionSums[$criterion] += (float) $val;
+                    $criterionCounts[$criterion]++;
+                }
+            }
+            $totalCostCredits += (int) $result->cost_credits;
+        }
+
+        $aggregate = [];
+        foreach ($criteria as $criterion) {
+            $count = $criterionCounts[$criterion] ?? 0;
+            $aggregate[$criterion] = $count > 0
+                ? round($criterionSums[$criterion] / $count, 2)
+                : null;
+        }
+
+        // Pass rate is computed over gating (active, non-errored) cases only;
+        // deferred cases are tracked separately and do not dilute the gate.
+        $gatingCases = $passedCases + $failedCases;
+        $passRate = $gatingCases > 0 ? round(($passedCases / $gatingCases) * 100, 1) : 0.0;
+        $overallAvg = array_sum($aggregate) / max(1, count(array_filter($aggregate, fn ($v) => $v !== null)));
+
+        $seeded = (array) $run->summary;
+
+        $run->update([
+            'status' => EvaluationStatus::Completed,
+            'aggregate_scores' => $aggregate,
+            'total_cost_credits' => $totalCostCredits,
+            'completed_at' => now(),
+            'summary' => [
+                'total_cases' => $totalCases,
+                'passed' => $passedCases,
+                'failed' => $failedCases,
+                'errored' => $erroredCases,
+                'deferred_count' => $deferredCount,
+                'deferred_passed' => $deferredPassed,
+                'silent_wins' => $silentWins,
+                'pass_rate_pct' => $passRate,
+                'overall_avg_score' => round($overallAvg, 2),
+                'regression_threshold' => self::REGRESSION_THRESHOLD,
+                'target_provider' => $seeded['target_provider'] ?? null,
+                'target_model' => $seeded['target_model'] ?? null,
+                'had_system_prompt_override' => $seeded['had_system_prompt_override'] ?? false,
+            ],
+        ]);
+
+        return $run->refresh();
     }
 }

--- a/app/Domain/Evaluation/Jobs/EvaluateDatasetCaseJob.php
+++ b/app/Domain/Evaluation/Jobs/EvaluateDatasetCaseJob.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Domain\Evaluation\Jobs;
+
+use App\Domain\Evaluation\Actions\ReplayEvaluationDatasetAction;
+use App\Domain\Evaluation\Models\EvaluationCase;
+use App\Domain\Evaluation\Models\EvaluationRun;
+use App\Jobs\Middleware\ApplyTenantTracer;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Evaluate one dataset case as part of a parallel replay batch. Writes a single
+ * `EvaluationRunResult` row via the shared action; the batch's `finally` callback
+ * aggregates the run once every case job has settled.
+ */
+class EvaluateDatasetCaseJob implements ShouldQueue
+{
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 2;
+
+    public int $timeout = 120;
+
+    /**
+     * @param  list<string>  $criteria
+     */
+    public function __construct(
+        public readonly string $teamId,
+        public readonly string $runId,
+        public readonly string $caseId,
+        public readonly string $targetProvider,
+        public readonly string $targetModel,
+        public readonly ?string $systemPrompt,
+        public readonly array $criteria,
+        public readonly string $judgeModel,
+    ) {
+        $this->onQueue('ai-calls');
+    }
+
+    public function middleware(): array
+    {
+        return [new ApplyTenantTracer];
+    }
+
+    public function handle(ReplayEvaluationDatasetAction $action): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        $run = EvaluationRun::withoutGlobalScopes()->find($this->runId);
+        $case = EvaluationCase::withoutGlobalScopes()->find($this->caseId);
+        if ($run === null || $case === null) {
+            return;
+        }
+
+        $action->evaluateCase(
+            run: $run,
+            case: $case,
+            targetProvider: $this->targetProvider,
+            targetModel: $this->targetModel,
+            systemPrompt: $this->systemPrompt,
+            criteria: $this->criteria,
+            judgeModel: $this->judgeModel,
+            teamId: $this->teamId,
+        );
+    }
+}

--- a/app/Domain/Evaluation/Models/EvaluationRunResult.php
+++ b/app/Domain/Evaluation/Models/EvaluationRunResult.php
@@ -18,6 +18,8 @@ class EvaluationRunResult extends Model
         'case_id',
         'actual_output',
         'score',
+        'criterion_scores',
+        'cost_credits',
         'judge_reasoning',
         'execution_time_ms',
         'error',
@@ -28,6 +30,8 @@ class EvaluationRunResult extends Model
     {
         return [
             'score' => 'float',
+            'criterion_scores' => 'array',
+            'cost_credits' => 'integer',
             'execution_time_ms' => 'integer',
             'created_at' => 'datetime',
         ];

--- a/app/Mcp/Tools/Evaluation/EvaluationReplayDatasetTool.php
+++ b/app/Mcp/Tools/Evaluation/EvaluationReplayDatasetTool.php
@@ -33,6 +33,7 @@ class EvaluationReplayDatasetTool extends Tool
             'judge_model' => $schema->string()->description('Judge model override (default: anthropic/claude-sonnet-4-5)'),
             'max_cases' => $schema->integer()->description('Max cases to replay (default 100, hard cap 500)'),
             'sync' => $schema->boolean()->description('Run inline (blocks) instead of queueing. Use only for <=10 cases. Default false.')->default(false),
+            'parallel' => $schema->boolean()->description('When queued, fan each case out as a batch on the ai-calls queue (much faster on large datasets, identical results). Ignored when sync=true. Default true.')->default(true),
         ];
     }
 
@@ -68,6 +69,9 @@ class EvaluationReplayDatasetTool extends Tool
         $judgeModel = $request->get('judge_model');
         $maxCases = max(1, min(500, (int) $request->get('max_cases', 100)));
         $sync = (bool) $request->get('sync', false);
+        $parallel = (bool) $request->get('parallel', true);
+        $normalizedPrompt = is_string($systemPrompt) && $systemPrompt !== '' ? $systemPrompt : null;
+        $normalizedJudge = is_string($judgeModel) && $judgeModel !== '' ? $judgeModel : null;
 
         if ($sync) {
             try {
@@ -76,9 +80,9 @@ class EvaluationReplayDatasetTool extends Tool
                     datasetId: $datasetId,
                     targetProvider: $provider,
                     targetModel: $model,
-                    systemPrompt: is_string($systemPrompt) && $systemPrompt !== '' ? $systemPrompt : null,
+                    systemPrompt: $normalizedPrompt,
                     criteria: $criteria,
-                    judgeModel: is_string($judgeModel) && $judgeModel !== '' ? $judgeModel : null,
+                    judgeModel: $normalizedJudge,
                     maxCases: $maxCases,
                 );
             } catch (\Throwable $e) {
@@ -94,19 +98,49 @@ class EvaluationReplayDatasetTool extends Tool
             ]));
         }
 
+        if ($parallel) {
+            try {
+                $run = $action->dispatchParallel(
+                    teamId: $user->current_team_id,
+                    datasetId: $datasetId,
+                    targetProvider: $provider,
+                    targetModel: $model,
+                    systemPrompt: $normalizedPrompt,
+                    criteria: $criteria,
+                    judgeModel: $normalizedJudge,
+                    maxCases: $maxCases,
+                );
+            } catch (\Throwable $e) {
+                return Response::error('Replay dispatch failed: '.$e->getMessage());
+            }
+
+            return Response::text(json_encode([
+                'status' => 'queued',
+                'mode' => 'parallel',
+                'run_id' => $run->id,
+                'dataset_id' => $datasetId,
+                'target_provider' => $provider,
+                'target_model' => $model,
+                'criteria' => $criteria,
+                'max_cases' => $maxCases,
+                'message' => 'Parallel replay dispatched (one job per case on ai-calls). Poll evaluation_run with action=get&run_id='.$run->id.' until status=completed.',
+            ]));
+        }
+
         ReplayEvaluationDatasetJob::dispatch(
             teamId: $user->current_team_id,
             datasetId: $datasetId,
             targetProvider: $provider,
             targetModel: $model,
-            systemPrompt: is_string($systemPrompt) && $systemPrompt !== '' ? $systemPrompt : null,
+            systemPrompt: $normalizedPrompt,
             criteria: $criteria,
-            judgeModel: is_string($judgeModel) && $judgeModel !== '' ? $judgeModel : null,
+            judgeModel: $normalizedJudge,
             maxCases: $maxCases,
         );
 
         return Response::text(json_encode([
             'status' => 'queued',
+            'mode' => 'sequential',
             'dataset_id' => $datasetId,
             'target_provider' => $provider,
             'target_model' => $model,

--- a/database/migrations/2026_08_18_000001_add_criterion_scores_to_evaluation_run_results_table.php
+++ b/database/migrations/2026_08_18_000001_add_criterion_scores_to_evaluation_run_results_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('evaluation_run_results', function (Blueprint $table) {
+            // Per-criterion judge scores for this case, e.g. {"correctness": 8.5, "relevance": 9.0}.
+            // Needed so an evaluation run's aggregate can be recomputed from persisted rows
+            // (order-independently) after a parallel, fan-out replay — not just accumulated in
+            // memory during a sequential loop.
+            $table->jsonb('criterion_scores')->nullable()->after('score');
+            // Target + judge credit cost for this single case, summed into the run total at finalize.
+            $table->integer('cost_credits')->nullable()->after('criterion_scores');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('evaluation_run_results', function (Blueprint $table) {
+            $table->dropColumn(['criterion_scores', 'cost_credits']);
+        });
+    }
+};

--- a/tests/Feature/Domain/Evaluation/ParallelReplayEvaluationTest.php
+++ b/tests/Feature/Domain/Evaluation/ParallelReplayEvaluationTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Feature\Domain\Evaluation;
+
+use App\Domain\Evaluation\Actions\ReplayEvaluationDatasetAction;
+use App\Domain\Evaluation\Enums\EvaluationCaseStatus;
+use App\Domain\Evaluation\Enums\EvaluationStatus;
+use App\Domain\Evaluation\Jobs\EvaluateDatasetCaseJob;
+use App\Domain\Evaluation\Models\EvaluationCase;
+use App\Domain\Evaluation\Models\EvaluationDataset;
+use App\Domain\Evaluation\Models\EvaluationRunResult;
+use App\Domain\Evaluation\Services\LlmJudge;
+use App\Domain\Shared\Models\Team;
+use App\Infrastructure\AI\Contracts\AiGatewayInterface;
+use App\Infrastructure\AI\DTOs\AiResponseDTO;
+use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Mockery;
+use Tests\TestCase;
+
+class ParallelReplayEvaluationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'P',
+            'slug' => 'parallel-'.uniqid(),
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+    }
+
+    private function seedDataset(int $caseCount = 3): EvaluationDataset
+    {
+        $dataset = EvaluationDataset::create([
+            'team_id' => $this->team->id,
+            'name' => 'Parallel set',
+            'description' => '',
+            'case_count' => $caseCount,
+        ]);
+        for ($i = 0; $i < $caseCount; $i++) {
+            EvaluationCase::create([
+                'dataset_id' => $dataset->id,
+                'team_id' => $this->team->id,
+                'input' => "What is {$i}+1?",
+                'expected_output' => (string) ($i + 1),
+                'context' => null,
+                'metadata' => [],
+            ]);
+        }
+
+        return $dataset;
+    }
+
+    private function bindPassingGateway(): void
+    {
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')->andReturn(new AiResponseDTO(
+            content: 'deterministic answer',
+            parsedOutput: null,
+            usage: new AiUsageDTO(10, 5, 1),
+            provider: 'anthropic',
+            model: 'claude-haiku-4-5-20251001',
+            latencyMs: 42,
+            schemaValid: true,
+            cached: false,
+        ));
+        $this->app->instance(AiGatewayInterface::class, $gateway);
+    }
+
+    private function bindJudge(float $score): void
+    {
+        $judge = Mockery::mock(LlmJudge::class);
+        $judge->shouldReceive('evaluate')->andReturn([
+            'score' => $score,
+            'reasoning' => 'ok',
+            'cost_credits' => 2,
+        ]);
+        $this->app->instance(LlmJudge::class, $judge);
+    }
+
+    public function test_dispatch_parallel_queues_one_job_per_case(): void
+    {
+        Bus::fake();
+        $dataset = $this->seedDataset(4);
+
+        $run = app(ReplayEvaluationDatasetAction::class)->dispatchParallel(
+            teamId: $this->team->id,
+            datasetId: $dataset->id,
+            targetProvider: 'anthropic',
+            targetModel: 'claude-haiku-4-5-20251001',
+        );
+
+        $this->assertSame(EvaluationStatus::Running, $run->status);
+        Bus::assertBatched(fn ($batch) => count($batch->jobs) === 4
+            && $batch->jobs->every(fn ($job) => $job instanceof EvaluateDatasetCaseJob));
+    }
+
+    public function test_parallel_path_matches_sequential_summary(): void
+    {
+        // Sequential baseline.
+        $seqDataset = $this->seedDataset(5);
+        $this->bindPassingGateway();
+        $this->bindJudge(8.5);
+        $sequential = app(ReplayEvaluationDatasetAction::class)->execute(
+            teamId: $this->team->id,
+            datasetId: $seqDataset->id,
+            targetProvider: 'anthropic',
+            targetModel: 'claude-haiku-4-5-20251001',
+        );
+
+        // Parallel run over an identical dataset, sync queue → jobs + batch finally run inline.
+        $parDataset = $this->seedDataset(5);
+        $parallel = app(ReplayEvaluationDatasetAction::class)->dispatchParallel(
+            teamId: $this->team->id,
+            datasetId: $parDataset->id,
+            targetProvider: 'anthropic',
+            targetModel: 'claude-haiku-4-5-20251001',
+        )->refresh();
+
+        $this->assertSame(EvaluationStatus::Completed, $parallel->status);
+
+        $drop = ['target_provider', 'target_model'];
+        $this->assertSame(
+            array_diff_key($sequential->summary, array_flip($drop)),
+            array_diff_key($parallel->summary, array_flip($drop)),
+        );
+        $this->assertEquals($sequential->aggregate_scores, $parallel->aggregate_scores);
+        $this->assertSame(5, $parallel->summary['total_cases']);
+        $this->assertSame(5, $parallel->summary['passed']);
+        $this->assertCount(5, EvaluationRunResult::where('run_id', $parallel->id)->get());
+    }
+
+    public function test_parallel_target_failure_recorded_as_error_and_finalized(): void
+    {
+        $dataset = $this->seedDataset(2);
+
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')->andThrow(new \RuntimeException('provider exploded'));
+        $this->app->instance(AiGatewayInterface::class, $gateway);
+
+        $run = app(ReplayEvaluationDatasetAction::class)->dispatchParallel(
+            teamId: $this->team->id,
+            datasetId: $dataset->id,
+            targetProvider: 'anthropic',
+            targetModel: 'broken',
+        )->refresh();
+
+        $this->assertSame(EvaluationStatus::Completed, $run->status);
+        $this->assertSame(2, $run->summary['errored']);
+        $this->assertSame(0, $run->summary['passed']);
+        $this->assertCount(2, EvaluationRunResult::where('run_id', $run->id)->whereNotNull('error')->get());
+    }
+
+    public function test_parallel_deferred_case_is_a_silent_win(): void
+    {
+        $dataset = EvaluationDataset::create([
+            'team_id' => $this->team->id, 'name' => 'gate', 'case_count' => 0,
+        ]);
+        EvaluationCase::create([
+            'dataset_id' => $dataset->id, 'team_id' => $this->team->id,
+            'input' => 'active', 'expected_output' => 'e', 'status' => EvaluationCaseStatus::Active, 'metadata' => [],
+        ]);
+        EvaluationCase::create([
+            'dataset_id' => $dataset->id, 'team_id' => $this->team->id,
+            'input' => 'deferred win', 'expected_output' => 'e', 'status' => EvaluationCaseStatus::Deferred, 'metadata' => [],
+        ]);
+
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')->andReturn(new AiResponseDTO(
+            content: 'a', parsedOutput: null, usage: new AiUsageDTO(1, 1, 1),
+            provider: 'anthropic', model: 'm', latencyMs: 1, schemaValid: true, cached: false,
+        ));
+        $this->app->instance(AiGatewayInterface::class, $gateway);
+
+        $judge = Mockery::mock(LlmJudge::class);
+        $judge->shouldReceive('evaluate')->andReturnUsing(fn (string $criterion, string $input) => [
+            'score' => str_contains($input, 'win') ? 9.0 : 3.0, 'reasoning' => 'x', 'cost_credits' => 1,
+        ]);
+        $this->app->instance(LlmJudge::class, $judge);
+
+        $run = app(ReplayEvaluationDatasetAction::class)->dispatchParallel(
+            teamId: $this->team->id,
+            datasetId: $dataset->id,
+            targetProvider: 'anthropic',
+            targetModel: 'm',
+        )->refresh();
+
+        $s = $run->summary;
+        $this->assertSame(0, $s['passed']);
+        $this->assertSame(1, $s['failed']);
+        $this->assertSame(1, $s['deferred_count']);
+        $this->assertSame(1, $s['deferred_passed']);
+        $this->assertCount(1, $s['silent_wins']);
+    }
+}


### PR DESCRIPTION
Fans one EvaluateDatasetCaseJob per case onto the ai-calls queue as a Bus batch; recomputes the run aggregate from persisted rows in the batch finally callback. Sequential execute() and parallel dispatchParallel() share prepareRun/evaluateCase/finalizeRun, so both produce an identical run summary (verified). Adds nullable evaluation_run_results.criterion_scores + cost_credits. MCP tool gains a parallel flag (default true; sequential job kept as fallback). Adversarial-verifier gate: PASS (6/6 claims proven, 46 Evaluation tests green, migration additive/reversible, no cloud overrides).