### PR TITLE
fix(mcp): enforce pr.require_approval at merge, close the approval fail-open

### DIFF
--- a/app/Mcp/Tools/GitRepository/GitPullRequestCreateTool.php
+++ b/app/Mcp/Tools/GitRepository/GitPullRequestCreateTool.php
@@ -78,9 +78,11 @@ class GitPullRequestCreateTool extends Tool
             ]);
 
             $approvalRequestId = null;
+            $approvalError = null;
+            $requiresApproval = (bool) ($repo->config['pr']['require_approval'] ?? false);
 
             // Create approval request if require_approval is enabled
-            if ($repo->config['pr']['require_approval'] ?? false) {
+            if ($requiresApproval) {
                 try {
                     $approvalRequest = app(CreateApprovalRequestAction::class)->execute(
                         teamId: $repo->team_id,
@@ -96,19 +98,31 @@ class GitPullRequestCreateTool extends Tool
 
                     $gitPr->update(['approval_request_id' => $approvalRequest->id]);
                     $approvalRequestId = $approvalRequest->id;
-                } catch (\Throwable) {
-                    // Approval creation failure should not block the PR
+                } catch (\Throwable $e) {
+                    // The PR already exists upstream, so we cannot unwind it — but the
+                    // caller must not be told approval is unnecessary. Report the
+                    // failure (this is the only place it is observable) and keep
+                    // requires_approval true: git_pr_merge fails closed on the missing
+                    // approval record, so the repo degrades to "unmergeable", not "ungated".
+                    report($e);
+                    $approvalError = 'Approval request could not be created: '.$e->getMessage().'. The PR cannot be merged until an approval exists.';
                 }
             }
 
-            return Response::text(json_encode([
+            $payload = [
                 'success' => true,
                 'pr_number' => $prData['pr_number'],
                 'pr_url' => $prData['pr_url'],
                 'platform_pr_id' => $gitPr->id,
                 'approval_request_id' => $approvalRequestId,
-                'requires_approval' => $approvalRequestId !== null,
-            ]));
+                'requires_approval' => $requiresApproval,
+            ];
+
+            if ($approvalError !== null) {
+                $payload['approval_error'] = $approvalError;
+            }
+
+            return Response::text(json_encode($payload));
         } catch (\Throwable $e) {
             throw $e;
         }

--- a/app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
+++ b/app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
@@ -2,6 +2,8 @@
 
 namespace App\Mcp\Tools\GitRepository;
 
+use App\Domain\Approval\Enums\ApprovalStatus;
+use App\Domain\Approval\Models\ApprovalRequest;
 use App\Domain\GitRepository\Models\GitPullRequest;
 use App\Domain\GitRepository\Models\GitRepository;
 use App\Domain\GitRepository\Services\GitOperationRouter;
@@ -19,7 +21,7 @@ class GitPullRequestMergeTool extends Tool
 
     protected string $name = 'git_pr_merge';
 
-    protected string $description = 'Merge a pull request in a git repository. Supports squash, merge, and rebase strategies. By default validates CI status before merging.';
+    protected string $description = 'Merge a pull request in a git repository. Supports squash, merge, and rebase strategies. By default validates CI status before merging. If the repository has pr.require_approval enabled, the merge is refused unless the linked ApprovalRequest is approved and unexpired — force does not bypass this.';
 
     public function schema(JsonSchema $schema): array
     {
@@ -38,7 +40,7 @@ class GitPullRequestMergeTool extends Tool
             'commit_message' => $schema->string()
                 ->description('Optional commit message body for the merge commit'),
             'force' => $schema->boolean()
-                ->description('Skip CI and review validation checks (default: false)'),
+                ->description('Skip CI and mergeability validation checks (default: false). Does NOT bypass pr.require_approval.'),
         ];
     }
 
@@ -54,9 +56,19 @@ class GitPullRequestMergeTool extends Tool
             return $this->notFoundError('repository');
         }
 
+        $prNumber = (int) $request->get('pr_number');
+
+        // Governance gate. Runs before the client is resolved so a refused merge
+        // performs no side effect at all, and outside the `force` escape hatch —
+        // force skips CI/mergeability checks, never a human approval.
+        if ($repo->config['pr']['require_approval'] ?? false) {
+            if ($refusal = $this->approvalRefusal($repo, $prNumber)) {
+                return $this->failedPreconditionError($refusal);
+            }
+        }
+
         try {
             $client = app(GitOperationRouter::class)->resolve($repo);
-            $prNumber = (int) $request->get('pr_number');
             $force = (bool) $request->get('force', false);
 
             // Validate PR is mergeable unless force is set
@@ -94,5 +106,47 @@ class GitPullRequestMergeTool extends Tool
         } catch (\Throwable $e) {
             throw $e;
         }
+    }
+
+    /**
+     * Reason the merge must be refused under pr.require_approval, or null when
+     * an approved, unexpired ApprovalRequest authorises it.
+     *
+     * Fails closed: a missing platform record or a missing approval link is a
+     * refusal, not a pass. Expiry is re-derived from `expires_at` rather than
+     * trusted from `status`, because ExpireStaleApprovals only sweeps pending
+     * rows — an approved row can sit past its deadline with status Approved.
+     */
+    private function approvalRefusal(GitRepository $repo, int $prNumber): ?string
+    {
+        $pr = GitPullRequest::where('git_repository_id', $repo->id)
+            ->where('pr_number', (string) $prNumber)
+            ->first();
+
+        if (! $pr) {
+            return "PR #{$prNumber} has no platform record, and this repository requires approval before merge. Create the PR through git_pr_create so an approval request is issued.";
+        }
+
+        // Scope the approval to the repository's team: an approval row from
+        // another tenant must never authorise this merge.
+        $approval = $pr->approval_request_id === null
+            ? null
+            : ApprovalRequest::withoutGlobalScopes()
+                ->where('team_id', $repo->team_id)
+                ->find($pr->approval_request_id);
+
+        if (! $approval) {
+            return "PR #{$prNumber} has no approval request linked, and this repository requires approval before merge.";
+        }
+
+        if ($approval->status !== ApprovalStatus::Approved) {
+            return "PR #{$prNumber} is awaiting approval (request {$approval->id} is {$approval->status->value}). Approve it before merging.";
+        }
+
+        if ($approval->expires_at !== null && $approval->expires_at->isPast()) {
+            return "Approval request {$approval->id} for PR #{$prNumber} expired at {$approval->expires_at->toIso8601String()}. Request a fresh approval before merging.";
+        }
+
+        return null;
     }
 }

--- a/docs/design/design-pr-approval-enforcement.md
+++ b/docs/design/design-pr-approval-enforcement.md
@@ -97,6 +97,20 @@ query and larastan keeps the concrete type.
   that is the intended correction, and it is the behaviour the tool description has
   claimed all along.
 
+## No bypass route
+
+`ActionProposalExecutor::executeGitPush` calls `$client->mergePullRequest()`
+directly, outside this tool, so an approved ActionProposal merges without the
+`require_approval` check. That is not a hole: such a proposal only exists because
+a human approved it, and it can only be minted by `GitOperationGate`, which is
+only reached through `GatedGitClient`. Placing the new check **before** the
+client is resolved means a refused merge never reaches the gate and therefore
+never mints a proposal an agent could then get approved as a way around it.
+
+The other merge surfaces were enumerated: `GitRepositoryController` (REST) only
+lists PRs, and the Bitbucket driver path is a separate integration with its own
+gate. `git_pr_merge` is the only user-facing merge on this model.
+
 ## Cloud layer
 
 `GitPullRequestMergeTool` / `GitPullRequestCreateTool` have no `cloud/` override

--- a/docs/design/design-pr-approval-enforcement.md
+++ b/docs/design/design-pr-approval-enforcement.md
@@ -1,0 +1,104 @@
+# Design — enforce `pr.require_approval` at merge time
+
+Date: 2026-08-28
+Origin: review of agent-fleet-o#140 (MRTR migration) — found while verifying the
+issue's claim that `GitPullRequestCreateTool` is a "gated" MCP call site.
+
+## Problem
+
+`GitRepository.config['pr']['require_approval']` is **write-only**. A repo-wide grep
+(`base/`, `cloud/`, excluding vendor) finds three occurrences:
+
+| File | Role |
+|---|---|
+| `GitRepositoryCreateTool.php:55` | schema description advertising the flag |
+| `GitPullRequestCreateTool.php:83` | reads it to *create* an `ApprovalRequest` |
+| `GitPullRequestCreateTool.php:23` | tool description promising "human review before merge" |
+
+Nothing reads it to **enforce** anything. `GitPullRequestMergeTool` merges without
+consulting `GitPullRequest.approval_request_id` or the linked `ApprovalRequest` status.
+
+The independent risk gate (`GatedGitClient` → `GitOperationGate`, `mergePullRequest`
+classified `high`) does not cover this: `GitOperationGate::resolvePolicy()` defaults to
+`['low' => 'auto', 'medium' => 'auto', 'high' => 'auto']`. A team that never set
+`settings.action_proposal_policy` — the default — gets no gate at all. So the documented
+outcome for `require_approval: true` is:
+
+> approval record created → merge proceeds unblocked → record stays `Pending` forever.
+
+Two secondary defects in the same path:
+
+- **Fail-open on approval creation.** `GitPullRequestCreateTool.php:99` is
+  `catch (\Throwable) {}`. If `CreateApprovalRequestAction` throws, the PR is already
+  created, `approval_request_id` stays null, and the tool returns
+  `requires_approval: false`. The caller is told no approval is needed. No Sentry event
+  either — the Throwable is swallowed at the only place it is observable.
+- **Issue #140 mis-scopes the call site.** Its migration sketch (item 6) lists
+  `GitPullRequestCreateTool` as a gated `tools/call` needing an MRTR resume path. It is
+  not deferrable: the PR is created *before* the approval record, so there is no pending
+  side effect to resume. The genuinely deferrable git seam is `GatedGitClient` /
+  `GitOperationProposedException`.
+
+## Non-goals
+
+- MRTR / `input_required` / `requestState` (that is #140 itself, unchanged).
+- Changing the default `action_proposal_policy`.
+- `ActionProposal::isExpired()`. It is pending-gated and therefore useless as an
+  execution guard, but it has **zero callers** (verified) and the execution chokepoint
+  `ExecuteActionProposalJob::handle()` checks `expires_at` directly since #133. Leaving
+  a dead footgun is out of scope for this fix; recorded in the issue thread instead.
+
+## Design
+
+### 1. Enforce at merge (fail-closed)
+
+`GitPullRequestMergeTool::handle()` gains a pre-merge check, placed **before** the CI
+validation and **outside** the `force` escape hatch:
+
+```
+if repo.config.pr.require_approval:
+    pr  = GitPullRequest for (repo, pr_number)          # team-scoped
+    req = pr?.approvalRequest
+    missing        -> FAILED_PRECONDITION  (fail closed)
+    Pending        -> FAILED_PRECONDITION
+    Rejected       -> FAILED_PRECONDITION
+    Expired / past expires_at -> FAILED_PRECONDITION
+    Approved       -> proceed
+```
+
+`force` deliberately does **not** bypass this. `force` documents itself as "skip CI and
+review validation checks"; a governance approval is neither. Making `force` bypass an
+approval would reintroduce the hole through the front door.
+
+Expiry is re-checked against `expires_at` at **merge** time, not trusted from the status
+column — same invariant as `ExecuteActionProposalJob` (see
+`mem:approval/action-proposal-execution-invariants`).
+
+### 2. Close the fail-open at create
+
+`GitPullRequestCreateTool`: report the Throwable (`report($e)`) so it reaches Sentry, and
+return `requires_approval: true` with an `approval_error` field rather than a false
+`false`. With (1) in place a missing approval record now blocks the merge, so a failed
+creation degrades closed instead of open.
+
+### 3. Model relation
+
+None needed — `GitPullRequest::approvalRequest()` and the `approval_request_id`
+column already exist and are already written. The gate reads `ApprovalRequest`
+directly rather than through the relation so the team scope is explicit in the
+query and larastan keeps the concrete type.
+
+## Blast radius
+
+- One new read of an existing column; no migration.
+- Behaviour changes **only** for repos that opted into `pr.require_approval`. For every
+  other repo the merge path is byte-identical.
+- Repos already relying on the (broken) permissive behaviour will start being blocked —
+  that is the intended correction, and it is the behaviour the tool description has
+  claimed all along.
+
+## Cloud layer
+
+`GitPullRequestMergeTool` / `GitPullRequestCreateTool` have no `cloud/` override
+(verified), so the base edit is live in cloud. Both tools are already registered; no MCP
+registration change is required.

--- a/docs/test-plans/test-plan-pr-approval-enforcement.md
+++ b/docs/test-plans/test-plan-pr-approval-enforcement.md
@@ -1,0 +1,35 @@
+# Test plan — `pr.require_approval` merge enforcement
+
+Target: `base/tests/Feature/Mcp/Tools/GitRepository/GitPullRequestApprovalGateTest.php`
+
+## Merge gate (`git_pr_merge`)
+
+| # | Setup | Expect |
+|---|---|---|
+| 1 | `require_approval` off | merges (unchanged path — regression guard) |
+| 2 | `require_approval` on, no `GitPullRequest` row | FAILED_PRECONDITION, client never called |
+| 3 | `require_approval` on, row with `approval_request_id = null` | FAILED_PRECONDITION |
+| 4 | approval `Pending` | FAILED_PRECONDITION |
+| 5 | approval `Rejected` | FAILED_PRECONDITION |
+| 6 | approval `Expired` | FAILED_PRECONDITION |
+| 7 | approval `Approved` but `expires_at` in the past | FAILED_PRECONDITION (expiry re-checked at merge, not trusted from status) |
+| 8 | approval `Approved`, `expires_at` null | merges |
+| 9 | approval `Approved`, `expires_at` future | merges |
+| 10 | `force = true` + approval `Pending` | FAILED_PRECONDITION — force must not bypass governance |
+| 11 | approval belongs to another team | FAILED_PRECONDITION (team scoping) |
+
+Assertion discipline: for every blocked case assert the **git client was not invoked**,
+not merely that the response was an error. A gate that errors after merging is not a gate.
+
+## Create fail-open (`git_pr_create`)
+
+| # | Setup | Expect |
+|---|---|---|
+| 12 | `require_approval` on, `CreateApprovalRequestAction` throws | `requires_approval: true`, `approval_error` present, `report()` called; PR still returned |
+| 13 | `require_approval` on, happy path | `approval_request_id` set, `requires_approval: true` |
+| 14 | `require_approval` off | no approval record, `requires_approval: false` |
+
+## Cross-checks
+
+- 12 + 4 composed: a failed approval creation must leave the PR **unmergeable**
+  (degrade closed), which is the whole point of pairing the two fixes.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16025,3 +16025,27 @@ parameters:
 			identifier: argument.unresolvableType
 			count: 1
 			path: app/Providers/FleetPluginServiceProvider.php
+
+		-
+			message: '#^Method App\\Mcp\\Tools\\GitRepository\\GitPullRequestMergeTool\:\:approvalRefusal\(\) never returns null so it can be removed from the return type\.$#'
+			identifier: return.unusedType
+			count: 1
+			path: app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between string and App\\Domain\\Approval\\Enums\\ApprovalStatus\:\:Approved will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
+
+		-
+			message: '#^Cannot access property \$value on string\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php

--- a/tests/Feature/Mcp/GitPullRequestApprovalGateTest.php
+++ b/tests/Feature/Mcp/GitPullRequestApprovalGateTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Approval\Actions\CreateApprovalRequestAction;
+use App\Domain\Approval\Enums\ApprovalStatus;
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\GitRepository\Contracts\GitClientInterface;
+use App\Domain\GitRepository\Models\GitPullRequest;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\GitOperationRouter;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Tools\GitRepository\GitPullRequestCreateTool;
+use App\Mcp\Tools\GitRepository\GitPullRequestMergeTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * pr.require_approval was write-only: GitPullRequestCreateTool created an
+ * ApprovalRequest and nothing ever read it back, so git_pr_merge merged
+ * regardless. These tests pin the gate closed.
+ */
+class GitPullRequestApprovalGateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private GitRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'T '.bin2hex(random_bytes(3)),
+            'slug' => 't-'.bin2hex(random_bytes(3)),
+            'owner_id' => $user->id,
+            'settings' => [],
+        ]);
+        $user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($user, ['role' => 'owner']);
+        $this->actingAs($user);
+
+        app()->instance('mcp.team_id', $this->team->id);
+
+        $this->repo = GitRepository::create([
+            'team_id' => $this->team->id,
+            'name' => 'test-repo',
+            'url' => 'https://github.com/example/test',
+            'provider' => 'github',
+            'mode' => 'api_only',
+            'default_branch' => 'main',
+            'config' => ['pr' => ['require_approval' => true]],
+            'status' => 'active',
+        ]);
+    }
+
+    private function decode(Response $response): array
+    {
+        return json_decode((string) $response->content(), true);
+    }
+
+    /**
+     * Binds a client that fails the test if any method is called. A refused
+     * merge must perform no side effect — asserting only on the error message
+     * would pass even if the PR had already been merged.
+     */
+    private function expectNoGitCalls(): void
+    {
+        $client = Mockery::mock(GitClientInterface::class);
+        $client->shouldNotReceive('mergePullRequest');
+        $client->shouldNotReceive('getPullRequestStatus');
+
+        $router = Mockery::mock(GitOperationRouter::class);
+        $router->shouldReceive('resolve')->andReturn($client);
+        app()->instance(GitOperationRouter::class, $router);
+    }
+
+    private function expectMerge(): void
+    {
+        $client = Mockery::mock(GitClientInterface::class);
+        $client->shouldReceive('getPullRequestStatus')->andReturn([
+            'mergeable' => true,
+            'ci_passing' => true,
+        ]);
+        $client->shouldReceive('mergePullRequest')->once()->andReturn([
+            'sha' => 'deadbeef',
+            'merged' => true,
+            'message' => 'Merged',
+        ]);
+
+        $router = Mockery::mock(GitOperationRouter::class);
+        $router->shouldReceive('resolve')->andReturn($client);
+        app()->instance(GitOperationRouter::class, $router);
+    }
+
+    private function makePr(?ApprovalRequest $approval = null, int $number = 7): GitPullRequest
+    {
+        return GitPullRequest::create([
+            'git_repository_id' => $this->repo->id,
+            'agent_id' => null,
+            'approval_request_id' => $approval?->id,
+            'title' => 'Some change',
+            'body' => '',
+            'branch' => 'feat/x',
+            'base_branch' => 'main',
+            'pr_number' => (string) $number,
+            'pr_url' => 'https://github.com/example/test/pull/'.$number,
+            'status' => 'open',
+        ]);
+    }
+
+    private function makeApproval(ApprovalStatus $status, ?string $expiresAt = null, ?string $teamId = null): ApprovalRequest
+    {
+        return ApprovalRequest::create([
+            'team_id' => $teamId ?? $this->team->id,
+            'status' => $status,
+            'context' => ['pr_number' => 7],
+            'expires_at' => $expiresAt,
+        ]);
+    }
+
+    private function merge(array $extra = []): Response
+    {
+        return app(GitPullRequestMergeTool::class)->handle(new Request(array_merge([
+            'repository_id' => $this->repo->id,
+            'pr_number' => 7,
+        ], $extra)));
+    }
+
+    private function assertRefused(Response $response): void
+    {
+        $this->assertTrue($response->isError(), 'Expected the merge to be refused.');
+        $this->assertSame('FAILED_PRECONDITION', $this->decode($response)['error']['code']);
+    }
+
+    // ---- merge gate --------------------------------------------------------
+
+    public function test_merges_normally_when_require_approval_is_off(): void
+    {
+        $this->repo->update(['config' => []]);
+        $this->makePr();
+        $this->expectMerge();
+
+        $response = $this->merge();
+
+        $this->assertFalse($response->isError());
+        $this->assertTrue($this->decode($response)['merged']);
+    }
+
+    public function test_refuses_when_no_platform_record_exists(): void
+    {
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge());
+    }
+
+    public function test_refuses_when_pr_has_no_approval_linked(): void
+    {
+        $this->makePr();
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge());
+    }
+
+    public function test_refuses_while_approval_is_pending(): void
+    {
+        $this->makePr($this->makeApproval(ApprovalStatus::Pending));
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge());
+    }
+
+    public function test_refuses_when_approval_was_rejected(): void
+    {
+        $this->makePr($this->makeApproval(ApprovalStatus::Rejected));
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge());
+    }
+
+    public function test_refuses_when_approval_status_is_expired(): void
+    {
+        $this->makePr($this->makeApproval(ApprovalStatus::Expired));
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge());
+    }
+
+    /**
+     * ExpireStaleApprovals only sweeps pending rows, so an approved row can sit
+     * past its deadline still marked Approved. Expiry must be re-derived here.
+     */
+    public function test_refuses_when_approved_but_past_expires_at(): void
+    {
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved, now()->subHour()->toDateTimeString()));
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge());
+    }
+
+    public function test_merges_when_approved_without_expiry(): void
+    {
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved));
+        $this->expectMerge();
+
+        $response = $this->merge();
+
+        $this->assertFalse($response->isError());
+        $this->assertTrue($this->decode($response)['merged']);
+    }
+
+    public function test_merges_when_approved_and_not_yet_expired(): void
+    {
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved, now()->addHour()->toDateTimeString()));
+        $this->expectMerge();
+
+        $this->assertFalse($this->merge()->isError());
+    }
+
+    public function test_force_does_not_bypass_the_approval_gate(): void
+    {
+        $this->makePr($this->makeApproval(ApprovalStatus::Pending));
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge(['force' => true]));
+    }
+
+    public function test_refuses_approval_belonging_to_another_team(): void
+    {
+        $otherOwner = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other '.bin2hex(random_bytes(3)),
+            'slug' => 'other-'.bin2hex(random_bytes(3)),
+            'owner_id' => $otherOwner->id,
+            'settings' => [],
+        ]);
+
+        $foreign = $this->makeApproval(ApprovalStatus::Approved, null, $otherTeam->id);
+        $this->makePr($foreign);
+        $this->expectNoGitCalls();
+
+        $this->assertRefused($this->merge());
+    }
+
+    // ---- create fail-open --------------------------------------------------
+
+    public function test_create_reports_and_stays_gated_when_approval_creation_fails(): void
+    {
+        $client = Mockery::mock(GitClientInterface::class);
+        $client->shouldReceive('createPullRequest')->andReturn([
+            'title' => 'Some change',
+            'pr_number' => 7,
+            'pr_url' => 'https://github.com/example/test/pull/7',
+        ]);
+        $router = Mockery::mock(GitOperationRouter::class);
+        $router->shouldReceive('resolve')->andReturn($client);
+        app()->instance(GitOperationRouter::class, $router);
+
+        $failing = Mockery::mock(CreateApprovalRequestAction::class);
+        $failing->shouldReceive('execute')->andThrow(new \RuntimeException('approval store down'));
+        app()->instance(CreateApprovalRequestAction::class, $failing);
+
+        $response = app(GitPullRequestCreateTool::class)->handle(new Request([
+            'repository_id' => $this->repo->id,
+            'title' => 'Some change',
+            'head' => 'feat/x',
+        ]));
+
+        $data = $this->decode($response);
+
+        // The PR exists upstream and cannot be unwound, but the caller must not
+        // be told approval is unnecessary.
+        $this->assertTrue($data['success']);
+        $this->assertTrue($data['requires_approval']);
+        $this->assertNull($data['approval_request_id']);
+        $this->assertArrayHasKey('approval_error', $data);
+
+        // ...and the PR must now be unmergeable, not ungated.
+        $this->expectNoGitCalls();
+        $this->assertRefused($this->merge());
+    }
+}


### PR DESCRIPTION
## The defect

`GitRepository.config['pr']['require_approval']` was **write-only**. A repo-wide grep over `base/`, `cloud/` and `overrides/` finds three occurrences:

| File | Role |
|---|---|
| `GitRepositoryCreateTool.php:55` | schema description advertising the flag |
| `GitPullRequestCreateTool.php:83` | reads it to *create* an `ApprovalRequest` |
| `GitPullRequestCreateTool.php:23` | tool description promising "human review before merge" |

Zero read sites enforce anything. `GitPullRequestMergeTool` never consulted `GitPullRequest.approval_request_id`, so the merge proceeded regardless of the approval's status.

The independent risk gate did not cover this either: `GitOperationGate::resolvePolicy()` defaults to `['low' => 'auto', 'medium' => 'auto', 'high' => 'auto']`, so a team that never set `settings.action_proposal_policy` — the default — got no gate at all. The outcome for `require_approval: true` was:

> approval record created → merge proceeds unblocked → record stays `Pending` forever.

## The fix

- `git_pr_merge` refuses unless the linked `ApprovalRequest` is `Approved` and unexpired. Fails closed on a missing platform record or a missing approval link. The check runs **before the client is resolved**, so a refused merge performs no side effect.
- `force` does **not** bypass it. `force` documents itself as skipping CI and mergeability checks; a governance approval is neither.
- Expiry is re-derived from `expires_at` at merge time rather than trusted from `status` — `ExpireStaleApprovals` only sweeps pending rows, so an approved row can sit past its deadline still marked `Approved`. Same invariant `ExecuteActionProposalJob` enforces since #133.
- The `catch (\Throwable) {}` at `GitPullRequestCreateTool.php:99` that swallowed approval-creation failure now reports the exception and keeps `requires_approval: true` with an `approval_error` field, instead of returning a false `requires_approval: false`. Paired with the merge gate, a failed approval creation degrades the PR to *unmergeable* rather than *ungated*.

## Bypass hunt

Every caller of `mergePullRequest` was traced:

| Path | Reaches `GitRepository` merge? | Gated? |
|---|---|---|
| `GitPullRequestMergeTool` | yes | new gate |
| Compact `GitManageTool` | no — `toolMap()` has only `pr_create`/`pr_list` | n/a |
| `GitRepositoryController` (REST) | no — lists PRs only | n/a |
| `ActionProposalExecutor::executeGitPush` | yes, but only for an already human-approved proposal | unreachable as a bypass — the gate runs before the client resolves, so a refused merge never mints a proposal |
| `BitbucketPrManageTool`, `BitbucketPrMergeNodeExecutor`, `GitHubIntegrationDriver` | no — Credential-based integrations, not `GitRepository` | separate gate |

## Tests

12 tests in `GitPullRequestApprovalGateTest`; **9 fail against the pre-fix code** (verified by stashing the two tool files and re-running). Every refusal case asserts the git client was **never invoked** — a gate that errors after merging is not a gate.

Full suite: 4891 passed, 0 failed, 37 skipped. Pint clean. PHPStan clean in both base and parent (4 baseline entries added by hand for the known larastan enum-cast-typed-as-string pattern, matching the 7 that already exist for `ApprovalStatus`).

## Notes

- No cloud override shadows either tool; both are registered in `CloudAgentFleetServer`, so this is live in production.
- Pre-existing asymmetry, unchanged here: `GitPullRequestMergeTool` is registered in cloud but not in the base `AgentFleetServer`.
- Separate coverage gap worth its own issue: `pr.require_approval` is a `GitRepository` config, so Bitbucket merges via the integration driver have no equivalent control.

Found while verifying the call-site inventory in #140, which is also re-scoped by this: `GitPullRequestCreateTool` is not an MRTR-deferrable site (the PR is created before the approval record), `GatedGitClient` is.

Refs #140

https://claude.ai/code/session_016wkeH6NS4CRgSSZoANqExy