### PR TITLE
fix(ai): stop retired model IDs from opening the provider circuit breaker

### DIFF
--- a/app/Infrastructure/AI/Gateways/FallbackAiGateway.php
+++ b/app/Infrastructure/AI/Gateways/FallbackAiGateway.php
@@ -208,13 +208,14 @@ class FallbackAiGateway implements AiGatewayInterface
                     'error' => $e->getMessage(),
                 ]);
             } catch (Throwable $e) {
-                // Auth errors (401 / missing or revoked key) are config errors disguised
-                // as provider failures — let the chain advance without breaking the
-                // circuit. Mirrors the \RuntimeException branch above.
-                if ($this->isAuthError($e)) {
+                // Auth errors (401 / missing or revoked key) and retired model IDs
+                // are config errors disguised as provider failures — let the chain
+                // advance without breaking the circuit. Mirrors the \RuntimeException
+                // branch above.
+                if ($this->isAuthError($e) || $this->isModelUnavailableError($e)) {
                     $firstException ??= $e;
                     $lastException = $e;
-                    Log::warning("AI Gateway fallback: {$providerName}/{$modelName} auth error (not recording CB failure)", [
+                    Log::warning("AI Gateway fallback: {$providerName}/{$modelName} config error (not recording CB failure)", [
                         'error' => $e->getMessage(),
                     ]);
 
@@ -399,10 +400,10 @@ class FallbackAiGateway implements AiGatewayInterface
                     'error' => $e->getMessage(),
                 ]);
             } catch (Throwable $e) {
-                if ($this->isAuthError($e)) {
+                if ($this->isAuthError($e) || $this->isModelUnavailableError($e)) {
                     $firstException ??= $e;
                     $lastException = $e;
-                    Log::warning("AI Gateway stream fallback: {$providerName}/{$modelName} auth error (not recording CB failure)", [
+                    Log::warning("AI Gateway stream fallback: {$providerName}/{$modelName} config error (not recording CB failure)", [
                         'error' => $e->getMessage(),
                     ]);
 
@@ -574,6 +575,22 @@ class FallbackAiGateway implements AiGatewayInterface
             || str_contains($msg, 'API key not valid')
             || (str_contains($msg, '[401]') && str_contains($msg, 'Anthropic'))
             || (str_contains($msg, 'status code 401'));
+    }
+
+    /**
+     * A retired or mistyped model ID (Groq 404, OpenAI/OpenRouter "not a valid model")
+     * never recovers on retry, and the breaker is keyed per PROVIDER — so letting one
+     * stale model config open it takes the provider down for every other team and
+     * fires a CRITICAL platform alert. Treat it as config error, like auth.
+     */
+    private function isModelUnavailableError(Throwable $e): bool
+    {
+        $msg = $e->getMessage();
+
+        return str_contains($msg, 'does not exist or you do not have access to it')
+            || str_contains($msg, 'is not a valid model ID')
+            || str_contains($msg, 'model_not_found')
+            || str_contains($msg, 'The model `');
     }
 
     /**

--- a/config/llm_pricing.php
+++ b/config/llm_pricing.php
@@ -223,12 +223,8 @@ return [
         ],
 
         'groq' => [
-            'llama-3.3-70b-versatile' => ['tier' => 'default', 'input_usd_per_mtok' => 0.59, 'output_usd_per_mtok' => 0.79, 'context_window' => 128_000, 'last_verified_at' => '2026-05-04'],
-            'llama-3.1-8b-instant' => ['tier' => 'nano', 'input_usd_per_mtok' => 0.05, 'output_usd_per_mtok' => 0.08, 'context_window' => 128_000, 'last_verified_at' => '2026-05-04'],
-            'llama-4-scout-17b-16e' => ['tier' => 'default', 'input_usd_per_mtok' => 0.11, 'output_usd_per_mtok' => 0.34, 'context_window' => 128_000, 'last_verified_at' => '2026-05-04'],
-            'gemma2-9b-it' => ['tier' => 'nano', 'input_usd_per_mtok' => 0.20, 'output_usd_per_mtok' => 0.20, 'context_window' => 8_192, 'last_verified_at' => '2026-05-04'],
-            'qwen-qwq-32b' => ['tier' => 'heavy', 'input_usd_per_mtok' => 0.29, 'output_usd_per_mtok' => 0.39, 'context_window' => 128_000, 'last_verified_at' => '2026-05-04'],
-            'mixtral-8x7b-32768' => ['tier' => 'default', 'input_usd_per_mtok' => 0.24, 'output_usd_per_mtok' => 0.24, 'context_window' => 32_768, 'last_verified_at' => '2026-05-04'],
+            'openai/gpt-oss-120b' => ['tier' => 'default', 'input_usd_per_mtok' => 0.15, 'output_usd_per_mtok' => 0.60, 'context_window' => 131_072, 'last_verified_at' => '2026-08-19'],
+            'openai/gpt-oss-20b' => ['tier' => 'nano', 'input_usd_per_mtok' => 0.075, 'output_usd_per_mtok' => 0.30, 'context_window' => 131_072, 'last_verified_at' => '2026-08-19'],
         ],
 
         'mistral' => [
@@ -329,8 +325,8 @@ return [
         'gpt-5-nano' => 128_000,
         'gemini-2.5-flash' => 1_048_576,
         'gemini-2.5-pro' => 1_048_576,
-        'llama-3.3-70b-versatile' => 128_000,
-        'llama-3.1-8b-instant' => 128_000,
+        'openai/gpt-oss-120b' => 131_072,
+        'openai/gpt-oss-20b' => 131_072,
         'mistral-large-latest' => 128_000,
         'mistral-small-latest' => 32_000,
     ],

--- a/config/llm_providers.php
+++ b/config/llm_providers.php
@@ -26,12 +26,10 @@ return [
     'groq' => [
         'name' => 'Groq',
         'models' => [
-            'llama-3.3-70b-versatile' => ['label' => 'Llama 3.3 70B', 'input_cost' => 0.59, 'output_cost' => 0.79],
-            'llama-3.1-8b-instant' => ['label' => 'Llama 3.1 8B', 'input_cost' => 0.05, 'output_cost' => 0.08],
-            'llama-4-scout-17b-16e' => ['label' => 'Llama 4 Scout', 'input_cost' => 0.11, 'output_cost' => 0.34],
-            'gemma2-9b-it' => ['label' => 'Gemma 2 9B', 'input_cost' => 0.20, 'output_cost' => 0.20],
-            'qwen-qwq-32b' => ['label' => 'Qwen QwQ 32B', 'input_cost' => 0.29, 'output_cost' => 0.39],
-            'mixtral-8x7b-32768' => ['label' => 'Mixtral 8x7B', 'input_cost' => 0.24, 'output_cost' => 0.24],
+            // Groq shut down the Llama 3.x IDs on 2026-08-16; only the GPT OSS
+            // pair remains a production (non-preview) text model on GroqCloud.
+            'openai/gpt-oss-120b' => ['label' => 'GPT OSS 120B', 'input_cost' => 0.15, 'output_cost' => 0.60],
+            'openai/gpt-oss-20b' => ['label' => 'GPT OSS 20B', 'input_cost' => 0.075, 'output_cost' => 0.30],
         ],
     ],
     'openrouter' => [

--- a/tests/Unit/Infrastructure/AI/FallbackGatewayModelUnavailableTest.php
+++ b/tests/Unit/Infrastructure/AI/FallbackGatewayModelUnavailableTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\AI;
+
+use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\Gateways\FallbackAiGateway;
+use App\Infrastructure\AI\Gateways\PrismAiGateway;
+use App\Infrastructure\AI\Services\CircuitBreaker;
+use Exception;
+use Tests\TestCase;
+
+class FallbackGatewayModelUnavailableTest extends TestCase
+{
+    private PrismAiGateway $gateway;
+
+    private CircuitBreaker $circuitBreaker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->gateway = $this->createMock(PrismAiGateway::class);
+        $this->circuitBreaker = $this->createMock(CircuitBreaker::class);
+
+        config(['services.groq.key' => 'gsk-test']);
+    }
+
+    private function makeRequest(): AiRequestDTO
+    {
+        return new AiRequestDTO(
+            provider: 'groq',
+            model: 'llama-3.3-70b-versatile',
+            systemPrompt: 'test',
+            userPrompt: 'test',
+        );
+    }
+
+    public function test_retired_model_id_does_not_open_the_circuit(): void
+    {
+        $fallbackGateway = new FallbackAiGateway($this->gateway, $this->circuitBreaker, []);
+
+        $this->circuitBreaker->method('isAvailable')->willReturn(true);
+        $this->circuitBreaker->expects($this->never())->method('recordFailure');
+
+        $this->gateway->method('complete')->willThrowException(new Exception(
+            'Groq Error [404]: invalid_request_error - The model `llama-3.3-70b-versatile` does not exist or you do not have access to it.'
+        ));
+
+        $this->expectException(Exception::class);
+        $fallbackGateway->complete($this->makeRequest());
+    }
+
+    public function test_genuine_provider_failure_still_opens_the_circuit(): void
+    {
+        $fallbackGateway = new FallbackAiGateway($this->gateway, $this->circuitBreaker, []);
+
+        $this->circuitBreaker->method('isAvailable')->willReturn(true);
+        $this->circuitBreaker->expects($this->once())->method('recordFailure')->with('groq');
+
+        $this->gateway->method('complete')->willThrowException(new Exception('Groq Error [503]: upstream unavailable'));
+
+        $this->expectException(Exception::class);
+        $fallbackGateway->complete($this->makeRequest());
+    }
+}

--- a/tests/Unit/Infrastructure/AI/FallbackGatewayModelUnavailableTest.php
+++ b/tests/Unit/Infrastructure/AI/FallbackGatewayModelUnavailableTest.php
@@ -43,7 +43,7 @@ class FallbackGatewayModelUnavailableTest extends TestCase
         $this->circuitBreaker->expects($this->never())->method('recordFailure');
 
         $this->gateway->method('complete')->willThrowException(new Exception(
-            'Groq Error [404]: invalid_request_error - The model `llama-3.3-70b-versatile` does not exist or you do not have access to it.'
+            'Groq Error [404]: invalid_request_error - The model `llama-3.3-70b-versatile` does not exist or you do not have access to it.',
         ));
 
         $this->expectException(Exception::class);


### PR DESCRIPTION
Groq shut down `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` on **2026-08-16**. Every call now returns 404, which `FallbackAiGateway` recorded as a circuit-breaker failure. The breaker is keyed **per provider**, so one team's stale model config opened groq for every team and fired the `circuit_breaker_open` CRITICAL alert every 10-minute cooldown window until the 1h staleness filter kicked in — ~6 alert emails per day.

## Changes
- `FallbackAiGateway::isModelUnavailableError()` — a retired/mistyped model ID never recovers on retry, so it advances the fallback chain **without** recording a breaker failure (mirrors the existing `isAuthError()` guard).
- `config/llm_providers.php` + `config/llm_pricing.php` — groq catalog refreshed to GroqCloud's current production text models (`openai/gpt-oss-120b`, `openai/gpt-oss-20b`); the other five entries were preview-only or already shut down. Prices verified against console.groq.com/docs/models on 2026-08-19.

## Tests
`FallbackGatewayModelUnavailableTest` — retired model ID does NOT call `recordFailure`; a genuine 503 still does. 97 related tests green (FallbackChain, CostCalculator, DistillTeamEvents, ClassifySignalIntent, TriageSentryIssue, ProviderResolver, ModelCatalog). phpstan clean, pint clean.

## Prod (already applied, verified)
- `.env`: `AI_CLASSIFICATION_MODEL` and `MEMORY_DISTILLATION_MODEL` moved off the dead model → `openai/gpt-oss-120b`; live Groq probe returns 200.
- Open breaker reset; agent `Medium Article Finder` migrated. 0 open breakers.