### PR TITLE
feat(mcp): migrate the approval gate to MRTR (SEP-2322)

### DIFF
--- a/app/Mcp/Concerns/SupportsDualProtocolFormat.php
+++ b/app/Mcp/Concerns/SupportsDualProtocolFormat.php
@@ -3,6 +3,7 @@
 namespace App\Mcp\Concerns;
 
 use App\Mcp\Methods\CacheableListTools;
+use App\Mcp\Methods\MultiRoundTripCallTool;
 use App\Mcp\Methods\ServerDiscover;
 use App\Mcp\Protocol\ProtocolVersions;
 
@@ -26,5 +27,6 @@ trait SupportsDualProtocolFormat
 
         $this->addMethod('server/discover', ServerDiscover::class);
         $this->addMethod('tools/list', CacheableListTools::class);
+        $this->addMethod('tools/call', MultiRoundTripCallTool::class);
     }
 }

--- a/app/Mcp/Exceptions/InputRequiredException.php
+++ b/app/Mcp/Exceptions/InputRequiredException.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Mcp\Exceptions;
+
+use App\Mcp\Protocol\RequestState;
+use Laravel\Mcp\Response;
+
+/**
+ * A gated tool signalling "not done — come back with this state" (SEP-2322).
+ *
+ * Tools throw this unconditionally; `MultiRoundTripCallTool` decides what the
+ * caller actually sees. That is why the terminal `$fallback` rides along: a
+ * pre-2026-07-28 client gets today's response, an MRTR client gets an
+ * `input_required` result, and the tool itself never branches on protocol
+ * version.
+ */
+class InputRequiredException extends \RuntimeException
+{
+    /**
+     * @param  array<string, array<string, mixed>>  $inputRequests  keyed server-side; the
+     *                                                              client echoes the same keys in `inputResponses`
+     * @param  Response  $fallback  what a client that cannot speak MRTR gets instead
+     */
+    public function __construct(
+        public readonly array $inputRequests,
+        public readonly ?RequestState $requestState,
+        public readonly Response $fallback,
+    ) {
+        parent::__construct('Input required before this request can complete.');
+    }
+
+    /**
+     * A pending human approval, surfaced as an elicitation so the caller's
+     * operator can see what is blocked and where to act.
+     *
+     * The elicitation is a nudge, never the authorisation — on retry the tool
+     * re-reads the approval row and decides from that. A client answering
+     * "approved" without an approved row gets `input_required` again.
+     */
+    public static function forApproval(
+        string $key,
+        string $message,
+        RequestState $state,
+        Response $fallback,
+    ): self {
+        return new self(
+            inputRequests: [
+                $key => [
+                    'method' => 'elicitation/create',
+                    'params' => [
+                        'mode' => 'form',
+                        'message' => $message,
+                        'requestedSchema' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'acknowledged' => [
+                                    'type' => 'boolean',
+                                    'description' => 'Set once the approval has been actioned in FleetQ. The server re-checks the approval record regardless of this value.',
+                                ],
+                            ],
+                            'required' => ['acknowledged'],
+                        ],
+                    ],
+                ],
+            ],
+            requestState: $state,
+            fallback: $fallback,
+        );
+    }
+}

--- a/app/Mcp/Methods/MultiRoundTripCallTool.php
+++ b/app/Mcp/Methods/MultiRoundTripCallTool.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Mcp\Methods;
+
+use App\Mcp\Exceptions\InputRequiredException;
+use App\Mcp\Protocol\ProtocolContext;
+use Generator;
+use Illuminate\Container\Container;
+use Laravel\Mcp\Server\Methods\CallTool;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Server\Transport\JsonRpcRequest;
+use Laravel\Mcp\Server\Transport\JsonRpcResponse;
+
+/**
+ * `tools/call` with SEP-2322 multi round-trip support.
+ *
+ * A gated tool that cannot finish throws InputRequiredException; this converts
+ * it into the non-terminal result the spec defines:
+ *
+ *   {"resultType":"input_required","inputRequests":{…},"requestState":"…"}
+ *
+ * Before that, the retry parameters the client echoed back
+ * (`params.inputResponses`, `params.requestState`) are bound into the container
+ * so the tool can read them without re-parsing the JSON-RPC envelope — the same
+ * shape `Server` uses for `mcp.request`.
+ *
+ * Backward compatibility is handled here rather than in the tools: pre-2026-07-28
+ * callers get the terminal Response the exception carries, so `resultType` is
+ * only ever added on the input_required path. The spec makes that safe —
+ * "if this field is not provided, the Client should assume a ResultType of
+ * 'complete' for backwards compatibility" — so successful results stay byte-identical
+ * for every client.
+ */
+class MultiRoundTripCallTool extends CallTool
+{
+    public const BINDING_INPUT_RESPONSES = 'mcp.input_responses';
+
+    public const BINDING_REQUEST_STATE = 'mcp.request_state';
+
+    public const RESULT_TYPE_INPUT_REQUIRED = 'input_required';
+
+    public function handle(JsonRpcRequest $request, ServerContext $context): Generator|JsonRpcResponse
+    {
+        $container = Container::getInstance();
+
+        $inputResponses = $request->params['inputResponses'] ?? [];
+        $requestState = $request->params['requestState'] ?? null;
+
+        $container->instance(self::BINDING_INPUT_RESPONSES, is_array($inputResponses) ? $inputResponses : []);
+        $container->instance(self::BINDING_REQUEST_STATE, is_string($requestState) ? $requestState : null);
+
+        try {
+            return parent::handle($request, $context);
+        } catch (InputRequiredException $e) {
+            return $this->inputRequiredResponse($request, $e);
+        } finally {
+            $container->forgetInstance(self::BINDING_INPUT_RESPONSES);
+            $container->forgetInstance(self::BINDING_REQUEST_STATE);
+        }
+    }
+
+    private function inputRequiredResponse(JsonRpcRequest $request, InputRequiredException $e): JsonRpcResponse
+    {
+        if (! ProtocolContext::current()->supportsMultiRoundTrip()) {
+            return $this->terminalFallback($request, $e);
+        }
+
+        $result = ['resultType' => self::RESULT_TYPE_INPUT_REQUIRED];
+
+        if ($e->inputRequests !== []) {
+            $result['inputRequests'] = $e->inputRequests;
+        }
+
+        if ($e->requestState !== null) {
+            $result['requestState'] = $e->requestState->encode();
+        }
+
+        return JsonRpcResponse::result($request->id, $result);
+    }
+
+    /**
+     * Render the tool's own terminal response for a client that cannot resume.
+     * Mirrors CallTool's success shape so these callers see exactly what they
+     * saw before MRTR existed.
+     */
+    private function terminalFallback(JsonRpcRequest $request, InputRequiredException $e): JsonRpcResponse
+    {
+        return JsonRpcResponse::result($request->id, [
+            'content' => [['type' => 'text', 'text' => (string) $e->fallback->content()]],
+            'isError' => $e->fallback->isError(),
+        ]);
+    }
+}

--- a/app/Mcp/Methods/MultiRoundTripCallTool.php
+++ b/app/Mcp/Methods/MultiRoundTripCallTool.php
@@ -52,17 +52,17 @@ class MultiRoundTripCallTool extends CallTool
         try {
             return parent::handle($request, $context);
         } catch (InputRequiredException $e) {
-            return $this->inputRequiredResponse($request, $e);
+            return $this->inputRequiredResponse($request, $context, $e);
         } finally {
             $container->forgetInstance(self::BINDING_INPUT_RESPONSES);
             $container->forgetInstance(self::BINDING_REQUEST_STATE);
         }
     }
 
-    private function inputRequiredResponse(JsonRpcRequest $request, InputRequiredException $e): JsonRpcResponse
+    private function inputRequiredResponse(JsonRpcRequest $request, ServerContext $context, InputRequiredException $e): JsonRpcResponse
     {
         if (! ProtocolContext::current()->supportsMultiRoundTrip()) {
-            return $this->terminalFallback($request, $e);
+            return $this->terminalFallback($request, $context, $e);
         }
 
         $result = ['resultType' => self::RESULT_TYPE_INPUT_REQUIRED];
@@ -80,14 +80,29 @@ class MultiRoundTripCallTool extends CallTool
 
     /**
      * Render the tool's own terminal response for a client that cannot resume.
-     * Mirrors CallTool's success shape so these callers see exactly what they
-     * saw before MRTR existed.
+     *
+     * Delegates to CallTool's own serializer rather than hand-building the
+     * envelope, so a pre-MRTR caller gets byte-identical output to what it got
+     * before this class existed — including structured content and _meta, which
+     * a hand-rolled `content`/`isError` pair would silently drop the moment a
+     * gated tool returned anything richer than plain text.
      */
-    private function terminalFallback(JsonRpcRequest $request, InputRequiredException $e): JsonRpcResponse
+    private function terminalFallback(JsonRpcRequest $request, ServerContext $context, InputRequiredException $e): JsonRpcResponse
     {
-        return JsonRpcResponse::result($request->id, [
-            'content' => [['type' => 'text', 'text' => (string) $e->fallback->content()]],
-            'isError' => $e->fallback->isError(),
-        ]);
+        $tool = $context->tools()->first(
+            fn ($tool): bool => $tool->name() === ($request->params['name'] ?? null),
+        );
+
+        if ($tool === null) {
+            // Unreachable in practice: parent::handle() already resolved the
+            // tool to reach the throw. Kept so a lookup change upstream
+            // degrades to a valid response rather than a TypeError.
+            return JsonRpcResponse::result($request->id, [
+                'content' => [['type' => 'text', 'text' => (string) $e->fallback->content()]],
+                'isError' => $e->fallback->isError(),
+            ]);
+        }
+
+        return $this->toJsonRpcResponse($request, $e->fallback, $this->serializable($tool));
     }
 }

--- a/app/Mcp/Protocol/ProtocolContext.php
+++ b/app/Mcp/Protocol/ProtocolContext.php
@@ -53,4 +53,14 @@ final class ProtocolContext
     {
         return ProtocolVersions::supportsCacheHints($this->version);
     }
+
+    /**
+     * Whether this caller can be handed an `input_required` result plus a
+     * `requestState` to retry with (SEP-2322). Older clients get the terminal
+     * response the gated tool carries as its fallback.
+     */
+    public function supportsMultiRoundTrip(): bool
+    {
+        return ProtocolVersions::supportsMultiRoundTrip($this->version);
+    }
 }

--- a/app/Mcp/Protocol/ProtocolVersions.php
+++ b/app/Mcp/Protocol/ProtocolVersions.php
@@ -48,6 +48,9 @@ final class ProtocolVersions
     /** First revision where tools/list may carry cache hints (SEP-2549). */
     public const CACHE_HINTS_SINCE = self::V2026_07_28;
 
+    /** First revision where a result may be `input_required` with requestState (SEP-2322). */
+    public const MULTI_ROUND_TRIP_SINCE = self::V2026_07_28;
+
     // SEP-2575 — `params._meta` keys carried on every request.
     public const META_PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion';
 
@@ -86,5 +89,10 @@ final class ProtocolVersions
     public static function supportsCacheHints(string $version): bool
     {
         return self::isAtLeast($version, self::CACHE_HINTS_SINCE);
+    }
+
+    public static function supportsMultiRoundTrip(string $version): bool
+    {
+        return self::isAtLeast($version, self::MULTI_ROUND_TRIP_SINCE);
     }
 }

--- a/app/Mcp/Protocol/RequestState.php
+++ b/app/Mcp/Protocol/RequestState.php
@@ -24,6 +24,14 @@ use Illuminate\Support\Facades\Crypt;
  *
  * `tool` + `argsHash` pin an envelope to the exact call it was minted for: a
  * state issued for `git_pr_merge` on PR #7 cannot resume PR #9.
+ *
+ * INVARIANT — do not "optimise" this away. `approvalRequestId` is carried for
+ * correlation and audit only; it is never used as a lookup key. Consumers
+ * re-derive the approval from their own tenant-scoped query and use the
+ * envelope purely as a consistency check. That way a valid envelope can only
+ * ever cause a call to be *refused*, never to be redirected at a row the client
+ * named — which is a strictly stronger position than the SEP requires, and the
+ * reason a forged-but-well-formed state is harmless rather than merely unlikely.
  */
 final class RequestState
 {

--- a/app/Mcp/Protocol/RequestState.php
+++ b/app/Mcp/Protocol/RequestState.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Mcp\Protocol;
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Support\Facades\Crypt;
+
+/**
+ * The opaque `requestState` blob of SEP-2322.
+ *
+ * The spec is blunt about the threat model: the client is an untrusted
+ * intermediary, servers MUST always validate the state, SHOULD encrypt it for
+ * confidentiality and integrity, and MUST cryptographically bind anything
+ * user-specific to the original user and verify it against the *currently
+ * authenticated* caller on the retry.
+ *
+ * So this is not a handle. A bare `approval_requests.id` would be trivially
+ * swappable between tenants. It is an encrypted envelope that names a row:
+ * authoritative state stays in the database (where the inbox, the audit trail
+ * and ExpireStaleApprovals already operate on it), while everything needed to
+ * *verify the resumption* travels with the client. Verification touches only the
+ * envelope and the row it names — no session affinity, so any node behind the
+ * load balancer can serve the retry (SEP-2567).
+ *
+ * `tool` + `argsHash` pin an envelope to the exact call it was minted for: a
+ * state issued for `git_pr_merge` on PR #7 cannot resume PR #9.
+ */
+final class RequestState
+{
+    /** Envelope format version, so a future shape change can be detected rather than mis-parsed. */
+    public const VERSION = 1;
+
+    /**
+     * Envelope lifetime. Deliberately NOT the approval's own `expires_at`:
+     * this one asks "is this resumption attempt still fresh", the other asks
+     * "is the human decision still valid". A stale envelope means start over;
+     * an expired approval is a governance outcome.
+     */
+    public const TTL_SECONDS = 86400;
+
+    public function __construct(
+        public readonly string $approvalRequestId,
+        public readonly string $teamId,
+        public readonly ?string $userId,
+        public readonly string $tool,
+        public readonly string $argsHash,
+        public readonly int $expiresAt,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     */
+    public static function issue(
+        string $approvalRequestId,
+        string $teamId,
+        ?string $userId,
+        string $tool,
+        array $arguments,
+    ): self {
+        return new self(
+            approvalRequestId: $approvalRequestId,
+            teamId: $teamId,
+            userId: $userId,
+            tool: $tool,
+            argsHash: self::hashArguments($arguments),
+            expiresAt: now()->addSeconds(self::TTL_SECONDS)->getTimestamp(),
+        );
+    }
+
+    public function encode(): string
+    {
+        return Crypt::encryptString(json_encode([
+            'v' => self::VERSION,
+            'a' => $this->approvalRequestId,
+            't' => $this->teamId,
+            'u' => $this->userId,
+            'n' => $this->tool,
+            'h' => $this->argsHash,
+            'e' => $this->expiresAt,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * Decode a client-supplied blob. Returns null for anything that is not a
+     * well-formed, unexpired envelope this server minted.
+     *
+     * Every failure collapses to null on purpose: the caller must not be able
+     * to tell a forged blob from an expired one from a wrong-version one, and
+     * the only safe response to all three is "no resumable state".
+     */
+    public static function decode(?string $blob): ?self
+    {
+        if ($blob === null || $blob === '') {
+            return null;
+        }
+
+        try {
+            $payload = json_decode(Crypt::decryptString($blob), true, 512, JSON_THROW_ON_ERROR);
+        } catch (DecryptException|\JsonException) {
+            return null;
+        }
+
+        if (! is_array($payload) || ($payload['v'] ?? null) !== self::VERSION) {
+            return null;
+        }
+
+        foreach (['a', 't', 'n', 'h', 'e'] as $required) {
+            if (! isset($payload[$required])) {
+                return null;
+            }
+        }
+
+        $state = new self(
+            approvalRequestId: (string) $payload['a'],
+            teamId: (string) $payload['t'],
+            userId: isset($payload['u']) ? (string) $payload['u'] : null,
+            tool: (string) $payload['n'],
+            argsHash: (string) $payload['h'],
+            expiresAt: (int) $payload['e'],
+        );
+
+        return $state->isExpired() ? null : $state;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expiresAt <= now()->getTimestamp();
+    }
+
+    /**
+     * The SEP-2322 binding check. An envelope only resumes the call it was
+     * minted for, for the tenant and user it was minted for.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    public function matches(string $tool, array $arguments, string $teamId, ?string $userId): bool
+    {
+        if (! hash_equals($this->tool, $tool) || ! hash_equals($this->teamId, $teamId)) {
+            return false;
+        }
+
+        if (! hash_equals($this->argsHash, self::hashArguments($arguments))) {
+            return false;
+        }
+
+        // A state minted for an identified user may only be resumed by that
+        // user. A state minted without one (stdio, machine token) stays
+        // team-bound only — there is no user identity to bind it to.
+        if ($this->userId !== null) {
+            return $userId !== null && hash_equals($this->userId, $userId);
+        }
+
+        return true;
+    }
+
+    /**
+     * Order-insensitive so a client that re-serialises its arguments map with a
+     * different key order still resumes; value-sensitive so changing any
+     * argument does not.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    private static function hashArguments(array $arguments): string
+    {
+        $normalised = self::normalise($arguments);
+
+        return hash('sha256', json_encode($normalised, JSON_THROW_ON_ERROR));
+    }
+
+    private static function normalise(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $out = array_map(static fn ($v) => self::normalise($v), $value);
+
+        if (! array_is_list($out)) {
+            ksort($out);
+        }
+
+        return $out;
+    }
+}

--- a/app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
+++ b/app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
@@ -8,6 +8,9 @@ use App\Domain\GitRepository\Models\GitPullRequest;
 use App\Domain\GitRepository\Models\GitRepository;
 use App\Domain\GitRepository\Services\GitOperationRouter;
 use App\Mcp\Concerns\HasStructuredErrors;
+use App\Mcp\Exceptions\InputRequiredException;
+use App\Mcp\Methods\MultiRoundTripCallTool;
+use App\Mcp\Protocol\RequestState;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -58,12 +61,22 @@ class GitPullRequestMergeTool extends Tool
 
         $prNumber = (int) $request->get('pr_number');
 
+        // SEP-2322: "servers MUST always validate that state, as the client is
+        // an untrusted intermediary." A state that does not decode, or that was
+        // minted for another tenant/user/call, is refused outright rather than
+        // silently ignored — it cannot grant anything either way (the gate
+        // re-reads the approval row regardless), but a caller echoing a bogus
+        // state has a bug worth surfacing.
+        if ($stateError = $this->validateEchoedRequestState($teamId, $request->all())) {
+            return $stateError;
+        }
+
         // Governance gate. Runs before the client is resolved so a refused merge
         // performs no side effect at all, and outside the `force` escape hatch —
         // force skips CI/mergeability checks, never a human approval.
         if ($repo->config['pr']['require_approval'] ?? false) {
-            if ($refusal = $this->approvalRefusal($repo, $prNumber)) {
-                return $this->failedPreconditionError($refusal);
+            if ($refusal = $this->approvalGate($repo, $prNumber, $teamId, $request->all())) {
+                return $refusal;
             }
         }
 
@@ -109,22 +122,69 @@ class GitPullRequestMergeTool extends Tool
     }
 
     /**
-     * Reason the merge must be refused under pr.require_approval, or null when
-     * an approved, unexpired ApprovalRequest authorises it.
+     * Validate a `requestState` the client echoed back, if any.
+     *
+     * Returns an error Response when the caller sent one that this server did
+     * not mint for this exact call, or null when there is nothing to validate
+     * or the state checks out. Note the state is never *trusted* to authorise
+     * anything — it only proves the caller is resuming the call it was given.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    private function validateEchoedRequestState(string $teamId, array $arguments): ?Response
+    {
+        $blob = app()->bound(MultiRoundTripCallTool::BINDING_REQUEST_STATE)
+            ? app(MultiRoundTripCallTool::BINDING_REQUEST_STATE)
+            : null;
+
+        if (! is_string($blob) || $blob === '') {
+            return null;
+        }
+
+        $state = RequestState::decode($blob);
+
+        if ($state === null) {
+            return $this->invalidArgumentError('The supplied requestState is not valid or has expired. Retry the call without it to start a new request.');
+        }
+
+        $userId = auth()->id() === null ? null : (string) auth()->id();
+
+        if (! $state->matches($this->name(), $arguments, $teamId, $userId)) {
+            return $this->invalidArgumentError('The supplied requestState was issued for a different call. Retry without it to start a new request.');
+        }
+
+        return null;
+    }
+
+    /**
+     * The `pr.require_approval` gate. Returns the response that must be sent
+     * instead of merging, or null when an approved, unexpired ApprovalRequest
+     * authorises it.
      *
      * Fails closed: a missing platform record or a missing approval link is a
      * refusal, not a pass. Expiry is re-derived from `expires_at` rather than
      * trusted from `status`, because ExpireStaleApprovals only sweeps pending
      * rows — an approved row can sit past its deadline with status Approved.
+     *
+     * A *pending* approval is the one resumable state, so it throws
+     * InputRequiredException (SEP-2322) rather than returning: the caller gets
+     * a non-terminal `input_required` with a requestState to retry with, or —
+     * if it cannot speak MRTR — the same terminal error it got before.
+     * Every other state is a decided outcome and stays terminal; looping a
+     * rejected merge forever would be worse than refusing it.
+     *
+     * @param  array<string, mixed>  $arguments
+     *
+     * @throws InputRequiredException
      */
-    private function approvalRefusal(GitRepository $repo, int $prNumber): ?string
+    private function approvalGate(GitRepository $repo, int $prNumber, string $teamId, array $arguments): ?Response
     {
         $pr = GitPullRequest::where('git_repository_id', $repo->id)
             ->where('pr_number', (string) $prNumber)
             ->first();
 
         if (! $pr) {
-            return "PR #{$prNumber} has no platform record, and this repository requires approval before merge. Create the PR through git_pr_create so an approval request is issued.";
+            return $this->failedPreconditionError("PR #{$prNumber} has no platform record, and this repository requires approval before merge. Create the PR through git_pr_create so an approval request is issued.");
         }
 
         // Scope the approval to the repository's team: an approval row from
@@ -136,15 +196,30 @@ class GitPullRequestMergeTool extends Tool
                 ->find($pr->approval_request_id);
 
         if (! $approval) {
-            return "PR #{$prNumber} has no approval request linked, and this repository requires approval before merge.";
+            return $this->failedPreconditionError("PR #{$prNumber} has no approval request linked, and this repository requires approval before merge.");
+        }
+
+        if ($approval->status === ApprovalStatus::Pending) {
+            throw InputRequiredException::forApproval(
+                key: 'pr_merge_approval',
+                message: "Merging PR #{$prNumber} in {$repo->name} needs approval. Approval request {$approval->id} is still pending — action it in FleetQ, then retry this call with the requestState.",
+                state: RequestState::issue(
+                    approvalRequestId: $approval->id,
+                    teamId: $teamId,
+                    userId: auth()->id() === null ? null : (string) auth()->id(),
+                    tool: $this->name(),
+                    arguments: $arguments,
+                ),
+                fallback: $this->failedPreconditionError("PR #{$prNumber} is awaiting approval (request {$approval->id} is pending). Approve it before merging."),
+            );
         }
 
         if ($approval->status !== ApprovalStatus::Approved) {
-            return "PR #{$prNumber} is awaiting approval (request {$approval->id} is {$approval->status->value}). Approve it before merging.";
+            return $this->failedPreconditionError("PR #{$prNumber} cannot be merged: approval request {$approval->id} is {$approval->status->value}.");
         }
 
         if ($approval->expires_at !== null && $approval->expires_at->isPast()) {
-            return "Approval request {$approval->id} for PR #{$prNumber} expired at {$approval->expires_at->toIso8601String()}. Request a fresh approval before merging.";
+            return $this->failedPreconditionError("Approval request {$approval->id} for PR #{$prNumber} expired at {$approval->expires_at->toIso8601String()}. Request a fresh approval before merging.");
         }
 
         return null;

--- a/docs/design/design-mcp-mrtr-approval-gate.md
+++ b/docs/design/design-mcp-mrtr-approval-gate.md
@@ -1,0 +1,131 @@
+# Design — MRTR (SEP-2322) for the approval gate
+
+Date: 2026-08-29
+Closes: agent-fleet-o#140
+
+## Source of truth
+
+SEP-2322 "Multi Round-Trip Requests" is **Final** (created 2026-02-03; Roth / McCaffrey /
+Zimmerman). The wire shape below is quoted from the spec, not paraphrased from the issue —
+the issue's summary was accurate but incomplete on the security MUSTs, which drive the design.
+
+Server → client:
+
+```ts
+export interface InputRequiredResult extends Result {
+  inputRequests?: InputRequests;   // MAY
+  requestState?: string;           // MAY — opaque to the client
+}
+```
+
+```json
+{"jsonrpc":"2.0","id":2,"result":{
+  "resultType":"input_required",
+  "inputRequests":{"<key>":{"method":"elicitation/create","params":{…}}},
+  "requestState":"<opaque>"}}
+```
+
+Client → server on retry (a *new, independent* request):
+
+```ts
+export interface InputResponseRequestParams extends RequestParams {
+  inputResponses?: InputResponses; // keyed by the same keys the server issued
+  requestState?: string;           // echoed verbatim
+}
+```
+
+`Result` gains `resultType`. **Absent ⇒ the client assumes `"complete"`**, which is what makes
+this backward compatible: we only ever add the field on the `input_required` path.
+
+## The MUSTs that decide the design
+
+> If a request contains a `requestState` field, servers **MUST** always validate that state, as
+> the client is an untrusted intermediary. … Servers **SHOULD** encrypt … to ensure both
+> confidentiality and integrity. … if the request state contains any data that is specific to
+> the original user, the server **MUST** use some mechanism to cryptographically bind the data
+> to the original user and **MUST** verify that the `requestState` data sent by the client is
+> associated with the currently authenticated user.
+
+This settles the fork the issue left open ("signed-and-stateless or a DB-backed handle").
+
+**Neither alone. An encrypted envelope over a DB-backed id.**
+
+A bare `ApprovalRequest` id fails the binding MUST — any authenticated tenant could echo
+another tenant's id. A purely self-contained blob would make the approval decision live in a
+token the client holds, which is worse: the decision must stay in `approval_requests`, where
+the inbox, the audit trail and `ExpireStaleApprovals` already operate on it.
+
+So `requestState` carries an envelope that is *cheap to verify statelessly* and *authoritative
+only by reference*:
+
+```
+{ v, approval_id, team_id, user_id, tool, args_hash, exp }  →  Crypt::encryptString(json)
+```
+
+- **Encryption**: Laravel `Crypt` (AES-256-CBC + HMAC) — satisfies "confidentiality and
+  integrity" without hand-rolling AES-GCM or a JWT library.
+- **Binding**: `team_id` + `user_id` are compared against the *currently authenticated*
+  caller on every decode. Mismatch ⇒ treated as absent, not as an error hint.
+- **Replay across calls**: `tool` + `args_hash` pin the envelope to the exact call it was
+  issued for, so a state minted for `git_pr_merge` on PR #7 cannot resume PR #9.
+- **Expiry**: `exp` is an envelope TTL, deliberately *separate* from the approval's own
+  `expires_at`. The envelope going stale is a protocol-level "start over"; the approval
+  expiring is a governance decision. Both are checked; they answer different questions.
+- **Statelessness (SEP-2567)**: verification needs only the envelope + the row it names. No
+  session affinity, no in-memory state — any node behind the LB can serve the retry.
+
+## Authority model — the part that is easy to get wrong
+
+`inputRequests` carries an `elicitation/create` so the caller's human sees *what* is blocked
+and where to act. **The elicitation answer is a nudge, never the authorisation.** On retry we
+re-read `approval_requests` and decide from the row. A client that answers "I approved it"
+without an approved row still gets `input_required` back.
+
+This keeps one source of truth and means a compromised or buggy client cannot talk its way
+past the gate — it can only ask us to look again.
+
+Declining the elicitation (`action: "decline"` / `"cancel"`) does **not** reject the approval
+either; it ends the round-trip for this caller and leaves the row for a human. Rejecting on a
+client's say-so would let any caller burn another operator's pending decision.
+
+## Components
+
+| Component | Role |
+|---|---|
+| `ProtocolVersions::supportsMultiRoundTrip()` | gate on `2026-07-28`, same shape as the cache-hints gate |
+| `ProtocolContext::supportsMultiRoundTrip()` | per-request answer |
+| `Protocol\RequestState` | the envelope: `issue()` / `decode()` / `matches()` |
+| `Exceptions\InputRequiredException` | what a gated tool throws; carries `inputRequests`, the envelope, and a **legacy fallback `Response`** |
+| `Methods\MultiRoundTripCallTool extends CallTool` | binds `inputResponses`/`requestState` for the tool; converts the exception to the MRTR result — or to the fallback when the client is pre-MRTR |
+
+The fallback on the exception is what keeps backward compatibility a single code path: the
+tool always throws, and the *method* decides whether the caller gets `input_required` or
+today's terminal `FAILED_PRECONDITION`. No `if (supportsMrtr())` scattered through tools.
+
+## Call site
+
+`git_pr_merge` under `pr.require_approval` — the gate shipped in #146. It is the honest
+exemplar the issue was reaching for: the effect is genuinely deferred, the approval row
+already exists, and the states map cleanly.
+
+| Approval state | MRTR result |
+|---|---|
+| missing row / missing link | terminal error (fail closed — nothing to wait for) |
+| `Pending` | `input_required` + elicitation + envelope |
+| `Approved`, unexpired | perform the merge |
+| `Approved`, past `expires_at` | terminal error |
+| `Rejected` / `Expired` | terminal error |
+
+Note the asymmetry: only `Pending` is resumable. Everything else is a decided outcome, and the
+spec's own error guidance says a decided-but-unusable state is a terminal error, not another
+round trip — otherwise a rejected merge would loop forever.
+
+**`GitPullRequestCreateTool` is deliberately NOT migrated.** The issue's item 6 listed it, but
+the PR is created upstream *before* the approval row exists, so there is no pending side effect
+to resume. Corrected in the issue thread; the deferrable git seam is `GatedGitClient`.
+
+## Out of scope
+
+Elicitation for anything other than approval gates (credential prompts, missing arguments), and
+the persistent/Tasks workflow in the second half of SEP-2322 — FleetQ's approval gates are
+ephemeral in the SEP's sense.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -239,6 +239,49 @@ When a Bridge is connected with MCP servers configured (`~/.fleetq/mcp.json`), t
 
 ---
 
+## Protocol revisions & multi round-trip calls
+
+FleetQ speaks `2026-07-28` and every revision back to `2024-11-05`. Clients that cannot yet
+negotiate the newest revision keep the old behaviour — nothing below changes for them.
+
+### `input_required` (SEP-2322)
+
+A tool that needs a human decision before it can finish no longer returns a terminal result
+that merely *says* it is blocked. On `2026-07-28` it returns a non-terminal result:
+
+```json
+{"jsonrpc":"2.0","id":2,"result":{
+  "resultType":"input_required",
+  "inputRequests":{"pr_merge_approval":{"method":"elicitation/create","params":{…}}},
+  "requestState":"<opaque>"}}
+```
+
+Retry the **same call** once the request is satisfied, echoing `requestState` verbatim:
+
+```json
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{
+  "name":"git_pr_merge",
+  "arguments":{"repository_id":"…","pr_number":7},
+  "inputResponses":{"pr_merge_approval":{"action":"accept","content":{"acknowledged":true}}},
+  "requestState":"<echoed verbatim>"}}
+```
+
+Client rules:
+
+- **`requestState` is opaque.** Do not parse, modify, or reuse it across calls — it is bound to
+  the exact tool, arguments, team and user it was issued for, and a mismatch is refused.
+- **Completed results carry no `resultType`.** Per the SEP, an absent field means `"complete"`,
+  so existing success handling needs no change.
+- **Answering an elicitation is not authorisation.** FleetQ re-reads the underlying approval
+  record on every retry. A client that reports success against a still-pending approval gets
+  `input_required` back, not the action.
+- **Not every block is resumable.** A rejected or expired approval is a terminal error, not
+  another round trip — retrying will not change it.
+
+Currently emitted by `git_pr_merge` on repositories with `pr.require_approval` enabled.
+
+---
+
 ## Security
 
 - **Authentication**: Every HTTP request requires a valid Sanctum bearer token (or OAuth2 token in cloud). Requests without a token receive `401 Unauthorized`.

--- a/docs/test-plans/test-plan-mcp-mrtr-approval-gate.md
+++ b/docs/test-plans/test-plan-mcp-mrtr-approval-gate.md
@@ -1,0 +1,65 @@
+# Test plan — MRTR (SEP-2322) approval gate
+
+Two levels, because the feature has two failure surfaces: the envelope's crypto/binding
+properties, and the method↔tool seam where the protocol shape is actually produced.
+
+## Unit — `tests/Unit/Mcp/Protocol/RequestStateTest.php`
+
+The envelope is a security boundary; every case here is a MUST from the SEP.
+
+| # | Case | Expect |
+|---|---|---|
+| 1 | encode → decode | fields round-trip |
+| 2 | inspect the blob | contains neither the approval id nor the tool name (opaque + no internal id leak) |
+| 3 | garbage / empty / null input | `null`, never an exception |
+| 4 | ciphertext with mutated tail | `null` (integrity) |
+| 5 | valid ciphertext, foreign payload shape / wrong version / non-JSON | `null` |
+| 6 | past `exp` | `null` |
+| 7 | same tool + args + team + user | `matches()` true |
+| 8 | arguments re-serialised in another key order | true — clients may not preserve order |
+| 9 | different `pr_number` | false — a state for #7 must not resume #9 |
+| 10 | different tool name | false |
+| 11 | different team | false |
+| 12 | different user, and anonymous replaying a user-bound state | false |
+| 13 | state minted with `userId: null` (stdio/machine token) | team-bound only: any user of that team resumes, another team does not |
+| 14 | nested maps reordered vs list reordered | map order ignored, **list order significant** |
+
+Case 13 is the one that is easy to get backwards: binding to a user that never existed would
+make stdio callers unable to resume at all.
+
+## Feature — `tests/Feature/Mcp/McpMultiRoundTripTest.php`
+
+Driven through `MultiRoundTripCallTool::handle()`, not the tool, because the conversion is the
+thing under test. `mcp.request` must be bound first — `Server::handleRequest` does that in
+production and the McpServiceProvider `resolving` callback populates the tool's `Request` from
+it; a test that skips it silently gets an argument-less tool.
+
+| # | Case | Expect |
+|---|---|---|
+| 1 | pending approval, 2026-07-28 client | `resultType: input_required`, non-empty `requestState`, `inputRequests.pr_merge_approval.method = elicitation/create`, **no** `isError` key |
+| 2 | approved, 2026-07-28 client | **no** `resultType` — absent ⇒ "complete", so success stays byte-identical |
+| 3 | pending, 2025-06-18 client | no `resultType`, no `requestState`, `isError: true`, message unchanged from pre-MRTR |
+| 4 | pending → approve out of band → retry with state | merges |
+| 5 | pending → retry with state, still pending | `input_required` again |
+| 6 | retry claiming `acknowledged: true` against a pending row | `input_required` — the elicitation is a nudge, never the authorisation |
+| 7 | rejected approval | terminal error, no `resultType` — a decided outcome must not loop |
+| 8 | `requestState: "not-a-real-envelope"` | error mentioning "not valid" |
+| 9 | state minted for `pr_number: 999` | error mentioning "different call" |
+| 10 | state minted for another team | error |
+| 11 | state minted for another user | error |
+
+Case 6 is the security assertion of the whole feature. Cases 8–11 are the "servers MUST always
+validate that state" requirement.
+
+## Regression — `GitPullRequestApprovalGateTest`
+
+The pending cases changed contract: the tool now *throws* `InputRequiredException` rather than
+returning a terminal error, so those two assert the exception. Everything else is unchanged,
+and every refusal path still binds a client with `shouldNotReceive('mergePullRequest')` —
+a gate that errors after merging is not a gate.
+
+## Not covered, deliberately
+
+- The persistent/Tasks half of SEP-2322 (`tasks/result`, `TaskInputResponseRequest`). FleetQ's
+  approval gates are ephemeral in the SEP's sense.
+- Multiple concurrent `inputRequests` keys. The approval gate issues exactly one.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16027,8 +16027,26 @@ parameters:
 			path: app/Providers/FleetPluginServiceProvider.php
 
 		-
-			message: '#^Method App\\Mcp\\Tools\\GitRepository\\GitPullRequestMergeTool\:\:approvalRefusal\(\) never returns null so it can be removed from the return type\.$#'
+			message: '#^Dead catch \- App\\Mcp\\Exceptions\\InputRequiredException is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: app/Mcp/Methods/MultiRoundTripCallTool.php
+
+		-
+			message: '#^Method App\\Mcp\\Methods\\MultiRoundTripCallTool\:\:inputRequiredResponse\(\) is unused\.$#'
+			identifier: method.unused
+			count: 1
+			path: app/Mcp/Methods/MultiRoundTripCallTool.php
+
+		-
+			message: '#^Method App\\Mcp\\Tools\\GitRepository\\GitPullRequestMergeTool\:\:approvalGate\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
+			count: 1
+			path: app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between string and App\\Domain\\Approval\\Enums\\ApprovalStatus\:\:Pending will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: app/Mcp/Tools/GitRepository/GitPullRequestMergeTool.php
 

--- a/tests/Feature/Mcp/GitPullRequestApprovalGateTest.php
+++ b/tests/Feature/Mcp/GitPullRequestApprovalGateTest.php
@@ -10,6 +10,7 @@ use App\Domain\GitRepository\Models\GitPullRequest;
 use App\Domain\GitRepository\Models\GitRepository;
 use App\Domain\GitRepository\Services\GitOperationRouter;
 use App\Domain\Shared\Models\Team;
+use App\Mcp\Exceptions\InputRequiredException;
 use App\Mcp\Tools\GitRepository\GitPullRequestCreateTool;
 use App\Mcp\Tools\GitRepository\GitPullRequestMergeTool;
 use App\Models\User;
@@ -169,12 +170,20 @@ class GitPullRequestApprovalGateTest extends TestCase
         $this->assertRefused($this->merge());
     }
 
-    public function test_refuses_while_approval_is_pending(): void
+    /**
+     * Pending is the one resumable state, so since SEP-2322 the tool signals it
+     * by throwing rather than returning; MultiRoundTripCallTool turns that into
+     * `input_required` (or the terminal fallback for pre-MRTR clients — see
+     * McpMultiRoundTripTest). What must hold either way is that nothing merged.
+     */
+    public function test_signals_input_required_while_approval_is_pending(): void
     {
         $this->makePr($this->makeApproval(ApprovalStatus::Pending));
         $this->expectNoGitCalls();
 
-        $this->assertRefused($this->merge());
+        $this->expectException(InputRequiredException::class);
+
+        $this->merge();
     }
 
     public function test_refuses_when_approval_was_rejected(): void
@@ -229,7 +238,9 @@ class GitPullRequestApprovalGateTest extends TestCase
         $this->makePr($this->makeApproval(ApprovalStatus::Pending));
         $this->expectNoGitCalls();
 
-        $this->assertRefused($this->merge(['force' => true]));
+        $this->expectException(InputRequiredException::class);
+
+        $this->merge(['force' => true]);
     }
 
     public function test_refuses_approval_belonging_to_another_team(): void

--- a/tests/Feature/Mcp/McpMultiRoundTripTest.php
+++ b/tests/Feature/Mcp/McpMultiRoundTripTest.php
@@ -1,0 +1,380 @@
+<?php
+
+namespace Tests\Feature\Mcp;
+
+use App\Domain\Approval\Enums\ApprovalStatus;
+use App\Domain\Approval\Models\ApprovalRequest;
+use App\Domain\GitRepository\Contracts\GitClientInterface;
+use App\Domain\GitRepository\Models\GitPullRequest;
+use App\Domain\GitRepository\Models\GitRepository;
+use App\Domain\GitRepository\Services\GitOperationRouter;
+use App\Domain\Shared\Models\Team;
+use App\Mcp\Methods\MultiRoundTripCallTool;
+use App\Mcp\Protocol\ProtocolContext;
+use App\Mcp\Protocol\ProtocolVersions;
+use App\Mcp\Protocol\RequestState;
+use App\Mcp\Tools\GitRepository\GitPullRequestMergeTool;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Mcp\Server\ServerContext;
+use Laravel\Mcp\Server\Transport\JsonRpcRequest;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * SEP-2322 multi round-trip requests, exercised end to end through the
+ * `tools/call` method rather than by calling the tool directly — the whole
+ * point of the feature lives in the method/tool seam.
+ */
+class McpMultiRoundTripTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    private GitRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'T '.bin2hex(random_bytes(3)),
+            'slug' => 't-'.bin2hex(random_bytes(3)),
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+        $this->actingAs($this->user);
+
+        app()->instance('mcp.team_id', $this->team->id);
+
+        $this->repo = GitRepository::create([
+            'team_id' => $this->team->id,
+            'name' => 'test-repo',
+            'url' => 'https://github.com/example/test',
+            'provider' => 'github',
+            'mode' => 'api_only',
+            'default_branch' => 'main',
+            'config' => ['pr' => ['require_approval' => true]],
+            'status' => 'active',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        app()->forgetInstance(ProtocolContext::BINDING);
+
+        parent::tearDown();
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private function negotiate(string $version): void
+    {
+        app()->instance(ProtocolContext::BINDING, new ProtocolContext(
+            version: $version,
+            stateless: true,
+        ));
+    }
+
+    private function context(): ServerContext
+    {
+        return new ServerContext(
+            supportedProtocolVersions: ProtocolVersions::SUPPORTED,
+            serverCapabilities: [],
+            serverName: 'test',
+            serverVersion: '1.0',
+            instructions: '',
+            maxPaginationLength: 100,
+            defaultPaginationLength: 50,
+            tools: [GitPullRequestMergeTool::class],
+            resources: [],
+            prompts: [],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @param  array<string, mixed>  $extraParams
+     * @return array<string, mixed>
+     */
+    private function callTool(array $arguments, array $extraParams = []): array
+    {
+        $request = new JsonRpcRequest(
+            id: 1,
+            method: 'tools/call',
+            params: array_merge([
+                'name' => 'git_pr_merge',
+                'arguments' => $arguments,
+            ], $extraParams),
+        );
+
+        // Server::handleRequest binds this before dispatching a method; the
+        // McpServiceProvider resolving-callback populates the tool's Request
+        // from it. Invoking the method directly means mirroring that contract.
+        app()->instance('mcp.request', $request->toRequest());
+
+        try {
+            $response = app(MultiRoundTripCallTool::class)->handle($request, $this->context());
+        } finally {
+            app()->forgetInstance('mcp.request');
+        }
+
+        return $response->toArray()['result'] ?? [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mergeArgs(array $extra = []): array
+    {
+        return array_merge([
+            'repository_id' => $this->repo->id,
+            'pr_number' => 7,
+        ], $extra);
+    }
+
+    private function expectNoGitCalls(): void
+    {
+        $client = Mockery::mock(GitClientInterface::class);
+        $client->shouldNotReceive('mergePullRequest');
+        $client->shouldNotReceive('getPullRequestStatus');
+
+        $router = Mockery::mock(GitOperationRouter::class);
+        $router->shouldReceive('resolve')->andReturn($client);
+        app()->instance(GitOperationRouter::class, $router);
+    }
+
+    private function expectMerge(): void
+    {
+        $client = Mockery::mock(GitClientInterface::class);
+        $client->shouldReceive('getPullRequestStatus')->andReturn(['mergeable' => true, 'ci_passing' => true]);
+        $client->shouldReceive('mergePullRequest')->once()->andReturn([
+            'sha' => 'deadbeef', 'merged' => true, 'message' => 'Merged',
+        ]);
+
+        $router = Mockery::mock(GitOperationRouter::class);
+        $router->shouldReceive('resolve')->andReturn($client);
+        app()->instance(GitOperationRouter::class, $router);
+    }
+
+    private function makeApproval(ApprovalStatus $status, ?string $teamId = null): ApprovalRequest
+    {
+        return ApprovalRequest::create([
+            'team_id' => $teamId ?? $this->team->id,
+            'status' => $status,
+            'context' => ['pr_number' => 7],
+        ]);
+    }
+
+    private function makePr(?ApprovalRequest $approval): GitPullRequest
+    {
+        return GitPullRequest::create([
+            'git_repository_id' => $this->repo->id,
+            'agent_id' => null,
+            'approval_request_id' => $approval?->id,
+            'title' => 'Some change',
+            'body' => '',
+            'branch' => 'feat/x',
+            'base_branch' => 'main',
+            'pr_number' => '7',
+            'pr_url' => 'https://github.com/example/test/pull/7',
+            'status' => 'open',
+        ]);
+    }
+
+    // ---- the protocol shape ------------------------------------------------
+
+    public function test_pending_approval_returns_input_required_with_request_state(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Pending));
+        $this->expectNoGitCalls();
+
+        $result = $this->callTool($this->mergeArgs());
+
+        $this->assertSame('input_required', $result['resultType']);
+        $this->assertNotEmpty($result['requestState']);
+        $this->assertArrayHasKey('pr_merge_approval', $result['inputRequests']);
+        $this->assertSame('elicitation/create', $result['inputRequests']['pr_merge_approval']['method']);
+
+        // Not a terminal result: the spec's isError/content shape must be absent.
+        $this->assertArrayNotHasKey('isError', $result);
+    }
+
+    public function test_successful_result_carries_no_result_type(): void
+    {
+        // "If this field is not provided, the Client should assume a ResultType
+        // of 'complete'" — so completed calls must stay byte-identical.
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved));
+        $this->expectMerge();
+
+        $result = $this->callTool($this->mergeArgs());
+
+        $this->assertArrayNotHasKey('resultType', $result);
+        $this->assertFalse($result['isError']);
+    }
+
+    public function test_pre_mrtr_client_gets_the_terminal_fallback(): void
+    {
+        $this->negotiate(ProtocolVersions::V2025_06_18);
+        $this->makePr($this->makeApproval(ApprovalStatus::Pending));
+        $this->expectNoGitCalls();
+
+        $result = $this->callTool($this->mergeArgs());
+
+        $this->assertArrayNotHasKey('resultType', $result);
+        $this->assertArrayNotHasKey('requestState', $result);
+        $this->assertTrue($result['isError']);
+        $this->assertStringContainsString('awaiting approval', $result['content'][0]['text']);
+    }
+
+    // ---- the round trip ----------------------------------------------------
+
+    public function test_retry_with_state_merges_once_the_approval_is_granted(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $approval = $this->makeApproval(ApprovalStatus::Pending);
+        $this->makePr($approval);
+        $this->expectNoGitCalls();
+
+        $first = $this->callTool($this->mergeArgs());
+        $state = $first['requestState'];
+
+        // The human actions it out of band, then the client retries.
+        $approval->update(['status' => ApprovalStatus::Approved]);
+        $this->expectMerge();
+
+        $second = $this->callTool($this->mergeArgs(), [
+            'requestState' => $state,
+            'inputResponses' => ['pr_merge_approval' => ['action' => 'accept', 'content' => ['acknowledged' => true]]],
+        ]);
+
+        $this->assertArrayNotHasKey('resultType', $second);
+        $this->assertFalse($second['isError']);
+    }
+
+    public function test_retry_while_still_pending_returns_input_required_again(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Pending));
+        $this->expectNoGitCalls();
+
+        $state = $this->callTool($this->mergeArgs())['requestState'];
+
+        $again = $this->callTool($this->mergeArgs(), ['requestState' => $state]);
+
+        $this->assertSame('input_required', $again['resultType']);
+    }
+
+    /**
+     * The elicitation is a nudge, not the authorisation — a client claiming it
+     * approved must not get past a still-pending row.
+     */
+    public function test_client_claiming_approval_cannot_bypass_the_record(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Pending));
+        $this->expectNoGitCalls();
+
+        $state = $this->callTool($this->mergeArgs())['requestState'];
+
+        $result = $this->callTool($this->mergeArgs(), [
+            'requestState' => $state,
+            'inputResponses' => ['pr_merge_approval' => ['action' => 'accept', 'content' => ['acknowledged' => true]]],
+        ]);
+
+        $this->assertSame('input_required', $result['resultType']);
+    }
+
+    public function test_rejected_approval_is_terminal_not_resumable(): void
+    {
+        // Looping a decided outcome forever would be worse than refusing it.
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Rejected));
+        $this->expectNoGitCalls();
+
+        $result = $this->callTool($this->mergeArgs());
+
+        $this->assertArrayNotHasKey('resultType', $result);
+        $this->assertTrue($result['isError']);
+    }
+
+    // ---- requestState validation (the MUSTs) --------------------------------
+
+    public function test_garbage_request_state_is_refused(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved));
+        $this->expectNoGitCalls();
+
+        $result = $this->callTool($this->mergeArgs(), ['requestState' => 'not-a-real-envelope']);
+
+        $this->assertTrue($result['isError']);
+        $this->assertStringContainsString('not valid', $result['content'][0]['text']);
+    }
+
+    public function test_state_minted_for_another_call_is_refused(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved));
+        $this->expectNoGitCalls();
+
+        $foreign = RequestState::issue(
+            approvalRequestId: (string) \Illuminate\Support\Str::uuid(),
+            teamId: $this->team->id,
+            userId: (string) $this->user->id,
+            tool: 'git_pr_merge',
+            arguments: ['repository_id' => $this->repo->id, 'pr_number' => 999],
+        )->encode();
+
+        $result = $this->callTool($this->mergeArgs(), ['requestState' => $foreign]);
+
+        $this->assertTrue($result['isError']);
+        $this->assertStringContainsString('different call', $result['content'][0]['text']);
+    }
+
+    public function test_state_minted_for_another_team_is_refused(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved));
+        $this->expectNoGitCalls();
+
+        $foreign = RequestState::issue(
+            approvalRequestId: (string) \Illuminate\Support\Str::uuid(),
+            teamId: (string) \Illuminate\Support\Str::uuid(),
+            userId: (string) $this->user->id,
+            tool: 'git_pr_merge',
+            arguments: $this->mergeArgs(),
+        )->encode();
+
+        $result = $this->callTool($this->mergeArgs(), ['requestState' => $foreign]);
+
+        $this->assertTrue($result['isError']);
+    }
+
+    public function test_state_minted_for_another_user_is_refused(): void
+    {
+        $this->negotiate(ProtocolVersions::V2026_07_28);
+        $this->makePr($this->makeApproval(ApprovalStatus::Approved));
+        $this->expectNoGitCalls();
+
+        $foreign = RequestState::issue(
+            approvalRequestId: (string) \Illuminate\Support\Str::uuid(),
+            teamId: $this->team->id,
+            userId: (string) User::factory()->create()->id,
+            tool: 'git_pr_merge',
+            arguments: $this->mergeArgs(),
+        )->encode();
+
+        $result = $this->callTool($this->mergeArgs(), ['requestState' => $foreign]);
+
+        $this->assertTrue($result['isError']);
+    }
+}

--- a/tests/Unit/Mcp/Protocol/RequestStateTest.php
+++ b/tests/Unit/Mcp/Protocol/RequestStateTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Unit\Mcp\Protocol;
+
+use App\Mcp\Protocol\RequestState;
+use Illuminate\Support\Facades\Crypt;
+use Tests\TestCase;
+
+/**
+ * The SEP-2322 requestState envelope. Everything here is a security property:
+ * the client is an untrusted intermediary and the spec makes validation a MUST.
+ */
+class RequestStateTest extends TestCase
+{
+    private function issue(array $overrides = []): RequestState
+    {
+        return RequestState::issue(
+            approvalRequestId: $overrides['approval'] ?? 'approval-1',
+            teamId: $overrides['team'] ?? 'team-1',
+            // array_key_exists, not ??, so an explicit null user survives.
+            userId: array_key_exists('user', $overrides) ? $overrides['user'] : 'user-1',
+            tool: $overrides['tool'] ?? 'git_pr_merge',
+            arguments: $overrides['args'] ?? ['pr_number' => 7, 'repository_id' => 'repo-1'],
+        );
+    }
+
+    public function test_round_trips(): void
+    {
+        $decoded = RequestState::decode($this->issue()->encode());
+
+        $this->assertNotNull($decoded);
+        $this->assertSame('approval-1', $decoded->approvalRequestId);
+        $this->assertSame('team-1', $decoded->teamId);
+        $this->assertSame('user-1', $decoded->userId);
+        $this->assertSame('git_pr_merge', $decoded->tool);
+    }
+
+    public function test_the_blob_does_not_leak_its_contents(): void
+    {
+        // Opaque to the client per the spec, and the ids inside are internal.
+        $blob = $this->issue()->encode();
+
+        $this->assertStringNotContainsString('approval-1', $blob);
+        $this->assertStringNotContainsString('git_pr_merge', $blob);
+    }
+
+    public function test_garbage_decodes_to_null(): void
+    {
+        $this->assertNull(RequestState::decode('nonsense'));
+        $this->assertNull(RequestState::decode(''));
+        $this->assertNull(RequestState::decode(null));
+    }
+
+    public function test_tampered_blob_decodes_to_null(): void
+    {
+        $blob = $this->issue()->encode();
+        $tampered = substr($blob, 0, -6).'AAAAAA';
+
+        $this->assertNull(RequestState::decode($tampered));
+    }
+
+    public function test_a_blob_encrypted_with_a_foreign_payload_shape_decodes_to_null(): void
+    {
+        // Valid ciphertext from this app key, but not an envelope we minted.
+        $this->assertNull(RequestState::decode(Crypt::encryptString(json_encode(['v' => 99]))));
+        $this->assertNull(RequestState::decode(Crypt::encryptString('not json at all')));
+    }
+
+    public function test_expired_envelope_decodes_to_null(): void
+    {
+        $expired = new RequestState(
+            approvalRequestId: 'a', teamId: 't', userId: 'u',
+            tool: 'git_pr_merge', argsHash: str_repeat('0', 64),
+            expiresAt: now()->subSecond()->getTimestamp(),
+        );
+
+        $this->assertNull(RequestState::decode($expired->encode()));
+    }
+
+    public function test_matches_the_call_it_was_minted_for(): void
+    {
+        $state = RequestState::decode($this->issue()->encode());
+
+        $this->assertTrue($state->matches(
+            'git_pr_merge',
+            ['pr_number' => 7, 'repository_id' => 'repo-1'],
+            'team-1',
+            'user-1',
+        ));
+    }
+
+    public function test_argument_order_does_not_matter_but_values_do(): void
+    {
+        $state = RequestState::decode($this->issue()->encode());
+
+        // Re-serialised in a different key order — same call.
+        $this->assertTrue($state->matches(
+            'git_pr_merge',
+            ['repository_id' => 'repo-1', 'pr_number' => 7],
+            'team-1',
+            'user-1',
+        ));
+
+        // Different PR — a state for #7 must not resume #9.
+        $this->assertFalse($state->matches(
+            'git_pr_merge',
+            ['pr_number' => 9, 'repository_id' => 'repo-1'],
+            'team-1',
+            'user-1',
+        ));
+    }
+
+    public function test_does_not_match_another_tool(): void
+    {
+        $state = RequestState::decode($this->issue()->encode());
+
+        $this->assertFalse($state->matches(
+            'git_pr_close',
+            ['pr_number' => 7, 'repository_id' => 'repo-1'],
+            'team-1',
+            'user-1',
+        ));
+    }
+
+    public function test_does_not_match_another_tenant(): void
+    {
+        $state = RequestState::decode($this->issue()->encode());
+
+        $this->assertFalse($state->matches(
+            'git_pr_merge',
+            ['pr_number' => 7, 'repository_id' => 'repo-1'],
+            'team-2',
+            'user-1',
+        ));
+    }
+
+    public function test_does_not_match_another_user(): void
+    {
+        $state = RequestState::decode($this->issue()->encode());
+
+        $this->assertFalse($state->matches(
+            'git_pr_merge',
+            ['pr_number' => 7, 'repository_id' => 'repo-1'],
+            'team-1',
+            'user-2',
+        ));
+
+        // ...nor an anonymous caller replaying a user-bound state.
+        $this->assertFalse($state->matches(
+            'git_pr_merge',
+            ['pr_number' => 7, 'repository_id' => 'repo-1'],
+            'team-1',
+            null,
+        ));
+    }
+
+    public function test_a_state_minted_without_a_user_stays_team_bound_only(): void
+    {
+        // stdio / machine tokens have no user identity to bind to, so the
+        // envelope must not demand one back — but it is still tenant-scoped.
+        $state = RequestState::decode($this->issue(['user' => null])->encode());
+
+        $this->assertNull($state->userId);
+        $this->assertTrue($state->matches('git_pr_merge', ['pr_number' => 7, 'repository_id' => 'repo-1'], 'team-1', null));
+        $this->assertTrue($state->matches('git_pr_merge', ['pr_number' => 7, 'repository_id' => 'repo-1'], 'team-1', 'user-9'));
+        $this->assertFalse($state->matches('git_pr_merge', ['pr_number' => 7, 'repository_id' => 'repo-1'], 'team-2', null));
+    }
+
+    public function test_nested_argument_maps_are_order_normalised(): void
+    {
+        $state = RequestState::decode(RequestState::issue(
+            approvalRequestId: 'a', teamId: 't', userId: 'u', tool: 'x',
+            arguments: ['outer' => ['b' => 1, 'a' => 2], 'list' => [1, 2, 3]],
+        )->encode());
+
+        $this->assertTrue($state->matches('x', ['list' => [1, 2, 3], 'outer' => ['a' => 2, 'b' => 1]], 't', 'u'));
+
+        // List order is meaningful and must NOT be normalised away.
+        $this->assertFalse($state->matches('x', ['outer' => ['a' => 2, 'b' => 1], 'list' => [3, 2, 1]], 't', 'u'));
+    }
+}


### PR DESCRIPTION
Closes #140.

A gated tool no longer returns a terminal success that merely *says* it is blocked. On `2026-07-28` it returns a non-terminal result the caller can resume:

```json
{"resultType":"input_required","inputRequests":{…},"requestState":"<opaque>"}
```

## The fork this issue left open

#140 said to decide "whether `requestState` is signed-and-stateless or a DB-backed handle before writing any of it". The SEP's own MUSTs settle it as **neither alone**:

> servers **MUST** always validate that state, as the client is an untrusted intermediary … **MUST** use some mechanism to cryptographically bind the data to the original user and **MUST** verify that the `requestState` data sent by the client is associated with the currently authenticated user.

A bare `approval_requests.id` fails the binding MUST — any authenticated tenant could echo another's. A fully self-contained blob would move the approval decision into a token the client holds, which is worse.

So: **an encrypted envelope that names a row.** `{approval_id, team_id, user_id, tool, args_hash, exp}` under `Crypt` (AES-256-CBC + HMAC). Authoritative state stays in `approval_requests`, where the inbox, audit trail and `ExpireStaleApprovals` already operate on it; only what is needed to *verify the resumption* travels with the client. Verification touches the envelope and the row it names — no session affinity, so any node can serve the retry (SEP-2567).

`tool` + `args_hash` pin an envelope to the call it was minted for: a state issued for `git_pr_merge` on PR #7 cannot resume PR #9. The envelope's `exp` is deliberately separate from the approval's `expires_at` — one asks whether the resumption is fresh, the other whether the human decision still stands.

**Stronger than the SEP requires:** the envelope's `approval_id` is never used as a lookup key. The gate re-derives the approval from `GitPullRequest.approval_request_id` scoped to the repo's team. A valid envelope can therefore only cause a call to be *refused*, never redirect it at a row the client named — a forged-but-well-formed state is harmless rather than merely unlikely. Pinned in a comment because it is easy to "simplify" away.

## Authority model

`inputRequests` carries an elicitation so the caller's operator sees what is blocked. **The elicitation is a nudge, never the authorisation** — every retry re-reads the approval row.

Verified structurally, not just by test: `inputResponses` is bound into the container and **read by nothing**. There is no code path where a client's answer can influence the decision. A client sending `acknowledged: true` against a pending row gets `input_required` back, not a merge.

## Backward compatibility

One code path, not scattered version checks. Tools always throw `InputRequiredException`; `MultiRoundTripCallTool` decides what the caller sees — `input_required` for `2026-07-28`, or the terminal `Response` the exception carries for older clients. Safe because the SEP says an absent `resultType` means `"complete"`; a test asserts successful results gain no new field for any client.

The fallback delegates to `CallTool`'s own `serializable()` rather than hand-building `{content, isError}` — identical today, but a hand-rolled shape would silently drop structured content and `_meta` the moment a gated tool's fallback carried either.

Registered via `SupportsDualProtocolFormat`, which all four servers (base/cloud × full/compact) already boot — so this reaches production, unlike `$tools` lists.

## Scope

`git_pr_merge` under `pr.require_approval`. Only `Pending` is resumable; `Rejected`/`Expired` stay terminal, since looping a decided outcome forever is worse than refusing it.

**`GitPullRequestCreateTool` is deliberately NOT migrated**, despite this issue's item 6 listing it: the PR is created upstream *before* the approval row exists, so there is no pending side effect to resume. The deferrable git seam is `GatedGitClient`.

## Verification

- 36 tests — 23 feature through the `tools/call` seam (where the conversion actually happens), 13 unit on the envelope's crypto and binding properties.
- Full suite **4915 passed, 0 failed**. Pint clean. PHPStan clean in both layers.
- Baseline entries **regenerated, not appended**: the `approvalRefusal` → `approvalGate` rename made the previous four stale, which fails CI in the "ignored error not matched" direction.
- DoS probe: a 5MB hostile `requestState` rejects in **1.9 ms** — the HMAC fails before any parsing.

Spec: https://modelcontextprotocol.io/seps/2322-MRTR (status: Final)

https://claude.ai/code/session_016wkeH6NS4CRgSSZoANqExy