### PR TITLE
[FleetQ] Fix: Fix bug: RedisException: php_network_getaddresses: getaddrinfo for redis failed: Name or service not known

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,7 +50,11 @@ QUEUE_CONNECTION=redis
 CACHE_STORE=redis
 
 REDIS_CLIENT=predis
-REDIS_HOST=redis
+# 127.0.0.1 works for the local `composer setup`/`composer dev` workflow (Redis
+# runs on the host machine). Docker Compose overrides this to the `redis`
+# service name via docker-compose.yml's `environment:` block, so this file
+# does not need editing for `make install`/`docker compose up`.
+REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 REDIS_DB=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - APP_ENV=local
       - COMPOSER_CACHE_DIR=/root/.composer
       - RUNNING_IN_DOCKER=true
+      - REDIS_HOST=redis
     networks:
       - agent-fleet-open
       - agent-fleet-internal
@@ -93,6 +94,7 @@ services:
     environment:
       - APP_ENV=local
       - RUNNING_IN_DOCKER=true
+      - REDIS_HOST=redis
     networks:
       - agent-fleet-open
       - agent-fleet-internal
@@ -122,6 +124,7 @@ services:
     environment:
       - APP_ENV=local
       - RUNNING_IN_DOCKER=true
+      - REDIS_HOST=redis
     networks:
       - agent-fleet-open
       - agent-fleet-internal
@@ -161,6 +164,7 @@ services:
     environment:
       - APP_ENV=local
       - RUNNING_IN_DOCKER=true
+      - REDIS_HOST=redis
     networks:
       - agent-fleet-open
       - agent-fleet-internal

--- a/docker/php/entrypoint.sh
+++ b/docker/php/entrypoint.sh
@@ -21,14 +21,15 @@ fi
 # gates the initial `docker compose up`, but it is NOT re-evaluated when a
 # single container is restarted independently (e.g. `docker restart app`,
 # or Redis being recreated while this container keeps running) — that gap
-# is what surfaces as "RedisException: Connection refused". REDIS_HOST/PORT
-# live only in the .env file (no `env_file:` directive wires them into the
-# container's real environment), so read them from there directly. Uses
-# fsockopen via PHP (always present in this image) instead of `nc`, which
-# alpine's busybox does not guarantee.
+# is what surfaces as "RedisException: Connection refused". Prefer the
+# container's real REDIS_HOST env (set explicitly in docker-compose.yml),
+# falling back to the .env file (whose default is host-machine-oriented,
+# 127.0.0.1, for the non-Docker `composer dev` workflow) and then 127.0.0.1.
+# Uses fsockopen via PHP (always present in this image) instead of `nc`,
+# which alpine's busybox does not guarantee.
 env_file=/var/www/.env
-redis_host=$( [ -f "$env_file" ] && grep -m1 '^REDIS_HOST=' "$env_file" | cut -d '=' -f2- )
-redis_port=$( [ -f "$env_file" ] && grep -m1 '^REDIS_PORT=' "$env_file" | cut -d '=' -f2- )
+redis_host="${REDIS_HOST:-$( [ -f "$env_file" ] && grep -m1 '^REDIS_HOST=' "$env_file" | cut -d '=' -f2- )}"
+redis_port="${REDIS_PORT:-$( [ -f "$env_file" ] && grep -m1 '^REDIS_PORT=' "$env_file" | cut -d '=' -f2- )}"
 redis_host="${redis_host:-127.0.0.1}"
 redis_port="${redis_port:-6379}"
 


### PR DESCRIPTION
Automated fix opened by FleetQ for experiment `01a08755-0b5b-705c-bfbd-11bb168bd705`.

**Issue:** Fix bug: RedisException: php_network_getaddresses: getaddrinfo for redis failed: Name or service not known

⚠️ Draft PR — requires human review before merge.