### PR TITLE
fix(memory): нощната дестилация да уважава доставчика на екипа

### DIFF
--- a/app/Domain/Memory/Actions/DistillTeamEventsAction.php
+++ b/app/Domain/Memory/Actions/DistillTeamEventsAction.php
@@ -9,6 +9,8 @@ use App\Domain\Shared\Exceptions\AiAccessUnavailableException;
 use App\Domain\Shared\Models\Team;
 use App\Infrastructure\AI\Contracts\AiGatewayInterface;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
+use App\Infrastructure\AI\Exceptions\VpsLocalAgentException;
+use App\Infrastructure\AI\Services\ProviderResolver;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
@@ -36,6 +38,7 @@ PROMPT;
     public function __construct(
         private readonly AiGatewayInterface $gateway,
         private readonly StoreMemoryAction $storeMemory,
+        private readonly ProviderResolver $providerResolver,
     ) {}
 
     /**
@@ -75,10 +78,18 @@ PROMPT;
         // backpressure, not a defect, so it must be skipped like the
         // fallback-chain case instead of churning failed_jobs and Sentry
         // forever. (#824/#847/#1035/#1064)
+        //
+        // VpsLocalAgentException попада в същата категория: екип, чийто default
+        // сочи `claude-code-vps`, но не е в whitelist-а (или е ударил
+        // concurrency cap-а), не е дефект — това е същият backpressure. Хвърля
+        // се СЪЗНАТЕЛНО нагоре при интерактивна работа (там потребителят ТРЯБВА
+        // да види съобщението), затова НЕ се филтрира в BeforeSendFilter, а се
+        // поглъща само тук, във фоновата нощна задача. (FLEETQ-BJ)
         try {
-            $summary = $this->distil($events, $teamId);
+            $summary = $this->distil($events, $team, $teamId);
         } catch (RuntimeException $e) {
             if (! $e instanceof AiAccessUnavailableException
+                && ! $e instanceof VpsLocalAgentException
                 && ! str_contains($e->getMessage(), 'No available providers in fallback chain')) {
                 throw $e;
             }
@@ -137,7 +148,7 @@ PROMPT;
     /**
      * @param  Collection<int, AuditEntry>  $events
      */
-    private function distil(Collection $events, string $teamId): string
+    private function distil(Collection $events, ?Team $team, string $teamId): string
     {
         $log = $events
             ->sortBy('created_at')
@@ -149,18 +160,11 @@ PROMPT;
             ))
             ->implode("\n");
 
-        // The model carries its own provider prefix ("anthropic/claude-haiku-4-5")
-        // so the model name is never paired with a foreign provider (which 400s on
-        // gateways that don't expose Anthropic models). An un-prefixed override
-        // falls back to the separate distillation.provider config key.
-        $configured = (string) config('memory.distillation.model', 'anthropic/claude-haiku-4-5');
-        [$provider, $model] = str_contains($configured, '/')
-            ? explode('/', $configured, 2)
-            : [(string) config('memory.distillation.provider', 'anthropic'), $configured];
+        $resolved = $this->resolveDistillationModel($team);
 
         $response = $this->gateway->complete(new AiRequestDTO(
-            provider: $provider,
-            model: $model,
+            provider: $resolved['provider'],
+            model: $resolved['model'],
             systemPrompt: self::SYSTEM_PROMPT,
             userPrompt: "Recent activity log:\n\n".$log,
             maxTokens: 512,
@@ -170,6 +174,49 @@ PROMPT;
         ));
 
         return trim($response->content);
+    }
+
+    /**
+     * Изборът на ЕКИПА е водещ; евтиният дестилационен модел е само fallback.
+     *
+     * Дефект FLEETQ-BJ: този метод четеше `memory.distillation.model` първо и
+     * така заобикаляше цялата каскада skill → agent → team → GlobalSetting →
+     * платформа. На production стойността е `groq/openai/gpt-oss-120b`, чийто
+     * префикс носи и доставчика — така всеки екип, независимо от собствения си
+     * BYOK доставчик, беше пращан към Groq и всяка нощ в 01:31 гърмеше с
+     * „Groq Error [401]: Invalid API Key".
+     *
+     * Затова: първо `resolveWithSource(team:)`, и само когато екипът НЕ е
+     * изразил предпочитание налагаме дестилационния модел. „Няма предпочитание"
+     * покрива и двата платформени източника — `platform` (GlobalSetting) и
+     * `config` (конфигурационният fallback). На production GlobalSetting е NULL,
+     * тоест source е именно `config`; ако гледахме само `platform`, клонът
+     * никога нямаше да се задейства в prod и дестилацията щеше да върви на
+     * скъпия платформен модел вместо на евтиния haiku.
+     *
+     * @return array{provider: string, model: string}
+     */
+    private function resolveDistillationModel(?Team $team): array
+    {
+        $resolved = $this->providerResolver->resolveWithSource(team: $team);
+
+        if (! in_array($resolved['source'], ['platform', 'config'], true)) {
+            return [
+                'provider' => (string) $resolved['provider'],
+                'model' => (string) $resolved['model'],
+            ];
+        }
+
+        // Моделът носи собствен префикс за доставчик ("anthropic/claude-haiku-4-5"),
+        // за да не бъде сдвоен с чужд доставчик (което дава 400 на gateway-и без
+        // Anthropic модели). Стойност без префикс пада към отделния
+        // `distillation.provider` ключ.
+        $configured = (string) config('memory.distillation.model', 'anthropic/claude-haiku-4-5');
+        [$provider, $model] = str_contains($configured, '/')
+            ? explode('/', $configured, 2)
+            : [(string) config('memory.distillation.provider', 'anthropic'), $configured];
+
+        return ['provider' => $provider, 'model' => $model];
     }
 
     private function watermark(?Team $team): ?CarbonInterface

--- a/tests/Feature/Domain/Memory/DistillTeamEventsActionTest.php
+++ b/tests/Feature/Domain/Memory/DistillTeamEventsActionTest.php
@@ -11,6 +11,8 @@ use App\Infrastructure\AI\Contracts\AiGatewayInterface;
 use App\Infrastructure\AI\DTOs\AiRequestDTO;
 use App\Infrastructure\AI\DTOs\AiResponseDTO;
 use App\Infrastructure\AI\DTOs\AiUsageDTO;
+use App\Infrastructure\AI\Exceptions\VpsLocalAgentException;
+use App\Infrastructure\AI\Services\ProviderResolver;
 use App\Models\User;
 use Carbon\CarbonInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -49,6 +51,11 @@ class DistillTeamEventsActionTest extends TestCase
         ]);
     }
 
+    private function makeAction(AiGatewayInterface $gateway, StoreMemoryAction $store): DistillTeamEventsAction
+    {
+        return new DistillTeamEventsAction($gateway, $store, app(ProviderResolver::class));
+    }
+
     private function fakeGateway(string $content): AiGatewayInterface
     {
         $gateway = Mockery::mock(AiGatewayInterface::class);
@@ -73,7 +80,7 @@ class DistillTeamEventsActionTest extends TestCase
         $store = Mockery::mock(StoreMemoryAction::class);
         $store->shouldReceive('execute')->once()->andReturn(['memory-1']);
 
-        $action = new DistillTeamEventsAction($this->fakeGateway('- Budget exceeded twice this window.'), $store);
+        $action = $this->makeAction($this->fakeGateway('- Budget exceeded twice this window.'), $store);
         $result = $action->execute($this->team->id);
 
         $this->assertSame(3, $result['events']);
@@ -92,7 +99,7 @@ class DistillTeamEventsActionTest extends TestCase
         $store = Mockery::mock(StoreMemoryAction::class);
         $store->shouldNotReceive('execute');
 
-        $result = (new DistillTeamEventsAction($gateway, $store))->execute($this->team->id, null, true);
+        $result = $this->makeAction($gateway, $store)->execute($this->team->id, null, true);
 
         $this->assertSame(2, $result['events']);
         $this->assertSame(0, $result['stored']);
@@ -110,7 +117,7 @@ class DistillTeamEventsActionTest extends TestCase
         $store = Mockery::mock(StoreMemoryAction::class);
         $store->shouldNotReceive('execute');
 
-        $result = (new DistillTeamEventsAction($gateway, $store))->execute($this->team->id);
+        $result = $this->makeAction($gateway, $store)->execute($this->team->id);
 
         $this->assertSame(0, $result['events']);
         $this->assertSame(0, $result['stored']);
@@ -125,7 +132,7 @@ class DistillTeamEventsActionTest extends TestCase
         $store = Mockery::mock(StoreMemoryAction::class);
         $store->shouldReceive('execute')->once()->andReturn(['memory-1']);
 
-        $action = new DistillTeamEventsAction($this->fakeGateway('- One recent event.'), $store);
+        $action = $this->makeAction($this->fakeGateway('- One recent event.'), $store);
         $result = $action->execute($this->team->id, now()->subHours(3));
 
         $this->assertSame(1, $result['events']);
@@ -147,7 +154,7 @@ class DistillTeamEventsActionTest extends TestCase
         $store = Mockery::mock(StoreMemoryAction::class);
         $store->shouldNotReceive('execute');
 
-        $result = (new DistillTeamEventsAction($gateway, $store))->execute($this->team->id);
+        $result = $this->makeAction($gateway, $store)->execute($this->team->id);
 
         $this->assertSame(1, $result['events']);
         $this->assertSame(0, $result['stored']);
@@ -177,7 +184,123 @@ class DistillTeamEventsActionTest extends TestCase
         $store = Mockery::mock(StoreMemoryAction::class);
         $store->shouldNotReceive('execute');
 
-        $result = (new DistillTeamEventsAction($gateway, $store))->execute($this->team->id);
+        $result = $this->makeAction($gateway, $store)->execute($this->team->id);
+
+        $this->assertSame(1, $result['events']);
+        $this->assertSame(0, $result['stored']);
+        $this->assertNotNull($this->team->fresh()->settings['memory']['last_event_distill_at'] ?? null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     */
+    private function setTeamDefault(string $provider, string $model, array $extra = []): void
+    {
+        $this->team->update([
+            'settings' => array_merge([
+                'default_llm_provider' => $provider,
+                'default_llm_model' => $model,
+            ], $extra),
+        ]);
+    }
+
+    private function gatewayExpecting(callable $assert, string $content = '- Едно нещо.'): AiGatewayInterface
+    {
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')
+            ->once()
+            ->with(Mockery::on(fn (AiRequestDTO $request) => $assert($request) === true))
+            ->andReturn(new AiResponseDTO(
+                content: $content,
+                parsedOutput: null,
+                usage: new AiUsageDTO(10, 20, 1),
+                provider: 'x',
+                model: 'y',
+                latencyMs: 100,
+            ));
+
+        return $gateway;
+    }
+
+    public function test_team_default_provider_wins_over_the_distillation_model(): void
+    {
+        // Екипът е изразил предпочитание — то е водещо, дестилационният модел
+        // не бива да го пренаписва.
+        config(['memory.distillation.model' => 'anthropic/claude-haiku-4-5']);
+        $this->setTeamDefault('openai', 'gpt-4o');
+        $this->auditEntry('experiment.transitioned', now()->subHour());
+
+        $store = Mockery::mock(StoreMemoryAction::class);
+        $store->shouldReceive('execute')->once()->andReturn(['memory-1']);
+
+        $gateway = $this->gatewayExpecting(
+            fn (AiRequestDTO $r) => $r->provider === 'openai' && $r->model === 'gpt-4o',
+        );
+
+        $result = $this->makeAction($gateway, $store)->execute($this->team->id);
+
+        $this->assertSame(1, $result['stored']);
+    }
+
+    public function test_team_without_preference_falls_back_to_the_cheap_distillation_model(): void
+    {
+        // Без предпочитание на екипа (settings празни, GlobalSetting NULL) —
+        // тогава и само тогава важи евтиният дестилационен модел.
+        config(['memory.distillation.model' => 'anthropic/claude-haiku-4-5']);
+        $this->auditEntry('experiment.transitioned', now()->subHour());
+
+        $store = Mockery::mock(StoreMemoryAction::class);
+        $store->shouldReceive('execute')->once()->andReturn(['memory-1']);
+
+        $gateway = $this->gatewayExpecting(
+            fn (AiRequestDTO $r) => $r->provider === 'anthropic' && $r->model === 'claude-haiku-4-5',
+        );
+
+        $result = $this->makeAction($gateway, $store)->execute($this->team->id);
+
+        $this->assertSame(1, $result['stored']);
+    }
+
+    public function test_groq_is_not_called_for_a_team_with_its_own_default(): void
+    {
+        // Дефект-гард за FLEETQ-BJ: production държи
+        // MEMORY_DISTILLATION_MODEL=groq/openai/gpt-oss-120b, а префиксът носи
+        // доставчика. Преди поправката всеки екип — включително тези на
+        // claude-code-vps — беше пращан към Groq и получаваше 401 всяка нощ.
+        config(['memory.distillation.model' => 'groq/openai/gpt-oss-120b']);
+        $this->setTeamDefault('claude-code-vps', 'claude-sonnet-4-5');
+        $this->auditEntry('experiment.transitioned', now()->subHour());
+
+        $store = Mockery::mock(StoreMemoryAction::class);
+        $store->shouldReceive('execute')->once()->andReturn(['memory-1']);
+
+        $gateway = $this->gatewayExpecting(
+            fn (AiRequestDTO $r) => $r->provider !== 'groq' && $r->provider === 'claude-code-vps',
+        );
+
+        $this->makeAction($gateway, $store)->execute($this->team->id);
+    }
+
+    public function test_skips_when_the_vps_local_agent_is_not_allowed_for_the_team(): void
+    {
+        // Екип, чийто default сочи claude-code-vps, но не е whitelist-нат
+        // (на production: „Test кантора 1"), получава VpsLocalAgentException.
+        // Във фоновата нощна задача това е backpressure — пропуска се като
+        // останалите случаи, watermark-ът се придвижва и нищо не стига до
+        // Sentry. Съзнателно НЕ се филтрира в BeforeSendFilter: интерактивно
+        // потребителят трябва да види съобщението.
+        $this->setTeamDefault('claude-code-vps', 'claude-sonnet-4-5');
+        $this->auditEntry('experiment.transitioned', now()->subHour());
+
+        $gateway = Mockery::mock(AiGatewayInterface::class);
+        $gateway->shouldReceive('complete')
+            ->once()
+            ->andThrow(VpsLocalAgentException::notAllowed());
+
+        $store = Mockery::mock(StoreMemoryAction::class);
+        $store->shouldNotReceive('execute');
+
+        $result = $this->makeAction($gateway, $store)->execute($this->team->id);
 
         $this->assertSame(1, $result['events']);
         $this->assertSame(0, $result['stored']);


### PR DESCRIPTION
Затваря нощния Sentry шум **FLEETQ-BJ** (`Groq Error [401]: Invalid API Key`, 24 попадения, всяка нощ в 01:31).

## Причина

`DistillTeamEventsAction::distil()` четеше `memory.distillation.model` **първо** и така заобикаляше цялата каскада на `ProviderResolver` (skill → agent → team → GlobalSetting → платформа).

На production стойността е `groq/openai/gpt-oss-120b`, а префиксът носи и доставчика — тоест всеки екип, независимо от собствения си BYOK или локален Claude Code, беше пращан към Groq с невалиден ключ.

Дефект от познат клас: код чете глобална настройка там, където трябва да чете настройката на самия обект.

## Поправка

`resolveWithSource(team:)` е водещ. Евтиният дестилационен модел се налага **само** когато екипът не е изразил предпочитание — а това покрива и двата платформени източника, `platform` (GlobalSetting) и `config` (конфигурационният fallback).

Тази подробност е съществена: на production GlobalSetting е `NULL`, значи source е именно `config`. Ако условието гледаше само `platform`, клонът щеше да е мъртъв код в prod и всичките 77 екипа без предпочитание щяха да дестилират на скъпия платформен модел вместо на евтиния haiku.

Гардът поглъща и `VpsLocalAgentException` — екип, чийто default сочи `claude-code-vps`, но не е whitelist-нат, е същата backpressure като екип без креденшъл.

**`BeforeSendFilter` НЕ е пипан** нарочно: интерактивно потребителят ТРЯБВА да види съобщението „add your own API key in Team Settings"; крие се само тази фонова задача.

## Ефект по екипи (prod данни)

| Екип | Резолюция след поправката |
|---|---|
| PriceX Ltd. (whitelist) | `claude-code-vps` → локален CLI, нула ключове |
| Test кантора 1 (без whitelist) | `VpsLocalAgentException` → пропуска се тихо |
| Garza / Test | техният openai / openrouter |
| 77 екипа без предпочитание | дестилационният модел → BYOK или ясното съобщение |

## Тестове

4 нови, **всеки проверен че пада без поправката**. Изключение е fallback тестът — той по конструкция минава и със стария код, затова е проверен срещу правдоподобната свръх-корекция (`resolveWithSource` безусловно), при която пада заедно със заварения тест за чужд доставчик.

`php artisan test --filter=DistillTeamEventsAction` → 10 passed.

## ⚠ Задължително придружаващо действие

**Кодът сам не спира Groq.** Екип без предпочитание пак минава през `memory.distillation.model`. Задължително върви с премахването на `MEMORY_DISTILLATION_MODEL=groq/openai/gpt-oss-120b` от prod `.env`, след което стойността пада на `anthropic/claude-haiku-4-5`.

## Известен остатък (извън скоупа)

`resolveWithSource()` вика `enforceAllowedModels()`, тоест екип с непразен `allowed_models`, който не покрива резолвнатата двойка, може да хвърли `ModelNotAllowedException` от нощната задача. На production **нула екипа имат `allowed_models`**, така че днес рискът е теоретичен — не се поглъща мълчаливо, защото е истинска конфигурационна грешка.

https://claude.ai/code/session_015rLUbV4sTGiZw8KCwE9s3n