### PR TITLE
fix(memory): Supabase memory шаблонът включва RLS по подразбиране

### DIFF
--- a/app/Domain/Memory/Adapters/SupabaseVectorAdapter.php
+++ b/app/Domain/Memory/Adapters/SupabaseVectorAdapter.php
@@ -172,6 +172,19 @@ AS \$\$
     ORDER BY embedding <=> query_embedding ASC
     LIMIT match_count;
 \$\$;
+
+-- Row Level Security is ON by default: Supabase exposes new public-schema tables to
+-- the public `anon` key over REST. FleetQ uses the service_role key, which bypasses RLS.
+ALTER TABLE fleetq_memories ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE fleetq_memories FROM anon, authenticated;
+
+REVOKE ALL ON FUNCTION fleetq_match_memories(extensions.vector({$dim}), FLOAT, INT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION fleetq_match_memories(extensions.vector({$dim}), FLOAT, INT)
+    TO service_role;
+
+DROP POLICY IF EXISTS "Service role full access" ON fleetq_memories;
 SQL;
     }
 

--- a/database/sql/supabase_memory_setup.sql
+++ b/database/sql/supabase_memory_setup.sql
@@ -67,7 +67,34 @@ $$;
 COMMENT ON FUNCTION fleetq_match_memories IS
     'Cosine similarity search for FleetQ agent memories. Called via Supabase REST RPC by FleetQ agents.';
 
--- Optional: Row Level Security
--- Uncomment if you want to restrict access by user JWT:
--- ALTER TABLE fleetq_memories ENABLE ROW LEVEL SECURITY;
--- CREATE POLICY "Service role full access" ON fleetq_memories FOR ALL USING (true);
+-- Step 6: Lock the table down — Row Level Security ON by default
+-- Supabase grants full table access on new public-schema tables to the `anon` and
+-- `authenticated` roles, and the anon key is public (it ships inside browser apps).
+-- Without RLS anyone holding that key can read every memory over the REST API.
+-- FleetQ connects with the service_role key, which bypasses RLS, so this costs
+-- you nothing and is not optional.
+ALTER TABLE fleetq_memories ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE fleetq_memories FROM anon, authenticated;
+
+REVOKE ALL ON FUNCTION fleetq_match_memories(extensions.vector({{EMBEDDING_DIMENSION}}), FLOAT, INT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION fleetq_match_memories(extensions.vector({{EMBEDDING_DIMENSION}}), FLOAT, INT)
+    TO service_role;
+
+-- Earlier versions of this file suggested a "Service role full access" policy with
+-- USING (true). That policy had no TO clause, so it applied to every role including
+-- `anon`. service_role bypasses RLS anyway and needs no policy. Drop it if present.
+DROP POLICY IF EXISTS "Service role full access" ON fleetq_memories;
+
+-- Optional: let signed-in users read their own memories straight from your client app.
+-- Skip this entirely if only FleetQ touches the table. Keep the TO authenticated clause —
+-- a policy without it also covers `anon`.
+-- ALTER TABLE fleetq_memories ADD COLUMN IF NOT EXISTS user_id UUID DEFAULT auth.uid();
+-- GRANT SELECT ON fleetq_memories TO authenticated;
+-- CREATE POLICY "Users read own memories" ON fleetq_memories
+--     FOR SELECT TO authenticated USING (auth.uid() = user_id);
+
+-- Verify the result:
+--   SELECT relrowsecurity FROM pg_class WHERE relname = 'fleetq_memories';   -- expect: t
+--   SELECT policyname, roles, qual FROM pg_policies WHERE tablename = 'fleetq_memories';


### PR DESCRIPTION
## Какво

Скриптът `database/sql/supabase_memory_setup.sql`, който раздаваме на клиентите през MCP инструмента `supabase_provision_vector_memory`, създаваше таблицата `fleetq_memories` в схема `public` без Row Level Security.

Supabase дава достъп до нови таблици в `public` на ролите `anon` и `authenticated` през PostgREST. Anon ключът е публичен и се слага в браузърни приложения. Значи всеки с anon ключа на проекта можеше да прочете всички памети.

## Точност на твърдението, което задейства проверката

Получено беше външно съобщение, че файлът съдържа политика `using (true)`, която дава четене на всеки authenticated потребител. Това не е точно: редът беше закоментиран и никога не се изпълнява. Реалният проблем е по-голям, защото RLS изобщо не се включваше.

Самата закоментирана политика също беше сгрешена. `FOR ALL USING (true)` без `TO` клауза важи за всички роли, включително `anon`, въпреки че е озаглавена "Service role full access". А `service_role` заобикаля RLS и не се нуждае от политика.

## Промени

В шаблона и в резервния inline SQL в `SupabaseVectorAdapter`:

- `ENABLE ROW LEVEL SECURITY` вече не е коментар
- `REVOKE ALL` върху таблицата от `anon` и `authenticated`
- `REVOKE` на `fleetq_match_memories` от `PUBLIC`, `anon`, `authenticated`, плюс `GRANT EXECUTE` само на `service_role`
- `DROP POLICY IF EXISTS "Service role full access"` за базите, в които някой е разкоментирал стария ред
- опционалният пример за JWT достъп вече е с `TO authenticated` и обяснение защо клаузата е задължителна
- две заявки за проверка на резултата

FleetQ се свързва със `service_role` ключа, който заобикаля RLS, така че пътят за четене и запис не се променя.

## Претърсване за същия модел

Единственото друго попадение на `USING (true)` е `semantic_cache_entries` в `2026_02_24_900001_enable_rls_on_tenant_tables.php`. Там е нарочно, кешът е споделен между екипите, документирано е в кода и към тази база няма PostgREST нито роля `anon`. Не се променя.

## Проверка

```
php artisan test --filter=SupabaseVectorAdapterTest
Tests: 7 passed (16 assertions)

pint --test app/Domain/Memory/Adapters/SupabaseVectorAdapter.php → passed
```

https://claude.ai/code/session_01Qcv2jUX97dxofzZFPtS6Dr