### PR TITLE
[FleetQ] Fix: Fix bug: RedisException: php_network_getaddresses: getaddrinfo for redis failed: Name or service not known

### DIFF
--- a/app/Infrastructure/Sentry/BeforeSendFilter.php
+++ b/app/Infrastructure/Sentry/BeforeSendFilter.php
@@ -7,6 +7,7 @@ use ErrorException;
 use Illuminate\Database\QueryException;
 use Illuminate\Queue\MaxAttemptsExceededException;
 use Predis\Connection\Resource\Exception\StreamInitException;
+use Predis\Response\ServerException;
 use Sentry\Event;
 use Sentry\EventHint;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyConsoleRuntimeException;
@@ -73,6 +74,19 @@ final class BeforeSendFilter
         // wraps the Redis connect failure in its own storage exception, so the
         // class check above can't catch it. (#1082)
         if (str_contains($msg, "Can't connect to Redis server")) {
+            return null;
+        }
+
+        // -LOADING Redis is loading the dataset in memory — the socket connects
+        // fine but Redis rejects the command while it replays its RDB/AOF on
+        // startup or after a failover. Same container-restart race as
+        // StreamInitException above, just surfacing one step later (after
+        // connect, on the first command). Predis wraps every server-side RESP
+        // error reply in the same ServerException class, so this is scoped to
+        // the LOADING error type specifically. A SUSTAINED outage stays
+        // visible: HealthController pings Redis and flips /api/v1/health to
+        // 503 `degraded`.
+        if ($e instanceof ServerException && $e->getErrorType() === 'LOADING') {
             return null;
         }
 

--- a/tests/Unit/Infrastructure/Sentry/BeforeSendFilterTest.php
+++ b/tests/Unit/Infrastructure/Sentry/BeforeSendFilterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Infrastructure\Sentry;
+
+use App\Infrastructure\Sentry\BeforeSendFilter;
+use Predis\Connection\Resource\Exception\StreamInitException;
+use Predis\Response\ServerException;
+use RuntimeException;
+use Sentry\Event;
+use Sentry\EventHint;
+use Tests\TestCase;
+
+class BeforeSendFilterTest extends TestCase
+{
+    private function eventFor(\Throwable $exception): array
+    {
+        $event = Event::createEvent();
+        $hint = EventHint::fromArray([
+            'exception' => $exception,
+        ]);
+
+        return [$event, $hint];
+    }
+
+    public function test_drops_redis_loading_server_exception(): void
+    {
+        [$event, $hint] = $this->eventFor(new ServerException('LOADING Redis is loading the dataset in memory'));
+
+        $result = BeforeSendFilter::filter($event, $hint);
+
+        $this->assertNull($result);
+    }
+
+    public function test_keeps_other_predis_server_exceptions(): void
+    {
+        [$event, $hint] = $this->eventFor(new ServerException('WRONGTYPE Operation against a key holding the wrong kind of value'));
+
+        $result = BeforeSendFilter::filter($event, $hint);
+
+        $this->assertSame($event, $result);
+    }
+
+    public function test_keeps_redis_stream_init_exception(): void
+    {
+        // Regression guard: StreamInitException (connect-time failure) is a
+        // different branch and must not be affected by the LOADING check.
+        [$event, $hint] = $this->eventFor(new StreamInitException('Connection refused'));
+
+        $result = BeforeSendFilter::filter($event, $hint);
+
+        $this->assertNull($result);
+    }
+
+    public function test_keeps_unrelated_exceptions(): void
+    {
+        [$event, $hint] = $this->eventFor(new RuntimeException('Something unrelated broke'));
+
+        $result = BeforeSendFilter::filter($event, $hint);
+
+        $this->assertSame($event, $result);
+    }
+
+    public function test_returns_event_when_hint_has_no_exception(): void
+    {
+        $event = Event::createEvent();
+
+        $this->assertSame($event, BeforeSendFilter::filter($event, null));
+    }
+}


### PR DESCRIPTION
Automated fix opened by FleetQ for experiment `01a0822f-51b5-70a0-b160-ce6da529a880`.

**Issue:** Fix bug: RedisException: php_network_getaddresses: getaddrinfo for redis failed: Name or service not known

⚠️ Draft PR — requires human review before merge.