### PR TITLE
feat(a2a): serve A2A so external peers can talk to our agents

### DIFF
--- a/app/Domain/AgentChatProtocol/Actions/DiscoverA2aAgentAction.php
+++ b/app/Domain/AgentChatProtocol/Actions/DiscoverA2aAgentAction.php
@@ -18,8 +18,9 @@ use Illuminate\Support\Str;
  * well-known URI and registering it as a callable-once-supported ExternalAgent
  * (adapter_kind = a2a).
  *
- * Read/discovery only — message dispatch to A2A agents is a deferred slice and
- * is guarded in ProtocolDispatcher. Flag-gated by `agent_chat.a2a.discovery_enabled`.
+ * Discovery only: this action registers the peer, it does not talk to it.
+ * Dispatch is implemented separately in ProtocolDispatcher::dispatchA2a and is
+ * gated by its own flag. Flag-gated by `agent_chat.a2a.discovery_enabled`.
  */
 class DiscoverA2aAgentAction
 {
@@ -117,10 +118,35 @@ class DiscoverA2aAgentAction
         return ExternalAgent::create([
             'id' => Str::uuid7()->toString(),
             'team_id' => $teamId,
-            'slug' => Str::slug($card->name).'-'.substr(Str::uuid7()->toString(), 0, 6),
+            'slug' => $this->uniqueSlug($teamId, $card->name),
             'endpoint_url' => $card->endpointUrl,
             'credential_id' => $credentialId,
             ...$attributes,
         ]);
+    }
+
+    /**
+     * Build a slug that is unique per team.
+     *
+     * The previous suffix was `substr(Str::uuid7(), 0, 6)`. UUIDv7 leads with a
+     * millisecond timestamp, so those six hex characters only change about every
+     * 4.6 hours — every peer discovered in the same window shared them, and two
+     * cards with the same `name` collided on the (team_id, slug) unique index
+     * and surfaced as a 500 instead of a second registered agent.
+     */
+    private function uniqueSlug(string $teamId, string $name): string
+    {
+        $base = Str::slug($name) ?: 'a2a-agent';
+
+        do {
+            $slug = $base.'-'.Str::lower(Str::random(6));
+        } while (
+            ExternalAgent::withoutGlobalScopes()
+                ->where('team_id', $teamId)
+                ->where('slug', $slug)
+                ->exists()
+        );
+
+        return $slug;
     }
 }

--- a/app/Domain/AgentChatProtocol/Enums/AgentChatVisibility.php
+++ b/app/Domain/AgentChatProtocol/Enums/AgentChatVisibility.php
@@ -11,6 +11,23 @@ enum AgentChatVisibility: string
     case Marketplace = 'marketplace';
     case Public = 'public';
 
+    /**
+     * Coerce a raw attribute into the enum.
+     *
+     * Eloquent hands this back as the enum at runtime, but static analysis sees
+     * the column's declared string type, so every `?->allowsPublicManifest()`
+     * on it reads as a call on a string. Normalising once keeps the call sites
+     * both correct and analysable instead of scattering baseline entries.
+     */
+    public static function normalize(mixed $value): ?self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        return is_string($value) ? self::tryFrom($value) : null;
+    }
+
     public function allowsPublicManifest(): bool
     {
         return in_array($this, [self::Marketplace, self::Public], true);

--- a/app/Domain/AgentChatProtocol/Exceptions/A2aDispatchNotSupportedException.php
+++ b/app/Domain/AgentChatProtocol/Exceptions/A2aDispatchNotSupportedException.php
@@ -9,10 +9,10 @@ use RuntimeException;
 /**
  * Thrown when something tries to *dispatch a message* to an A2A external agent.
  *
- * A2A discovery (reading the AgentCard) is implemented; A2A message dispatch
- * (JSON-RPC `message/send` + task lifecycle) is a deliberately deferred slice.
- * This exception is the boundary marker — it prevents A2A agents from silently
- * falling through to the generic HTTP `POST {endpoint}/chat` path, which is not
- * the A2A wire protocol.
+ * Dispatch IS implemented (A2aClient speaks JSON-RPC message/send + tasks/get);
+ * this marks the case where it is switched off via `agent_chat.a2a.dispatch_enabled`.
+ * It exists so a disabled A2A agent fails loudly instead of silently falling
+ * through to the generic HTTP `POST {endpoint}/chat` path, which is not the A2A
+ * wire protocol and would reach the peer as a malformed request.
  */
 class A2aDispatchNotSupportedException extends RuntimeException {}

--- a/app/Domain/AgentChatProtocol/Exceptions/A2aRpcException.php
+++ b/app/Domain/AgentChatProtocol/Exceptions/A2aRpcException.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AgentChatProtocol\Exceptions;
+
+/**
+ * A JSON-RPC level failure while serving an inbound A2A call.
+ *
+ * Carries the A2A error code so the transport can emit a spec-shaped `error`
+ * member instead of an HTTP status: A2A peers read the JSON-RPC envelope, and
+ * a bare 4xx tells them nothing about *which* part of the call was wrong.
+ *
+ * @see https://a2a-protocol.org/latest/specification/ §8 Error Handling
+ */
+class A2aRpcException extends \RuntimeException
+{
+    public const PARSE_ERROR = -32700;
+
+    public const INVALID_REQUEST = -32600;
+
+    public const METHOD_NOT_FOUND = -32601;
+
+    public const INVALID_PARAMS = -32602;
+
+    public const INTERNAL_ERROR = -32603;
+
+    public const TASK_NOT_FOUND = -32001;
+
+    public const TASK_NOT_CANCELABLE = -32002;
+
+    public function __construct(public readonly int $rpcCode, string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function methodNotFound(string $method): self
+    {
+        return new self(self::METHOD_NOT_FOUND, "Method not found: {$method}");
+    }
+
+    public static function invalidParams(string $detail): self
+    {
+        return new self(self::INVALID_PARAMS, $detail);
+    }
+
+    public static function taskNotFound(string $id): self
+    {
+        return new self(self::TASK_NOT_FOUND, "Task not found: {$id}");
+    }
+}

--- a/app/Domain/AgentChatProtocol/Services/A2aServer.php
+++ b/app/Domain/AgentChatProtocol/Services/A2aServer.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AgentChatProtocol\Services;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentChatProtocol\Enums\MessageDirection;
+use App\Domain\AgentChatProtocol\Enums\MessageStatus;
+use App\Domain\AgentChatProtocol\Exceptions\A2aRpcException;
+use App\Domain\AgentChatProtocol\Exceptions\InvalidProtocolMessageException;
+use App\Domain\AgentChatProtocol\Models\AgentChatMessage;
+use Illuminate\Support\Str;
+
+/**
+ * Server side of A2A: answers `message/send` and `tasks/get` for one of our own
+ * agents, so an external A2A peer can hold a conversation with it.
+ *
+ * This is a protocol facade, NOT a second execution engine. `message/send`
+ * funnels into the same ProtocolReceiver the REST chat endpoint uses, which
+ * fires ChatMessageReceived and lets ExecuteAgentOnChatMessage run the agent on
+ * the queue. Because that path is asynchronous, we always answer with an A2A
+ * Task rather than an immediate Message — which is exactly what the Task
+ * lifecycle exists for. `tasks/get` then reports progress by reading the
+ * inbound/outbound AgentChatMessage pair:
+ *
+ *   outbound reply exists (in_reply_to = inbound msg_id) -> completed
+ *   inbound marked Failed by the listener                -> failed
+ *   otherwise                                            -> working
+ *
+ * @see https://a2a-protocol.org/latest/specification/
+ */
+class A2aServer
+{
+    public function __construct(private readonly ProtocolReceiver $receiver) {}
+
+    /**
+     * Execute one JSON-RPC call and return the complete response envelope.
+     *
+     * @param  array<string, mixed>  $rpc
+     * @return array<string, mixed>
+     */
+    public function handle(Agent $agent, array $rpc): array
+    {
+        $id = $rpc['id'] ?? null;
+
+        try {
+            if (($rpc['jsonrpc'] ?? null) !== '2.0') {
+                throw new A2aRpcException(A2aRpcException::INVALID_REQUEST, 'jsonrpc must be "2.0"');
+            }
+
+            $method = (string) ($rpc['method'] ?? '');
+            $params = (array) ($rpc['params'] ?? []);
+
+            $result = match ($method) {
+                'message/send' => $this->messageSend($agent, $params),
+                'tasks/get' => $this->tasksGet($agent, $params),
+                // Cancellation would have to reach into a queued agent run, which
+                // there is no mechanism for. The spec has an error for exactly
+                // this, and returning it beats pretending the task stopped.
+                'tasks/cancel' => throw new A2aRpcException(
+                    A2aRpcException::TASK_NOT_CANCELABLE,
+                    'This agent does not support cancelling an in-flight task.',
+                ),
+                default => throw A2aRpcException::methodNotFound($method),
+            };
+
+            return ['jsonrpc' => '2.0', 'id' => $id, 'result' => $result];
+        } catch (A2aRpcException $e) {
+            return $this->error($id, $e->rpcCode, $e->getMessage());
+        } catch (InvalidProtocolMessageException $e) {
+            return $this->error($id, A2aRpcException::INVALID_PARAMS, $e->getMessage());
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    private function messageSend(Agent $agent, array $params): array
+    {
+        $message = (array) ($params['message'] ?? []);
+        $text = $this->textFromParts((array) ($message['parts'] ?? []));
+
+        if ($text === '') {
+            throw A2aRpcException::invalidParams('message.parts must contain at least one non-empty text part.');
+        }
+
+        // The protocol validator requires UUIDs, while A2A lets a peer use any
+        // string for messageId/contextId. Reuse theirs when it happens to be a
+        // UUID, otherwise mint one and keep the original for correlation.
+        $peerMessageId = (string) ($message['messageId'] ?? '');
+        $peerContextId = (string) ($message['contextId'] ?? $params['contextId'] ?? '');
+
+        $msgId = Str::isUuid($peerMessageId) ? $peerMessageId : Str::uuid7()->toString();
+        $sessionId = Str::isUuid($peerContextId) ? $peerContextId : Str::uuid7()->toString();
+
+        $inbound = $this->receiver->receiveChat($agent, [
+            'msg_id' => $msgId,
+            'session_id' => $sessionId,
+            'from' => 'a2a:peer',
+            'to' => (string) ($agent->chat_protocol_slug ?? $agent->id),
+            'content' => $text,
+            'timestamp' => now()->toIso8601String(),
+            'metadata' => array_filter([
+                'a2a' => true,
+                'peer_message_id' => $peerMessageId !== '' ? $peerMessageId : null,
+                'peer_context_id' => $peerContextId !== '' ? $peerContextId : null,
+            ], fn ($v) => $v !== null),
+        ]);
+
+        return $this->task($inbound, 'submitted');
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    private function tasksGet(Agent $agent, array $params): array
+    {
+        $id = (string) ($params['id'] ?? '');
+        if ($id === '') {
+            throw A2aRpcException::invalidParams('tasks/get requires an "id".');
+        }
+
+        // Scope by agent as well as id: a task id from one agent must never
+        // resolve against another, even within the same team.
+        $inbound = AgentChatMessage::withoutGlobalScopes()
+            ->where('agent_id', $agent->id)
+            ->where('direction', MessageDirection::Inbound)
+            ->where('msg_id', $id)
+            ->first();
+
+        if ($inbound === null) {
+            throw A2aRpcException::taskNotFound($id);
+        }
+
+        return $this->task($inbound, $this->stateFor($inbound));
+    }
+
+    private function stateFor(AgentChatMessage $inbound): string
+    {
+        if ($this->replyTo($inbound) !== null) {
+            return 'completed';
+        }
+
+        return $inbound->getAttribute('status') === MessageStatus::Failed ? 'failed' : 'working';
+    }
+
+    private function replyTo(AgentChatMessage $inbound): ?AgentChatMessage
+    {
+        return AgentChatMessage::withoutGlobalScopes()
+            ->where('agent_id', $inbound->agent_id)
+            ->where('direction', MessageDirection::Outbound)
+            ->where('in_reply_to', $inbound->msg_id)
+            ->latest('created_at')
+            ->first();
+    }
+
+    /**
+     * Build the A2A Task object for an inbound message in a given state.
+     *
+     * @return array<string, mixed>
+     */
+    private function task(AgentChatMessage $inbound, string $state): array
+    {
+        $reply = $state === 'completed' ? $this->replyTo($inbound) : null;
+
+        // Echo back the token the peer used as contextId; fall back to the row
+        // id if the session relation is not loaded.
+        $session = $inbound->getAttribute('session');
+        $contextId = $session !== null ? (string) $session->session_token : (string) $inbound->session_id;
+
+        $task = [
+            'kind' => 'task',
+            'id' => (string) $inbound->msg_id,
+            'contextId' => $contextId,
+            'status' => [
+                'state' => $state,
+                'timestamp' => now()->toIso8601String(),
+            ],
+            'history' => [$this->messageObject('user', $this->contentOf($inbound), (string) $inbound->msg_id)],
+        ];
+
+        if ($state === 'failed') {
+            $task['status']['message'] = $this->messageObject(
+                'agent',
+                (string) ($inbound->getAttribute('error') ?? 'Agent execution failed.'),
+                Str::uuid7()->toString(),
+            );
+        }
+
+        if ($reply !== null) {
+            $text = $this->contentOf($reply);
+            $task['artifacts'] = [[
+                'artifactId' => (string) $reply->msg_id,
+                'name' => 'reply',
+                'parts' => [['kind' => 'text', 'text' => $text]],
+            ]];
+            $task['history'][] = $this->messageObject('agent', $text, (string) $reply->msg_id);
+        }
+
+        return $task;
+    }
+
+    /**
+     * The `payload` column is a JSON cast; reading it through getAttribute
+     * keeps the array shape honest for static analysis.
+     */
+    private function contentOf(AgentChatMessage $message): string
+    {
+        return (string) (((array) $message->getAttribute('payload'))['content'] ?? '');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function messageObject(string $role, string $text, string $messageId): array
+    {
+        return [
+            'kind' => 'message',
+            'role' => $role,
+            'messageId' => $messageId,
+            'parts' => [['kind' => 'text', 'text' => $text]],
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $parts
+     */
+    private function textFromParts(array $parts): string
+    {
+        $chunks = [];
+        foreach ($parts as $part) {
+            if (is_array($part) && ($part['kind'] ?? null) === 'text' && isset($part['text'])) {
+                $chunks[] = (string) $part['text'];
+            }
+        }
+
+        return trim(implode("\n", $chunks));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function error(mixed $id, int $code, string $message): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $id,
+            'error' => ['code' => $code, 'message' => $message],
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/A2aServerController.php
+++ b/app/Http/Controllers/Api/V1/A2aServerController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domain\AgentChatProtocol\Services\A2aServer;
+use App\Domain\AgentChatProtocol\Services\HmacJwtVerifier;
+use App\Http\Controllers\Concerns\ResolvesChatProtocolAgent;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * A2A JSON-RPC endpoint for a single agent — the server half of the protocol
+ * FleetQ already speaks as a client through A2aClient.
+ *
+ * Authorization is the same trait the REST chat endpoint uses, so an agent's
+ * visibility governs both transports identically.
+ *
+ * @tags Agent Chat Protocol
+ */
+class A2aServerController extends Controller
+{
+    use ResolvesChatProtocolAgent;
+
+    public function __construct(
+        private readonly A2aServer $server,
+        private readonly HmacJwtVerifier $jwt,
+    ) {}
+
+    public function __invoke(Request $request, string $agentId): JsonResponse
+    {
+        if (! (bool) config('agent_chat.a2a.server_enabled', false)) {
+            abort(404, 'A2A server is not enabled');
+        }
+
+        $agent = $this->resolveChatProtocolAgent($request, $agentId, $this->jwt);
+        $this->enforceChatProtocolRate($request, $agent);
+
+        $body = $request->all();
+
+        // A JSON-RPC fault is reported inside a 200 envelope, not as an HTTP
+        // status — the peer parses `error`, and a bare 400 would tell it nothing
+        // about which member of the call was wrong.
+        return response()->json($this->server->handle($agent, $body));
+    }
+}

--- a/app/Http/Controllers/Api/V1/AgentChatController.php
+++ b/app/Http/Controllers/Api/V1/AgentChatController.php
@@ -9,6 +9,7 @@ use App\Domain\AgentChatProtocol\Enums\AckStatus;
 use App\Domain\AgentChatProtocol\Exceptions\InvalidProtocolMessageException;
 use App\Domain\AgentChatProtocol\Services\HmacJwtVerifier;
 use App\Domain\AgentChatProtocol\Services\ProtocolReceiver;
+use App\Http\Controllers\Concerns\ResolvesChatProtocolAgent;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -18,6 +19,8 @@ use Illuminate\Http\Request;
  */
 class AgentChatController extends Controller
 {
+    use ResolvesChatProtocolAgent;
+
     public function __construct(
         private readonly ProtocolReceiver $receiver,
         private readonly HmacJwtVerifier $jwt,
@@ -25,9 +28,9 @@ class AgentChatController extends Controller
 
     public function chat(Request $request, string $agentId): JsonResponse
     {
-        $agent = $this->resolveAgent($request, $agentId);
+        $agent = $this->resolveChatProtocolAgent($request, $agentId, $this->jwt);
 
-        $this->enforceRate($request, $agent);
+        $this->enforceChatProtocolRate($request, $agent);
 
         $payload = $request->all();
         try {
@@ -47,8 +50,8 @@ class AgentChatController extends Controller
 
     public function structured(Request $request, string $agentId): JsonResponse
     {
-        $agent = $this->resolveAgent($request, $agentId);
-        $this->enforceRate($request, $agent);
+        $agent = $this->resolveChatProtocolAgent($request, $agentId, $this->jwt);
+        $this->enforceChatProtocolRate($request, $agent);
 
         try {
             $message = $this->receiver->receiveStructured($agent, $request->all());
@@ -67,79 +70,11 @@ class AgentChatController extends Controller
 
     public function ack(Request $request, string $agentId): JsonResponse
     {
-        $agent = $this->resolveAgent($request, $agentId);
+        $agent = $this->resolveChatProtocolAgent($request, $agentId, $this->jwt);
         // Accept ACKs for outbound messages from this agent; store as inbound audit.
         $payload = $request->all();
 
         return response()->json(['status' => 'ack_received'], 200);
-    }
-
-    private function resolveAgent(Request $request, string $agentId): Agent
-    {
-        /** @var Agent|null $agent */
-        $agent = Agent::withoutGlobalScopes()
-            ->where('id', $agentId)
-            ->where('chat_protocol_enabled', true)
-            ->first();
-
-        if ($agent === null) {
-            abort(404, 'Agent not available on the chat protocol');
-        }
-
-        $visibility = $agent->chat_protocol_visibility;
-        if ($visibility !== null && $visibility->requiresSanctum()) {
-            $user = $request->user();
-            if ($user === null) {
-                abort(401, 'Sanctum token required');
-            }
-            if ((string) ($user->current_team_id ?? '') !== (string) $agent->team_id) {
-                abort(404, 'Agent not available on the chat protocol');
-            }
-        } elseif ($visibility !== null && $visibility->allowsPublicManifest()) {
-            $this->verifyJwt($request, $agent);
-        }
-
-        if ($request->hasHeader('content-length') && (int) $request->header('content-length') > (int) config('agent_chat.inbound.max_body_bytes', 512_000)) {
-            abort(413, 'Payload too large');
-        }
-
-        return $agent;
-    }
-
-    private function verifyJwt(Request $request, Agent $agent): void
-    {
-        $auth = $request->bearerToken();
-        if ($auth === null) {
-            abort(401, 'Bearer JWT required for public agent');
-        }
-        if (empty($agent->chat_protocol_secret)) {
-            abort(401, 'Agent secret not configured');
-        }
-        try {
-            $this->jwt->verify($auth, (string) $agent->chat_protocol_secret);
-        } catch (\Throwable $e) {
-            abort(401, 'Invalid JWT: '.$e->getMessage());
-        }
-    }
-
-    private function enforceRate(Request $request, Agent $agent): void
-    {
-        $perRemote = (int) config('agent_chat.inbound.rate_limit_per_remote_per_minute', 60);
-        $perAgent = (int) config('agent_chat.inbound.rate_limit_per_agent_per_minute', 300);
-
-        $remoteId = (string) ($request->input('from') ?? $request->ip());
-        $remoteKey = 'acp:remote:'.md5($remoteId).':'.$agent->id;
-        $agentKey = 'acp:agent:'.$agent->id;
-
-        $remoteCount = (int) cache()->get($remoteKey, 0);
-        $agentCount = (int) cache()->get($agentKey, 0);
-
-        if ($remoteCount >= $perRemote || $agentCount >= $perAgent) {
-            abort(429, 'Rate limit exceeded');
-        }
-
-        cache()->put($remoteKey, $remoteCount + 1, 60);
-        cache()->put($agentKey, $agentCount + 1, 60);
     }
 
     private function errorStatus(InvalidProtocolMessageException $e): int

--- a/app/Http/Controllers/Api/V1/AgentManifestController.php
+++ b/app/Http/Controllers/Api/V1/AgentManifestController.php
@@ -9,8 +9,10 @@ use App\Domain\AgentChatProtocol\Enums\AgentChatVisibility;
 use App\Domain\AgentChatProtocol\Services\AgentManifestCache;
 use App\Domain\Shared\Models\Team;
 use App\Http\Controllers\Controller;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 /**
  * Public Agent Chat Protocol manifest.
@@ -54,9 +56,7 @@ class AgentManifestController extends Controller
                 AgentChatVisibility::Marketplace->value,
                 AgentChatVisibility::Public->value,
             ])
-            ->where(function ($q) use ($slug): void {
-                $q->where('chat_protocol_slug', $slug)->orWhere('id', $slug);
-            })
+            ->where(fn ($q) => $this->matchSlugOrId($q, $slug))
             ->first();
 
         if ($agent === null) {
@@ -77,7 +77,63 @@ class AgentManifestController extends Controller
             abort(403, 'Forbidden');
         }
 
-        $team = Team::withoutGlobalScopes()->find($teamId);
+        return response()->json($this->buildA2aCard($agent));
+    }
+
+    /**
+     * Public A2A AgentCard at the RFC 8615 well-known URI.
+     *
+     * An external peer has no Sanctum token, so without this route the card was
+     * only reachable by the team that already owns the agent — which makes A2A
+     * discovery impossible for the one audience it exists for. Only agents the
+     * team has deliberately published (marketplace/public) are exposed.
+     */
+    public function publicA2a(string $slug): JsonResponse
+    {
+        $agent = Agent::withoutGlobalScopes()
+            ->where('chat_protocol_enabled', true)
+            ->where(fn ($q) => $this->matchSlugOrId($q, $slug))
+            ->first();
+
+        $visibility = $agent === null
+            ? null
+            : AgentChatVisibility::normalize($agent->getAttribute('chat_protocol_visibility'));
+
+        if ($visibility === null || ! $visibility->allowsPublicManifest()) {
+            abort(404, 'Agent not available on the chat protocol');
+        }
+
+        return response()->json($this->buildA2aCard($agent));
+    }
+
+    /**
+     * Match a public identifier against the slug, and against the id only when
+     * it could actually be one.
+     *
+     * `agents.id` is a Postgres `uuid` column: comparing it to an arbitrary
+     * string is not a miss, it is SQLSTATE 22P02 and a 500. Every public
+     * chat_protocol_slug is non-UUID by construction, so the unguarded
+     * `orWhere('id', $slug)` broke this endpoint for exactly the inputs it
+     * exists to serve. SQLite (the test database) accepts the comparison, which
+     * is why no test caught it.
+     */
+    private function matchSlugOrId(Builder $query, string $slug): Builder
+    {
+        $query->where('chat_protocol_slug', $slug);
+
+        if (Str::isUuid($slug)) {
+            $query->orWhere('id', $slug);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildA2aCard(Agent $agent): array
+    {
+        $team = Team::withoutGlobalScopes()->find($agent->team_id);
         $slug = $agent->chat_protocol_slug ?? $agent->id;
         $skills = $agent->skills()->get()->map(fn ($skill) => [
             'id' => $skill->id,
@@ -87,11 +143,20 @@ class AgentManifestController extends Controller
             'examples' => [],
         ])->values()->toArray();
 
-        return response()->json([
+        return [
             'schemaVersion' => '0.3',
             'name' => $agent->name,
             'description' => (string) ($agent->description ?? $agent->goal ?? ''),
-            'url' => url('/api/v1/agents/'.$agent->id.'/chat'),
+            // An AgentCard's `url` is where a peer sends A2A JSON-RPC. Pointing it
+            // at our REST chat endpoint made the card unusable: a conforming
+            // client would POST message/send and get our own envelope back.
+            'url' => url('/api/v1/agents/'.$agent->id.'/a2a'),
+            'preferredTransport' => 'JSONRPC',
+            'supportedInterfaces' => [[
+                'url' => url('/api/v1/agents/'.$agent->id.'/a2a'),
+                'protocolBinding' => 'JSONRPC',
+                'protocolVersion' => '0.3',
+            ]],
             'provider' => [
                 'organization' => $team?->name ?? 'FleetQ',
                 'url' => url('/'),
@@ -99,7 +164,7 @@ class AgentManifestController extends Controller
             'version' => '1.0.0',
             'documentationUrl' => url('/agents/'.$slug),
             'capabilities' => [
-                'streaming' => true,
+                'streaming' => false,
                 'pushNotifications' => false,
                 'stateTransitionHistory' => true,
             ],
@@ -110,6 +175,6 @@ class AgentManifestController extends Controller
             'defaultInputModes' => ['text/plain', 'application/json'],
             'defaultOutputModes' => ['text/plain', 'application/json'],
             'skills' => $skills,
-        ]);
+        ];
     }
 }

--- a/app/Http/Controllers/Concerns/ResolvesChatProtocolAgent.php
+++ b/app/Http/Controllers/Concerns/ResolvesChatProtocolAgent.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Concerns;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentChatProtocol\Enums\AgentChatVisibility;
+use App\Domain\AgentChatProtocol\Services\HmacJwtVerifier;
+use Illuminate\Http\Request;
+
+/**
+ * Inbound agent-chat authorization, shared by every transport that lets an
+ * outside caller reach one of our agents (REST chat, A2A JSON-RPC).
+ *
+ * It lives in one place deliberately: the rule that private/team agents need a
+ * same-team Sanctum token while public/marketplace agents need a JWT signed
+ * with the agent's own secret is the entire tenant boundary for this surface.
+ * Two transports maintaining their own copy is how one of them quietly drifts
+ * into being the weak one.
+ */
+trait ResolvesChatProtocolAgent
+{
+    protected function resolveChatProtocolAgent(Request $request, string $agentId, HmacJwtVerifier $jwt): Agent
+    {
+        /** @var Agent|null $agent */
+        $agent = Agent::withoutGlobalScopes()
+            ->where('id', $agentId)
+            ->where('chat_protocol_enabled', true)
+            ->first();
+
+        if ($agent === null) {
+            abort(404, 'Agent not available on the chat protocol');
+        }
+
+        $visibility = AgentChatVisibility::normalize($agent->getAttribute('chat_protocol_visibility'));
+        if ($visibility !== null && $visibility->requiresSanctum()) {
+            $user = $request->user();
+            if ($user === null) {
+                abort(401, 'Sanctum token required');
+            }
+            if ((string) ($user->current_team_id ?? '') !== (string) $agent->team_id) {
+                abort(404, 'Agent not available on the chat protocol');
+            }
+        } elseif ($visibility !== null && $visibility->allowsPublicManifest()) {
+            $this->verifyChatProtocolJwt($request, $agent, $jwt);
+        }
+
+        if ($request->hasHeader('content-length') && (int) $request->header('content-length') > (int) config('agent_chat.inbound.max_body_bytes', 512_000)) {
+            abort(413, 'Payload too large');
+        }
+
+        return $agent;
+    }
+
+    private function verifyChatProtocolJwt(Request $request, Agent $agent, HmacJwtVerifier $jwt): void
+    {
+        $auth = $request->bearerToken();
+        if ($auth === null) {
+            abort(401, 'Bearer JWT required for public agent');
+        }
+        if (empty($agent->chat_protocol_secret)) {
+            abort(401, 'Agent secret not configured');
+        }
+        try {
+            $jwt->verify($auth, (string) $agent->chat_protocol_secret);
+        } catch (\Throwable $e) {
+            abort(401, 'Invalid JWT: '.$e->getMessage());
+        }
+    }
+
+    protected function enforceChatProtocolRate(Request $request, Agent $agent): void
+    {
+        $perRemote = (int) config('agent_chat.inbound.rate_limit_per_remote_per_minute', 60);
+        $perAgent = (int) config('agent_chat.inbound.rate_limit_per_agent_per_minute', 300);
+
+        $remoteId = (string) ($request->input('from') ?? $request->ip());
+        $remoteKey = 'acp:remote:'.md5($remoteId).':'.$agent->id;
+        $agentKey = 'acp:agent:'.$agent->id;
+
+        $remoteCount = (int) cache()->get($remoteKey, 0);
+        $agentCount = (int) cache()->get($agentKey, 0);
+
+        if ($remoteCount >= $perRemote || $agentCount >= $perAgent) {
+            abort(429, 'Rate limit exceeded');
+        }
+
+        cache()->put($remoteKey, $remoteCount + 1, 60);
+        cache()->put($agentKey, $agentCount + 1, 60);
+    }
+}

--- a/app/Mcp/Servers/AgentFleetServer.php
+++ b/app/Mcp/Servers/AgentFleetServer.php
@@ -74,6 +74,7 @@ use App\Mcp\Tools\Agent\AgentWorkspaceContractGetTool;
 use App\Mcp\Tools\Agent\AgentWorkspaceExportTool;
 use App\Mcp\Tools\Agent\AgentWorkspaceImportTool;
 use App\Mcp\Tools\AgentChatProtocol\A2aDiscoverTool;
+use App\Mcp\Tools\AgentChatProtocol\A2aServerStatusTool;
 use App\Mcp\Tools\AgentChatProtocol\AgentChatManifestPublishTool;
 use App\Mcp\Tools\AgentChatProtocol\AgentChatManifestRevokeTool;
 use App\Mcp\Tools\AgentChatProtocol\AgentChatSendTool;
@@ -835,6 +836,7 @@ class AgentFleetServer extends Server
         ExternalAgentDeleteTool::class,
         ExternalAgentRefreshManifestTool::class,
         A2aDiscoverTool::class,
+        A2aServerStatusTool::class,
         ExternalAgentPingTool::class,
         AgentChatSendTool::class,
         AgentChatStructuredTool::class,

--- a/app/Mcp/Tools/AgentChatProtocol/A2aDiscoverTool.php
+++ b/app/Mcp/Tools/AgentChatProtocol/A2aDiscoverTool.php
@@ -24,7 +24,7 @@ class A2aDiscoverTool extends Tool
 
     protected string $name = 'external_agent_discover_a2a';
 
-    protected string $description = 'Discover an external A2A (Agent-to-Agent) agent by fetching its AgentCard from the well-known URI (/.well-known/agent-card.json) and registering it as an ExternalAgent. Pass the agent domain/base URL or a full card URL. Discovery only — calling A2A agents is not yet supported. Requires A2A_DISCOVERY_ENABLED=true.';
+    protected string $description = 'Discover an external A2A (Agent-to-Agent) agent by fetching its AgentCard from the well-known URI (/.well-known/agent-card.json) and registering it as an ExternalAgent. Pass the agent domain/base URL or a full card URL. Registers the peer so it can then be called with agent-chat-send. Requires A2A_DISCOVERY_ENABLED=true (and A2A_DISPATCH_ENABLED=true to call it).';
 
     public function schema(JsonSchema $schema): array
     {

--- a/app/Mcp/Tools/AgentChatProtocol/A2aServerStatusTool.php
+++ b/app/Mcp/Tools/AgentChatProtocol/A2aServerStatusTool.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\AgentChatProtocol;
+
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentChatProtocol\Enums\AgentChatVisibility;
+use App\Mcp\Attributes\AssistantTool;
+use App\Mcp\Concerns\HasStructuredErrors;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+#[AssistantTool('read')]
+class A2aServerStatusTool extends Tool
+{
+    use HasStructuredErrors;
+
+    protected string $name = 'a2a_server_status';
+
+    protected string $description = 'Report whether this team\'s agents are reachable by external A2A peers: the server flag, and per agent its AgentCard URL, JSON-RPC endpoint, visibility, and whether the card is published publicly. Use this to hand an external agent the right URL, or to work out why a peer cannot reach an agent.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'agent_id' => $schema->string()->description('Optional agent UUID to report on a single agent instead of all chat-enabled ones.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $validated = $request->validate(['agent_id' => 'nullable|string']);
+
+        $teamId = (app()->bound('mcp.team_id') ? app('mcp.team_id') : null) ?? auth()->user()?->current_team_id;
+        if (! $teamId) {
+            return $this->permissionDeniedError('No current team.');
+        }
+
+        $query = Agent::withoutGlobalScopes()
+            ->where('team_id', $teamId)
+            ->where('chat_protocol_enabled', true);
+
+        if (! empty($validated['agent_id'])) {
+            $query->where('id', $validated['agent_id']);
+        }
+
+        $agents = [];
+        foreach ($query->limit(200)->get() as $agent) {
+            $visibility = AgentChatVisibility::normalize($agent->getAttribute('chat_protocol_visibility'));
+            $public = $visibility?->allowsPublicManifest() ?? false;
+            $slug = $agent->chat_protocol_slug ?? $agent->id;
+            $rpcUrl = url('/api/v1/agents/'.$agent->id.'/a2a');
+
+            $agents[] = [
+                'agent_id' => $agent->id,
+                'name' => $agent->name,
+                'visibility' => $visibility?->value,
+                'rpc_url' => $rpcUrl,
+                'agent_card_url' => $public
+                    ? url('/.well-known/agents/'.$slug.'/agent-card.json')
+                    : $rpcUrl,
+                'card_is_public' => $public,
+                // Public agents authenticate peers with a JWT signed by the
+                // agent secret; team/private ones need a same-team Sanctum token.
+                'auth' => $public ? 'jwt_hs256_agent_secret' : 'sanctum_same_team',
+                'peer_ready' => $public && ! empty($agent->chat_protocol_secret),
+            ];
+        }
+
+        return Response::text((string) json_encode([
+            'server_enabled' => (bool) config('agent_chat.a2a.server_enabled', false),
+            'methods' => ['message/send', 'tasks/get'],
+            'streaming' => false,
+            'agents' => $agents,
+        ]));
+    }
+}

--- a/config/agent_chat.php
+++ b/config/agent_chat.php
@@ -42,6 +42,12 @@ return [
         // agents stay discoverable but not callable (ProtocolDispatcher throws).
         'dispatch_enabled' => env('A2A_DISPATCH_ENABLED', false),
 
+        // Server-side A2A: lets an external A2A peer talk to one of OUR agents
+        // over JSON-RPC (message/send + tasks/get). Independent of the two
+        // consumer flags above — this one opens an inbound surface, so it stays
+        // off until a deployment actually wants to be callable.
+        'server_enabled' => env('A2A_SERVER_ENABLED', false),
+
         // Max times to poll tasks/get for a long-running A2A Task before giving
         // up, and the delay between polls (ms). Bounds total wait alongside the
         // outbound timeout.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7278,23 +7278,8 @@ parameters:
 			count: 1
 			path: app/Domain/WorldModel/Models/TeamWorldModel.php
 
-		-
-			message: '#^Cannot call method allowsPublicManifest\(\) on string\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/Http/Controllers/Api/V1/AgentChatController.php
 
-		-
-			message: '#^Cannot call method requiresSanctum\(\) on string\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: app/Http/Controllers/Api/V1/AgentChatController.php
 
-		-
-			message: '#^Strict comparison using \!\=\= between string and null will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 2
-			path: app/Http/Controllers/Api/V1/AgentChatController.php
 
 		-
 			message: '#^Access to an undefined property App\\Domain\\Tool\\Models\\Tool\:\:\$pivot\.$#'

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\A2aServerController;
 use App\Http\Controllers\Api\V1\AgentChatController;
 use App\Http\Controllers\Api\V1\AgentChatSessionController;
 use App\Http\Controllers\Api\V1\AgentController;
@@ -97,6 +98,8 @@ Route::prefix('agents')
             ->name('agent-chat.inbound.structured');
         Route::post('/{agent}/ack', [AgentChatController::class, 'ack'])
             ->name('agent-chat.inbound.ack');
+        Route::post('/{agent}/a2a', A2aServerController::class)
+            ->name('agent-chat.inbound.a2a');
     });
 
 // Authenticated routes

--- a/routes/web.php
+++ b/routes/web.php
@@ -249,6 +249,8 @@ Route::get('/.well-known/agents', [AgentManifestController::class, 'index'])
     ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])
     ->middleware('throttle:60,1');
 
+Route::get('/.well-known/agents/{slug}/agent-card.json', [AgentManifestController::class, 'publicA2a'])
+    ->name('a2a.agent-card.agent');
 Route::get('/.well-known/agents/{slug}', [AgentManifestController::class, 'show'])
     ->name('agent-chat.manifest.show')
     ->withoutMiddleware([SetCurrentTeam::class, BypassAuth::class, EnsureTermsAccepted::class, SetPostgresRlsContext::class])

--- a/tests/Feature/Domain/AgentChatProtocol/A2aDiscoveryTest.php
+++ b/tests/Feature/Domain/AgentChatProtocol/A2aDiscoveryTest.php
@@ -166,8 +166,41 @@ class A2aDiscoveryTest extends TestCase
         $this->assertSame(1, ExternalAgent::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
     }
 
+    public function test_two_peers_sharing_a_card_name_do_not_collide_on_slug(): void
+    {
+        config(['agent_chat.a2a.discovery_enabled' => true]);
+
+        // The suffix used to come from the head of a UUIDv7, which is a
+        // millisecond timestamp — identical for anything registered within the
+        // same ~4.6 hours. Two same-named cards then hit the (team_id, slug)
+        // unique index and 500'd instead of both registering.
+        $cardOne = $this->sampleCard();
+        $cardOne['supportedInterfaces'] = [['url' => 'https://one.example.com/a2a/v1', 'protocolBinding' => 'JSONRPC']];
+        $cardTwo = $this->sampleCard();
+        $cardTwo['supportedInterfaces'] = [['url' => 'https://two.example.com/a2a/v1', 'protocolBinding' => 'JSONRPC']];
+
+        Http::fake([
+            'https://one.example.com/.well-known/agent-card.json' => Http::response($cardOne, 200),
+            'https://two.example.com/.well-known/agent-card.json' => Http::response($cardTwo, 200),
+        ]);
+
+        $action = app(DiscoverA2aAgentAction::class);
+        $first = $action->execute($this->team->id, 'https://one.example.com');
+        $second = $action->execute($this->team->id, 'https://two.example.com');
+
+        $this->assertNotSame($first->id, $second->id);
+        $this->assertNotSame($first->slug, $second->slug);
+        $this->assertSame(2, ExternalAgent::withoutGlobalScopes()->where('team_id', $this->team->id)->count());
+    }
+
     public function test_dispatching_to_a2a_agent_is_guarded(): void
     {
+        // Stated rather than inherited: this asserts the guard, so it must not
+        // depend on the ambient default (a developer with A2A_DISPATCH_ENABLED
+        // in their .env otherwise sees a real outbound call and a confusing
+        // ConnectionException here).
+        config(['agent_chat.a2a.dispatch_enabled' => false]);
+
         $agent = ExternalAgent::create([
             'id' => Str::uuid7()->toString(),
             'team_id' => $this->team->id,

--- a/tests/Feature/Domain/AgentChatProtocol/A2aServerTest.php
+++ b/tests/Feature/Domain/AgentChatProtocol/A2aServerTest.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Domain\AgentChatProtocol;
+
+use App\Domain\Agent\Enums\AgentStatus;
+use App\Domain\Agent\Models\Agent;
+use App\Domain\AgentChatProtocol\Enums\AgentChatVisibility;
+use App\Domain\AgentChatProtocol\Enums\MessageDirection;
+use App\Domain\AgentChatProtocol\Enums\MessageStatus;
+use App\Domain\AgentChatProtocol\Enums\MessageType;
+use App\Domain\AgentChatProtocol\Events\ChatMessageReceived;
+use App\Domain\AgentChatProtocol\Models\AgentChatMessage;
+use App\Domain\AgentChatProtocol\Services\HmacJwtVerifier;
+use App\Domain\Shared\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Server side of A2A: an external peer holding a conversation with one of our
+ * agents over JSON-RPC.
+ */
+class A2aServerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Team $team;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware([ThrottleRequests::class, ThrottleRequestsWithRedis::class]);
+        config(['agent_chat.a2a.server_enabled' => true]);
+
+        // The agent itself runs on a queued listener; these tests are about the
+        // protocol surface, so the reply is written directly where it matters.
+        Event::fake([ChatMessageReceived::class]);
+
+        $this->user = User::factory()->create();
+        $this->team = Team::create([
+            'name' => 'A2A Server Team',
+            'slug' => 'a2a-server-team-'.Str::random(6),
+            'owner_id' => $this->user->id,
+            'settings' => [],
+        ]);
+        $this->user->update(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($this->user, ['role' => 'owner']);
+    }
+
+    // ── transport + lifecycle ────────────────────────────────────────────────
+
+    public function test_message_send_accepts_a_peer_message_and_returns_a_submitted_task(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $response = $this->postJson($this->rpcUrl($agent), $this->rpc('message/send', [
+            'message' => [
+                'role' => 'user', 'kind' => 'message',
+                'messageId' => (string) Str::uuid7(),
+                'parts' => [['kind' => 'text', 'text' => 'What is the status?']],
+            ],
+        ]));
+
+        $response->assertOk();
+        $this->assertSame('2.0', $response->json('jsonrpc'));
+        $this->assertSame('task', $response->json('result.kind'));
+        $this->assertSame('submitted', $response->json('result.status.state'));
+
+        $taskId = $response->json('result.id');
+        $this->assertDatabaseHas('agent_chat_messages', [
+            'msg_id' => $taskId,
+            'agent_id' => $agent->id,
+            'direction' => MessageDirection::Inbound->value,
+        ]);
+        $this->assertSame('What is the status?', AgentChatMessage::withoutGlobalScopes()
+            ->where('msg_id', $taskId)->value('payload')['content']);
+    }
+
+    public function test_tasks_get_reports_working_until_the_agent_replies_then_completed_with_an_artifact(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $taskId = $this->postJson($this->rpcUrl($agent), $this->rpc('message/send', [
+            'message' => ['parts' => [['kind' => 'text', 'text' => 'ping']]],
+        ]))->json('result.id');
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('tasks/get', ['id' => $taskId]))
+            ->assertOk()
+            ->assertJsonPath('result.status.state', 'working');
+
+        $this->writeReply($agent, $taskId, 'pong from the agent');
+
+        $done = $this->postJson($this->rpcUrl($agent), $this->rpc('tasks/get', ['id' => $taskId]));
+        $done->assertOk();
+        $done->assertJsonPath('result.status.state', 'completed');
+        $this->assertSame('pong from the agent', $done->json('result.artifacts.0.parts.0.text'));
+        // History carries both turns so a peer can reconstruct the exchange.
+        $this->assertCount(2, $done->json('result.history'));
+        $this->assertSame('agent', $done->json('result.history.1.role'));
+    }
+
+    public function test_tasks_get_reports_failed_when_the_agent_run_failed(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $taskId = $this->postJson($this->rpcUrl($agent), $this->rpc('message/send', [
+            'message' => ['parts' => [['kind' => 'text', 'text' => 'boom']]],
+        ]))->json('result.id');
+
+        AgentChatMessage::withoutGlobalScopes()->where('msg_id', $taskId)
+            ->update(['status' => MessageStatus::Failed->value, 'error' => 'model refused']);
+
+        $response = $this->postJson($this->rpcUrl($agent), $this->rpc('tasks/get', ['id' => $taskId]));
+
+        $response->assertJsonPath('result.status.state', 'failed');
+        $this->assertSame('model refused', $response->json('result.status.message.parts.0.text'));
+    }
+
+    // ── JSON-RPC error surface ───────────────────────────────────────────────
+
+    public function test_unknown_task_id_returns_task_not_found_rather_than_an_http_error(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $response = $this->postJson($this->rpcUrl($agent), $this->rpc('tasks/get', ['id' => (string) Str::uuid7()]));
+
+        $response->assertOk();
+        $response->assertJsonPath('error.code', -32001);
+    }
+
+    public function test_a_task_id_from_another_agent_does_not_resolve(): void
+    {
+        $agentA = $this->agent(AgentChatVisibility::Team);
+        $agentB = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $taskId = $this->postJson($this->rpcUrl($agentA), $this->rpc('message/send', [
+            'message' => ['parts' => [['kind' => 'text', 'text' => 'for A only']]],
+        ]))->json('result.id');
+
+        $this->postJson($this->rpcUrl($agentB), $this->rpc('tasks/get', ['id' => $taskId]))
+            ->assertJsonPath('error.code', -32001);
+    }
+
+    public function test_unknown_method_returns_method_not_found(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('message/stream', []))
+            ->assertJsonPath('error.code', -32601);
+    }
+
+    public function test_cancel_is_refused_with_the_spec_error_instead_of_pretending(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('tasks/cancel', ['id' => 'x']))
+            ->assertJsonPath('error.code', -32002);
+    }
+
+    public function test_message_without_a_text_part_returns_invalid_params(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('message/send', ['message' => ['parts' => []]]))
+            ->assertJsonPath('error.code', -32602);
+    }
+
+    public function test_wrong_jsonrpc_version_returns_invalid_request(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $this->postJson($this->rpcUrl($agent), ['jsonrpc' => '1.0', 'id' => 1, 'method' => 'tasks/get'])
+            ->assertJsonPath('error.code', -32600);
+    }
+
+    public function test_a_non_uuid_peer_message_id_is_accepted_and_correlated(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        // A2A allows any string id; our protocol validator requires UUIDs.
+        $response = $this->postJson($this->rpcUrl($agent), $this->rpc('message/send', [
+            'message' => ['messageId' => 'peer-abc-123', 'parts' => [['kind' => 'text', 'text' => 'hi']]],
+        ]));
+
+        $response->assertOk();
+        $taskId = $response->json('result.id');
+        $this->assertTrue(Str::isUuid($taskId));
+
+        $payload = AgentChatMessage::withoutGlobalScopes()->where('msg_id', $taskId)->value('payload');
+        $this->assertSame('peer-abc-123', $payload['metadata']['peer_message_id']);
+    }
+
+    // ── authorization + gating ───────────────────────────────────────────────
+
+    public function test_server_disabled_returns_404(): void
+    {
+        config(['agent_chat.a2a.server_enabled' => false]);
+        $agent = $this->agent(AgentChatVisibility::Team);
+        Sanctum::actingAs($this->user, ['*']);
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('tasks/get', ['id' => 'x']))
+            ->assertStatus(404);
+    }
+
+    public function test_public_agent_requires_a_signed_jwt(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Public);
+        $agent->update(['chat_protocol_secret' => 'a2a-secret']);
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('message/send', [
+            'message' => ['parts' => [['kind' => 'text', 'text' => 'hi']]],
+        ]))->assertStatus(401);
+
+        $token = app(HmacJwtVerifier::class)->sign(['sub' => 'ext:peer'], 'a2a-secret', 60);
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('message/send', [
+            'message' => ['parts' => [['kind' => 'text', 'text' => 'hi']]],
+        ]), ['Authorization' => 'Bearer '.$token])->assertOk();
+    }
+
+    public function test_team_agent_is_not_reachable_from_another_team(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Team);
+
+        $outsider = User::factory()->create();
+        $otherTeam = Team::create([
+            'name' => 'Other', 'slug' => 'other-'.Str::random(6),
+            'owner_id' => $outsider->id, 'settings' => [],
+        ]);
+        $outsider->update(['current_team_id' => $otherTeam->id]);
+
+        Sanctum::actingAs($outsider, ['*']);
+
+        $this->postJson($this->rpcUrl($agent), $this->rpc('tasks/get', ['id' => 'x']))
+            ->assertStatus(404);
+    }
+
+    // ── discovery ────────────────────────────────────────────────────────────
+
+    public function test_public_agent_card_is_reachable_without_auth_and_points_at_the_rpc_endpoint(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Public);
+
+        $response = $this->getJson('/.well-known/agents/'.$agent->chat_protocol_slug.'/agent-card.json');
+
+        $response->assertOk();
+        $response->assertJsonPath('url', url('/api/v1/agents/'.$agent->id.'/a2a'));
+        $response->assertJsonPath('preferredTransport', 'JSONRPC');
+        $response->assertJsonPath('supportedInterfaces.0.protocolBinding', 'JSONRPC');
+    }
+
+    public function test_private_agent_card_is_not_published(): void
+    {
+        $agent = $this->agent(AgentChatVisibility::Private);
+
+        $this->getJson('/.well-known/agents/'.$agent->chat_protocol_slug.'/agent-card.json')
+            ->assertStatus(404);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private function rpcUrl(Agent $agent): string
+    {
+        return '/api/v1/agents/'.$agent->id.'/a2a';
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     * @return array<string, mixed>
+     */
+    private function rpc(string $method, array $params): array
+    {
+        return ['jsonrpc' => '2.0', 'id' => (string) Str::uuid7(), 'method' => $method, 'params' => $params];
+    }
+
+    private function agent(AgentChatVisibility $visibility): Agent
+    {
+        return Agent::create([
+            'id' => (string) Str::uuid7(),
+            'team_id' => $this->team->id,
+            'name' => 'A2A Server Agent '.Str::random(4),
+            'slug' => 'a2a-srv-'.Str::random(8),
+            'role' => 'assistant',
+            'goal' => 'answer peers',
+            'backstory' => 'test',
+            'provider' => 'anthropic',
+            'model' => 'claude-sonnet',
+            'status' => AgentStatus::Active,
+            'chat_protocol_enabled' => true,
+            'chat_protocol_visibility' => $visibility->value,
+            'chat_protocol_slug' => 'a2a-srv-'.Str::random(8),
+        ]);
+    }
+
+    /**
+     * Stand in for ExecuteAgentOnChatMessage, which is queued and faked here.
+     */
+    private function writeReply(Agent $agent, string $inReplyTo, string $text): void
+    {
+        $inbound = AgentChatMessage::withoutGlobalScopes()->where('msg_id', $inReplyTo)->firstOrFail();
+
+        AgentChatMessage::create([
+            'id' => (string) Str::uuid7(),
+            'team_id' => $agent->team_id,
+            'session_id' => $inbound->session_id,
+            'agent_id' => $agent->id,
+            'direction' => MessageDirection::Outbound,
+            'message_type' => MessageType::ChatMessage,
+            'msg_id' => (string) Str::uuid7(),
+            'in_reply_to' => $inReplyTo,
+            'from_identifier' => 'agent',
+            'to_identifier' => 'a2a:peer',
+            'status' => MessageStatus::Delivered,
+            'payload' => ['content' => $text],
+        ]);
+    }
+}

--- a/tests/Feature/Domain/AgentChatProtocol/AgentA2ACardTest.php
+++ b/tests/Feature/Domain/AgentChatProtocol/AgentA2ACardTest.php
@@ -96,7 +96,7 @@ class AgentA2ACardTest extends TestCase
             ->assertJsonFragment(['schemaVersion' => '0.3']);
     }
 
-    public function test_a2a_endpoint_returns_capabilities_with_streaming_true(): void
+    public function test_a2a_endpoint_declares_streaming_false_because_no_stream_method_is_served(): void
     {
         Sanctum::actingAs($this->user, ['*']);
 
@@ -105,7 +105,10 @@ class AgentA2ACardTest extends TestCase
         $response = $this->getJson('/api/v1/agents/'.$agent->id.'/a2a');
 
         $response->assertOk();
-        $this->assertTrue($response->json('capabilities.streaming'));
+        // capabilities.streaming advertises support for A2A `message/stream`.
+        // We only serve message/send and tasks/get, so claiming true would send
+        // conforming peers to a method that does not exist.
+        $this->assertFalse($response->json('capabilities.streaming'));
     }
 
     public function test_a2a_endpoint_returns_skills_array(): void

--- a/tests/Feature/Domain/AgentChatProtocol/AssistantBridgeTest.php
+++ b/tests/Feature/Domain/AgentChatProtocol/AssistantBridgeTest.php
@@ -11,12 +11,12 @@ use ReflectionClass;
 
 class AssistantBridgeTest extends TestCase
 {
-    public function test_all_16_agent_chat_protocol_tools_are_registered_on_server(): void
+    public function test_all_17_agent_chat_protocol_tools_are_registered_on_server(): void
     {
         $tools = (new ReflectionClass(AgentFleetServer::class))->getDefaultProperties()['tools'] ?? [];
         $acp = array_filter($tools, fn (string $class) => str_contains($class, 'AgentChatProtocol'));
 
-        $this->assertCount(16, $acp, 'Expected 16 Agent Chat Protocol MCP tools registered on the server.');
+        $this->assertCount(17, $acp, 'Expected 17 Agent Chat Protocol MCP tools registered on the server.');
     }
 
     public function test_agent_chat_protocol_tools_are_tier_annotated(): void
@@ -33,7 +33,7 @@ class AssistantBridgeTest extends TestCase
             $buckets[$tier]++;
         }
 
-        $this->assertSame(6, $buckets['read'], 'Expected 6 read-tier ACP tools (added agentverse_search).');
+        $this->assertSame(7, $buckets['read'], 'Expected 7 read-tier ACP tools (added a2a_server_status).');
         $this->assertSame(8, $buckets['write'], 'Expected 8 write-tier ACP tools (added external_agent_discover_a2a).');
         $this->assertSame(2, $buckets['destructive'], 'Expected 2 destructive-tier ACP tools.');
     }


### PR DESCRIPTION
Adds the server half of A2A. FleetQ could call other A2A agents but could not be called by one — discovery worked, with nothing on the other end of it.

## What's new
- `A2aServer` answers `message/send` and `tasks/get`. A protocol facade, not a second execution engine: it funnels into the same `ProtocolReceiver` the REST chat endpoint uses. That path is asynchronous, which is what the A2A Task lifecycle exists for — state is read from the inbound/outbound `AgentChatMessage` pair.
- `POST /api/v1/agents/{agent}/a2a`, gated by `A2A_SERVER_ENABLED` (default off — it opens an inbound surface).
- Authorization extracted into `ResolvesChatProtocolAgent`, shared with the REST chat endpoint. That rule is the whole tenant boundary for this surface; two transports keeping private copies is how one drifts into being the weak one.
- Public card at `/.well-known/agents/{slug}/agent-card.json` — the authed card was only reachable by the team that already owns the agent, which makes discovery impossible for its one audience.
- `a2a_server_status` MCP tool.

## Three defects found while proving it end to end
1. **`/.well-known/agents/{slug}` returned 500 for every real slug.** `orWhere('id', $slug)` compares a non-UUID string to a Postgres `uuid` column — SQLSTATE 22P02, not a miss. SQLite (the test database) accepts the comparison, which is why no test caught it.
2. **ExternalAgent slugs collided.** The suffix came from the head of a UUIDv7 — a millisecond timestamp, identical for anything registered within the same ~4.6 hours — so two peers sharing a card name hit the `(team_id, slug)` unique index.
3. **The card claimed `streaming: true`** while serving no `message/stream`; a test pinned the false claim. Also corrected two descriptions that still told readers dispatch was unimplemented.

## Verification
Full round trip over a real socket, not fakes: public card fetched unauthenticated → discovered as an ExternalAgent → Bearer credential attached → `message/send` → Task `working` → agent reply → `tasks/get` → `completed` with artifact and two-turn history.

Suite: 4931 passed, 0 failures. pint PASS (4383 files). phpstan clean — stale baseline entries for the moved code pruned from both baselines.

https://claude.ai/code/session_01LG1wafr5ryTufTwHuDKdnE